### PR TITLE
Fix log_create_pathname to set the correct path

### DIFF
--- a/src/common/text.c
+++ b/src/common/text.c
@@ -578,7 +578,6 @@ log_create_pathname (char *servname, char *channame, char *netname)
 	char *fs;
 	struct tm *tm;
 	time_t now;
-	char *xdir;
 
 	if (!netname)
 		netname = "NETWORK";
@@ -597,11 +596,7 @@ log_create_pathname (char *servname, char *channame, char *netname)
 	strftime (fnametime, sizeof (fnametime), fname, tm);
 
 	/* create final path/filename */
-	xdir = get_xdir_utf8 ();
-	if (!strncmp (fnametime, xdir, strlen (xdir)))
-		snprintf (fname, sizeof (fname), "%s", fnametime);
-	else
-		snprintf (fname, sizeof (fname), "%s/logs/%s", xdir, fnametime);
+	snprintf (fname, sizeof (fname), "%s/logs/%s", get_xdir_utf8 (), fnametime);
 
 	/* now we need it in FileSystem encoding */
 	fs = xchat_filename_from_utf8 (fname, -1, 0, 0, 0);


### PR DESCRIPTION
If the user specifies a log filename mask which starts with a "/", then log_create_pathname incorrectly assumes it to be the full path to the log file, since it only checks if the path starts with a "/". I've changed the code to check if the path starts with get_xdir_utf8 () instead of "/".

Note that there are legitimate reasons for the path to start with a "/", such as if the filename mask is "%c/..." (to make logs go into a directory per channel) and %c is the empty string (such as during connecting to a server). In the current build, this causes a nasty error dialog or two to show up complaining that the xchatlogs directory isn't writable.

(Originally #64)
