### PR TITLE
Unescaped backslash in mutex object name

### DIFF
--- a/src/common/xchat.c
+++ b/src/common/xchat.c
@@ -972,7 +972,7 @@ main (int argc, char *argv[])
 	{
 		DWORD error;
 
-		mutex = CreateMutex (NULL, TRUE, "Local\hexchat");
+		mutex = CreateMutex (NULL, TRUE, "Local\\hexchat");
 		error = GetLastError ();
 
 		if (error == ERROR_ALREADY_EXISTS || mutex == NULL)


### PR DESCRIPTION
There's this feature called escape sequences. To put a backslash into a string you have to write it a second time.
