### PR TITLE
Enhance LASTLOG to use gtk_xtext_search_textentry()

### DIFF
--- a/src/common/fe.h
+++ b/src/common/fe.h
@@ -98,7 +98,7 @@ void fe_set_nonchannel (struct session *sess, int state);
 void fe_set_nick (struct server *serv, char *newnick);
 void fe_ignore_update (int level);
 void fe_beep (void);
-void fe_lastlog (session *sess, session *lastlog_sess, char *sstr, gboolean regexp);
+void fe_lastlog (session *sess, session *lastlog_sess, char *sstr, gtk_xtext_search_flags flags);
 void fe_set_lag (server *serv, int lag);
 void fe_set_throttle (server *serv);
 void fe_set_away (server *serv);

--- a/src/common/xchat.c
+++ b/src/common/xchat.c
@@ -591,7 +591,7 @@ static char defaultconf_commands[] =
 	"NAME DIALOG\n"		"CMD query %2\n\n"\
 	"NAME DMSG\n"			"CMD msg =%2 &3\n\n"\
 	"NAME EXIT\n"			"CMD quit\n\n"\
-	"NAME GREP\n"			"CMD lastlog -r &2\n\n"\
+	"NAME GREP\n"			"CMD lastlog -r -- &2\n\n"\
 	"NAME IGNALL\n"			"CMD ignore %2!*@* ALL\n\n"\
 	"NAME J\n"				"CMD join &2\n\n"\
 	"NAME KILL\n"			"CMD quote KILL %2 :&3\n\n"\

--- a/src/common/xchat.h
+++ b/src/common/xchat.h
@@ -346,6 +346,15 @@ struct xchatprefs
 #define SET_ON 1
 #define SET_DEFAULT 2 /* use global setting */
 
+/* Moved from fe-gtk for use in outbound.c as well -- */
+typedef enum gtk_xtext_search_flags_e {
+	case_match = 1,
+	backward = 2,
+	highlight = 4,
+	follow = 8,
+	regexp = 16
+} gtk_xtext_search_flags;
+
 typedef struct session
 {
 	/* Per-Channel Alerts */
@@ -405,7 +414,7 @@ typedef struct session
 	int end_of_names:1;
 	int doing_who:1;		/* /who sent on this channel */
 	int done_away_check:1;	/* done checking for away status changes */
-	unsigned int lastlog_regexp:1;	/* this is a lastlog and using regexp */
+	gtk_xtext_search_flags lastlog_flags;
 } session;
 
 struct msproxy_state_t

--- a/src/fe-gtk/menu.c
+++ b/src/fe-gtk/menu.c
@@ -1235,7 +1235,7 @@ menu_search_prev ()
 	xtext_buffer *buf = xtext->buffer;
 
 	if (!gtk_xtext_search(xtext, buf->search_text,
-		(buf->search_flags & (case_match | follow | regexp) | backward), NULL))
+		(buf->search_flags & (case_match | follow | regexp)) | backward, NULL))
 	{
 		fe_message (_("Search hit end, not found."), FE_MSG_ERROR);
 	}

--- a/src/fe-gtk/xtext.h
+++ b/src/fe-gtk/xtext.h
@@ -43,13 +43,6 @@
 typedef struct _GtkXText GtkXText;
 typedef struct _GtkXTextClass GtkXTextClass;
 typedef struct textentry textentry;
-typedef enum gtk_xtext_search_flags_e {
-	case_match = 1,
-	backward = 2,
-	highlight = 4,
-	follow = 8,
-	regexp = 16
-} gtk_xtext_search_flags;
 
 typedef struct {
 	GtkXText *xtext;					/* attached to this widget */
@@ -263,7 +256,7 @@ void gtk_xtext_set_palette (GtkXText * xtext, GdkColor palette[]);
 void gtk_xtext_clear (xtext_buffer *buf, int lines);
 void gtk_xtext_save (GtkXText * xtext, int fh);
 void gtk_xtext_refresh (GtkXText * xtext, int do_trans);
-int gtk_xtext_lastlog (xtext_buffer *out, xtext_buffer *search_area, int (*cmp_func) (char *, void *userdata), void *userdata);
+int gtk_xtext_lastlog (xtext_buffer *out, xtext_buffer *search_area);
 textentry *gtk_xtext_search (GtkXText * xtext, const gchar *text, gtk_xtext_search_flags flags, GError **err);
 void gtk_xtext_reset_marker_pos (GtkXText *xtext);
 void gtk_xtext_check_marker_visibility(GtkXText *xtext);


### PR DESCRIPTION
This change adds options -h (highlight) and -m (match case) to the LASTLOG command,
and additionally option -- (double hyphen), used as an option ender when the search string
itself starts with a hyphen.  With this change, lastlog offers all of the functionality of
the Control-F Search window, because it uses the same search code.  Default behavior
of the GREP command remains the same, and of the LASTLOG command too (for
search strings that don't start with a hyphen).
