### PR TITLE
Allow user to enable or disable libproxy support explicitly

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -174,6 +174,11 @@ AC_ARG_ENABLE(ntlm,
 [  --enable-ntlm           enable Microsoft's NTLM auth (libntlm) library support (default: no)],
 	ntlm=$enableval, ntlm=no)
 
+AC_ARG_ENABLE(libproxy,
+[  --disable-libproxy      disable libproxy support (default: auto)],
+        libproxy=$enableval, libproxy=auto)
+
+
 dnl *********************************************************************
 dnl ** GLIB *************************************************************
 dnl *********************************************************************
@@ -462,13 +467,20 @@ dnl *********************************************************************
 dnl ** LIBPROXY *********************************************************
 dnl *********************************************************************
 
-PKG_CHECK_MODULES([LIBPROXY], [libproxy-1.0], [libproxy=yes], [
+if test "x$libproxy" = "xyes" -o "x$libproxy" = "xauto" ; then
+	PKG_CHECK_MODULES([LIBPROXY], [libproxy-1.0], [
+		COMMON_LIBS="$COMMON_LIBS $LIBPROXY_LIBS"
+		COMMON_CFLAGS="$COMMON_CFLAGS $LIBPROXY_CFLAGS"
+		AC_DEFINE(USE_LIBPROXY)
+		libproxy=yes
+	], [
+		if test "x$libproxy" = "xyes" ; then
+			AC_MSG_ERROR(Can't find libproxy!)
+		fi
+		libproxy=no
+	])
+else
 	libproxy=no
-])
-if test "x$libproxy" = "xyes" ; then
-	COMMON_LIBS="$COMMON_LIBS $LIBPROXY_LIBS"
-	COMMON_CFLAGS="$COMMON_CFLAGS $LIBPROXY_CFLAGS"
-	AC_DEFINE(USE_LIBPROXY)
 fi
 
 dnl *********************************************************************
@@ -957,6 +969,7 @@ echo Plugin interface ...... : $plugin
 echo NLS/gettext ........... : $USE_NLS
 echo IPv6 support .......... : $ipv6
 echo MS Proxy NTLM \(ISA\) ... : $have_ntlm
+echo libproxy support ...... : $libproxy
 echo
 echo Perl .................. : $perl
 echo Python ................ : $python


### PR DESCRIPTION
This adds the switches `--enable-libproxy` or `--disable-libproxy` to the configure script.

`./configure --help` displays the help that libproxy support can be explicitly disabled.

Support defaults to `auto`. If explicitly enabled, and the library is not present, configure will error out.

The status at the end of ./configure lists whether libproxy will or will not be enabled.
