### PR TITLE
Fix memory leak related to url grabbing

### DIFF
--- a/src/common/cfgfiles.c
+++ b/src/common/cfgfiles.c
@@ -744,7 +744,7 @@ load_config (void)
 	prefs.input_tray_priv = prefs.input_tray_hilight = 1;
 	prefs.autodccsend = 2;	/* browse mode */
 	prefs.url_grabber = 1;
-	prefs.url_grabber_limit = 50; /* 0 means unlimited */
+	prefs.url_grabber_limit = 0; /* 0 means unlimited */
 	prefs.text_search_follow = 1;
 #ifdef WIN32
 	prefs.identd = 1;

--- a/src/common/tree.c
+++ b/src/common/tree.c
@@ -150,10 +150,11 @@ tree_find (tree *t, void *key, tree_cmp_func *cmp, void *data, int *pos)
 	return mybsearch (key, &t->array[0], t->elements, cmp, data, pos);
 }
 
-void
+void *
 tree_remove_at_pos (tree *t, int pos)
 {
 	int post_bytes;
+	void *ret = t->array[pos];
 
 	t->elements--;
 	if (pos != t->elements)
@@ -161,6 +162,7 @@ tree_remove_at_pos (tree *t, int pos)
 		post_bytes = (t->elements - pos) * sizeof (void *);
 		memmove (&t->array[pos], &t->array[pos + 1], post_bytes);
 	}
+	return ret;
 }
 
 int

--- a/src/common/tree.h
+++ b/src/common/tree.h
@@ -10,7 +10,7 @@ tree *tree_new (tree_cmp_func *cmp, void *data);
 void tree_destroy (tree *t);
 void *tree_find (tree *t, void *key, tree_cmp_func *cmp, void *data, int *pos);
 int tree_remove (tree *t, void *key, int *pos);
-void tree_remove_at_pos (tree *t, int pos);
+void *tree_remove_at_pos (tree *t, int pos);
 void tree_foreach (tree *t, tree_traverse_func *func, void *data);
 int tree_insert (tree *t, void *key);
 void tree_append (tree* t, void *key);

--- a/src/common/url.c
+++ b/src/common/url.c
@@ -31,6 +31,7 @@
 #endif
 
 void *url_tree = NULL;
+GTree *url_btree = NULL;
 
 
 static int
@@ -46,6 +47,8 @@ url_clear (void)
 	tree_foreach (url_tree, (tree_traverse_func *)url_free, NULL);
 	tree_destroy (url_tree);
 	url_tree = NULL;
+	g_tree_destroy (url_btree);
+	url_btree = NULL;
 }
 
 static int
@@ -80,11 +83,7 @@ url_autosave (void)
 static int
 url_find (char *urltext)
 {
-	int pos;
-
-	if (tree_find (url_tree, urltext, (tree_cmp_func *)g_ascii_strcasecmp, NULL, &pos))
-		return 1;
-	return 0;
+	return (g_tree_lookup_extended (url_btree, urltext, NULL, NULL));
 }
 
 static void
@@ -110,14 +109,17 @@ url_add (char *urltext, int len)
 	if (data[len - 1] == ')')	/* chop trailing ) */
 		data[len - 1] = 0;
 
+	if (!url_tree)
+	{
+		url_tree = tree_new ((tree_cmp_func *)strcasecmp, NULL);
+		url_btree = g_tree_new ((GCompareFunc)strcasecmp);
+	}
+
 	if (url_find (data))
 	{
 		free (data);
 		return;
 	}
-
-	if (!url_tree)
-		url_tree = tree_new ((tree_cmp_func *)g_ascii_strcasecmp, NULL);
 
 	size = tree_size (url_tree);
 	/* 0 is unlimited */
@@ -127,10 +129,17 @@ url_add (char *urltext, int len)
 		   xchat is running */
 		size -= prefs.url_grabber_limit;
 		for(; size > 0; size--)
-			tree_remove_at_pos (url_tree, 0);
+		{
+			char *pos;
+
+			pos = tree_remove_at_pos (url_tree, 0);
+			g_tree_remove (url_btree, pos);
+			free (pos);
+		}
 	}
 
 	tree_append (url_tree, data);
+	g_tree_insert (url_btree, data, GINT_TO_POINTER (tree_size (url_tree) - 1));
 	fe_url_add (data);
 }
 


### PR DESCRIPTION
Hexchat, like xchat, uses src/common/tree.c to keep lists of usernames
(one list per session) and urls (one list for the whole app).
Usernames are kept in sorted order.  Urls were kept in sorted order,
too, through svn revision 1501; with 1502, urls are kept in FIFO order.
(Don't be fooled by the name 'tree'; each list is really an array.)

This change to FIFO order for urls broke duplicate checking, because that
was still done using a binary search, in tree_find(); and of course you
can't binary-search a FIFO-ordered list.

So, beginning with revision 1502, the list of urls can grow indefinitely
large.  Most of them are in fact duplicates.  In a long-running process of
mine, hexchat had accumulated over half a million urls!  (514,172 to be
exact).  Doing a sort -u on the file gave only twenty thousand (20,374).
That's a forty-day accumulation, and I consider it reasonable.

Revision 1502 also added limiting code and parameter url_grabber_limit.
But in implementing this (in url_add()), code to shrink the array size
did not free the url strings.  This is a true memory leak, but it would
only occur when url_grabber_limit was changed from its default of 0.

As a fix, I have done url duplicate detection entirely in url.c, by adding
a GTree and the usual lines to add, search, delete; it took surprisingly
little code.  I have restored the default of url_grabber_limit to 0; it
had been changed to 50 when the problem was insufficiently understood.
In tree.c I have made tree_remove_at_pos() return the pointer just
removed, so that url_add() can free its storage.
