### PR TITLE
Be more explicit about the license in the readme.

### DIFF
--- a/README
+++ b/README
@@ -3,10 +3,10 @@ HexChat README
  X-Chat ("xchat") Copyright (c) 1998-2010 By Peter Zelezny.
  HexChat ("hexchat") Copyright (c) 2009-2012 By Berke Viktor.
 
- This program is released under the GPL v2 with the additional exemption
- that compiling, linking, and/or using OpenSSL is allowed. You may
- provide binary packages linked to the OpenSSL libraries, provided that
- all other requirements of the GPL are met.
+ This program is released under the GPL version 2 or greater, with the
+ additional exemption that compiling, linking, and/or using OpenSSL is
+ allowed. You may provide binary packages linked to the OpenSSL libraries,
+ provided that all other requirements of the GPL are met.
  See file COPYING for details.
 
  For building instructions, see http://www.hexchat.org/developers/building


### PR DESCRIPTION
Most of the headers of the source files in Hexchat say:

```
 * the Free Software Foundation; either version 2 of the License, or
 * (at your option) any later version.
```

And xchat itself was released under GPLv2+. I'm assuming the readme
saying "GPL v2" was just a typo.
