### PR TITLE
Fix DSO linking

### DIFF
--- a/src/fe-gtk/Makefile.am
+++ b/src/fe-gtk/Makefile.am
@@ -4,7 +4,7 @@ bin_PROGRAMS = hexchat
 
 INCLUDES = $(GUI_CFLAGS) -DG_DISABLE_CAST_CHECKS -DLOCALEDIR=\"$(localedir)\"
 
-hexchat_LDADD = ../common/libxchatcommon.a $(GUI_LIBS)
+hexchat_LDADD = ../common/libxchatcommon.a $(GUI_LIBS) -lgmodule-2.0
 
 EXTRA_DIST = \
 	about.h ascii.h banlist.h chanlist.h chanview.h chanview-tabs.c \


### PR DESCRIPTION
/usr/bin/ld: sexy-spell-entry.o: undefined reference to symbol 'g_module_open'
/usr/bin/ld: note: 'g_module_open' is defined in DSO /lib64/libgmodule-2.0.so.0 so try adding it to the linker command line
/lib64/libgmodule-2.0.so.0: could not read symbols: Invalid operation

http://forums.fedoraforum.org/showthread.php?t=283372
