### PR TITLE
Add support for ircd-seven's IDENTIFY-MSG feature

### DIFF
--- a/src/common/proto-irc.c
+++ b/src/common/proto-irc.c
@@ -49,6 +49,7 @@ irc_login (server *serv, char *user, char *realname)
 {
 	if (serv->password[0])
 		tcp_sendf (serv, "PASS %s\r\n", serv->password);
+	tcp_sendf (serv, "CAP LS\r\n");
 
 	tcp_sendf (serv,
 				  "NICK %s\r\n"
@@ -1110,6 +1111,38 @@ process_named_msg (session *sess, char *type, char *word[], char *word_eol[])
 			if (*text == ':')
 				text++;
 			EMIT_SIGNAL (XP_TE_WALLOPS, sess, nick, text, NULL, NULL, 0);
+			return;
+		}
+	}
+
+	else if (len == 3)
+	{
+		guint32 t;
+
+		t = WORDL((guint8)type[0], (guint8)type[1], (guint8)type[2], (guint8)type[3]);
+		switch (t)
+		{
+		case WORDL('C','A','P','\0'):
+			if (strncasecmp(word[4], "ACK", 3) == 0)
+			{
+				if (strncasecmp(word[5][0]==':' ? word[5]+1 : word[5],
+					"identify-msg", 12) == 0)
+				{
+					serv->have_idmsg = TRUE;
+					tcp_send_len(serv, "CAP END\r\n", 9);
+				}
+			}
+			else if (strncasecmp(word[4], "LS", 2) == 0)
+			{
+				if (strstr(word_eol[5], "identify-msg") != 0)
+					tcp_send_len(serv, "CAP REQ :identify-msg\r\n", 23);
+				else
+					tcp_send_len(serv, "CAP END\r\n", 9);
+			}
+			else if (strncasecmp(word[4], "NAK",3) == 0)
+			{
+				tcp_send_len(serv, "CAP END\r\n", 9);
+			}
 			return;
 		}
 	}


### PR DESCRIPTION
IDENTIFY-MSG is a feature provided by the freenode network which allows a user to have each line from the IRCD prepended with either "+" or "-", depending on whether the user who said the line is identified to services or not. Clients can then interpret this and present it to the user in some form. XChat has (fairly well-hidden) support for this in its previous incarnation, on the Hyperion IRCD, where it was enabled with "CAPAB IDENTIFY-MSG", however this was changed with the move to ircd-seven in 2010, and XChat upstream never added support.

This repo is just incorporating "51_freenode_ircd-seven.patch" from Ubuntu's XChat package; take a look at https://bugs.launchpad.net/ubuntu/+source/xchat/+bug/507072 for more information.
