### PR TITLE
Option not to play sound when away

### DIFF
--- a/src/common/cfgfiles.c
+++ b/src/common/cfgfiles.c
@@ -563,6 +563,7 @@ const struct prefs vars[] = {
 	{"stamp_log_format", P_OFFSET (timestamp_log_format), TYPE_STR},
 	{"stamp_text", P_OFFINT (timestamp), TYPE_BOOL},
 	{"stamp_text_format", P_OFFSET (stamp_format), TYPE_STR},
+	{"no_sound_away", P_OFFINT (no_sound_away), TYPE_BOOL},
 
 	{"tab_chans", P_OFFINT (tabchannels), TYPE_BOOL},
 	{"tab_dialogs", P_OFFINT (privmsgtab), TYPE_BOOL},

--- a/src/common/text.c
+++ b/src/common/text.c
@@ -2243,7 +2243,7 @@ char *sound_files[NUM_XP];
 void
 sound_beep (session *sess)
 {
-	if (!sess->server->is_away){
+	if (!prefs.no_sound_away || !sess->server->is_away){
 		if (sound_files[XP_TE_BEEP] && sound_files[XP_TE_BEEP][0])
 			/* user defined beep _file_ */
 			sound_play_event (XP_TE_BEEP);

--- a/src/common/xchat.h
+++ b/src/common/xchat.h
@@ -245,6 +245,7 @@ struct xchatprefs
 	unsigned int slist_skip;
 	unsigned int slist_select;
 	unsigned int filterbeep;
+	unsigned int no_sound_away;
 
 	unsigned int input_balloon_chans;
 	unsigned int input_balloon_hilight;

--- a/src/fe-gtk/setup.c
+++ b/src/fe-gtk/setup.c
@@ -1540,6 +1540,19 @@ setup_autotoggle_cb (GtkToggleButton *but, GtkToggleButton *ext)
 }
 
 static void
+setup_no_sound_away_cb (GtkToggleButton *but, GtkToggleButton *ext)
+{
+	if (but->active)
+	{
+		setup_prefs.no_sound_away = 1;
+	}
+	else
+	{
+		setup_prefs.no_sound_away = 0;
+	}
+}
+
+static void
 setup_snd_filereq_cb (GtkWidget *entry, char *file)
 {
 	if (file)
@@ -1609,6 +1622,7 @@ setup_create_sound_page (void)
 	GtkWidget *sound_browse;
 	GtkWidget *sound_play;
 	GtkTreeSelection *sel;
+	GtkWidget *no_sound_away;
 
 	vbox1 = gtk_vbox_new (FALSE, 0);
 	gtk_container_set_border_width (GTK_CONTAINER (vbox1), 6);
@@ -1686,6 +1700,15 @@ setup_create_sound_page (void)
 	gtk_table_attach (GTK_TABLE (table2), entry3, 1, 3, 3, 4,
 							(GtkAttachOptions) (GTK_EXPAND | GTK_FILL),
 							(GtkAttachOptions) (0), 0, 0);
+	
+	no_sound_away = gtk_check_button_new_with_mnemonic(_("Do _not play sound when away"));
+	gtk_widget_show(no_sound_away);
+	gtk_table_attach(GTK_TABLE (table2), no_sound_away, 0, 3, 4, 5,
+							(GtkAttachOptions) (GTK_FILL),
+							(GtkAttachOptions) (0), 0, 0);
+	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (no_sound_away), setup_prefs.no_sound_away == 1);
+	g_signal_connect (G_OBJECT (no_sound_away), "toggled",
+							G_CALLBACK (setup_no_sound_away_cb), no_sound_away);
 
 	scrolledwindow1 = gtk_scrolled_window_new (NULL, NULL);
 	gtk_widget_show (scrolledwindow1);


### PR DESCRIPTION
Added option to allow not to play any sounds when in away status.
This would close issue #52.
