### PR TITLE
no highlights for some more annoying nicks

### DIFF
--- a/src/common/cfgfiles.c
+++ b/src/common/cfgfiles.c
@@ -787,7 +787,7 @@ load_config (void)
 	strcpy (prefs.font_alternative, DEF_FONT_ALTER);
 #endif
 	strcpy (prefs.dnsprogram, "host");
-	strcpy (prefs.irc_no_hilight, "NickServ,ChanServ");
+	strcpy (prefs.irc_no_hilight, "NickServ,ChanServ,InfoServ,N,Q");
 
 	g_free ((char *)username);
 	g_free ((char *)realname);


### PR DESCRIPTION
Ignores InfoServ, N, and Q for highlights by default.
The latter 2 are a quakenet thing.
Was considering removing Global and MemoServ, but some people might want to keep those.
