### PR TITLE
Broken #defines after autoconf + configure due to misbehaving AS_AC_EXPAND macro

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -26,7 +26,7 @@ AC_DEFUN([AS_AC_EXPAND],
   dnl loop until it doesn't change anymore
   while true; do
     new_full_var="`eval echo $full_var`"
-    if test "x$new_full_var"="x$full_var"; then break; fi
+    if test "x$new_full_var" = "x$full_var"; then break; fi
     full_var=$new_full_var
   done
 

--- a/configure.in
+++ b/configure.in
@@ -592,9 +592,8 @@ if test "x$dbus" = "xyes" ; then
 		COMMON_LIBS="$COMMON_LIBS $DBUS_LIBS"
 		COMMON_CFLAGS="$COMMON_CFLAGS $DBUS_CFLAGS"
 		AC_DEFINE(USE_DBUS)
-		AS_AC_EXPAND(DATADIR, $datadir)
 
-		DBUS_SERVICES_DIR="$DATADIR/dbus-1/services"
+		AS_AC_EXPAND(DBUS_SERVICES_DIR, "$datadir/dbus-1/services")
 		AC_SUBST(DBUS_SERVICES_DIR)
 		AC_DEFINE_UNQUOTED(DBUS_SERVICES_DIR, "$DBUS_SERVICES_DIR", [Where services dir for DBUS is])
 	fi
@@ -911,10 +910,10 @@ test "x$exec_prefix" = xNONE && exec_prefix="$prefix"
 
 AC_DEFINE_UNQUOTED(PREFIX, "${prefix}")
 
-HEXCHATLIBDIR=`eval echo ${libdir}/hexchat`
+AS_AC_EXPAND(HEXCHATLIBDIR, "${libdir}/hexchat")
 AC_DEFINE_UNQUOTED(HEXCHATLIBDIR, "$HEXCHATLIBDIR")
 
-HEXCHATSHAREDIR=`eval echo ${datadir}`
+AS_AC_EXPAND(HEXCHATSHAREDIR, "$datadir")
 AC_DEFINE_UNQUOTED(HEXCHATSHAREDIR, "$HEXCHATSHAREDIR")
 
 dnl for plugins/xxx/Makefile.am


### PR DESCRIPTION
On my system (openSUSE 12.2 / bash 4.2.24(1)-release (x86_64-suse-linux-gnu) ), the shell doesn't like that the '=' character in 'if test...' doesn't have spaces around it. This causes the test to always be true, and thus the loop breaks on the first iteration leading to the AS_AC_EXPAND macro only expanding once.

This leads to two #define's in config.h containing broken values: HEXCHATSHAREDIR and DBUS_SERVICES_DIR. The both contain the literal string "${prefix}". For example, HEXCHATSHAREDIR ends us as

`#define HEXCHATSHAREDIR "${prefix}/share"`

instead of

`#define HEXCHATSHAREDIR "/usr/local/share"`

My version of bash is consistent in that test "x"="y" is ALWAYS true, and test "x" = "y" (with the space around the =) is ALWAYS false, even though this behavior doesn't seem to be reproducible by anyone else.
EDIT: This behavior seems to be reproducible on a range of bash versions, and even on zsh.

```
~>if test "x"="y"; then echo 5; else echo 6; fi
5
~>if test "x" = "y"; then echo 5; else echo 6; fi
6
```

Putting the spaces doesn't break anyone else's builds at least.
