### PR TITLE
add gui option for text based status icons

### DIFF
--- a/src/common/cfgfiles.c
+++ b/src/common/cfgfiles.c
@@ -476,6 +476,7 @@ const struct prefs vars[] = {
 	{"gui_ulist_show_hosts", P_OFFINT(showhostname_in_userlist), TYPE_BOOL},
 	{"gui_ulist_sort", P_OFFINT (userlist_sort), TYPE_INT},
 	{"gui_ulist_style", P_OFFINT (style_namelistgad), TYPE_BOOL},
+	{"gui_ulist_texticons", P_OFFINT(gui_ulist_texticons), TYPE_BOOL},
 	{"gui_url_mod", P_OFFINT (gui_url_mod), TYPE_INT},
 	{"gui_usermenu", P_OFFINT (gui_usermenu), TYPE_BOOL},
 	{"gui_win_height", P_OFFINT (mainwindow_height), TYPE_INT},

--- a/src/common/xchat.h
+++ b/src/common/xchat.h
@@ -187,6 +187,7 @@ struct xchatprefs
 	int gui_win_state;
 	int gui_url_mod;
 	int gui_usermenu;
+	int gui_ulist_texticons;
 	int gui_join_dialog;
 	int gui_quit_dialog;
 #ifdef WIN32

--- a/src/fe-gtk/setup.c
+++ b/src/fe-gtk/setup.c
@@ -215,6 +215,7 @@ static const setting userlist_settings[] =
 	{ST_HEADER,	N_("User List"),0,0,0},
 	{ST_TOGGLE, N_("Show hostnames in user list"), P_OFFINTNL(showhostname_in_userlist), 0, 0, 0},
 	{ST_TOGGLE, N_("Use the Text box font and colors"), P_OFFINTNL(style_namelistgad),0,0,0},
+	{ST_TOGGLE, N_("Use text-based status icons"), P_OFFINTNL(gui_ulist_texticons), 0, 0, 0},
 /*	{ST_TOGGLE, N_("Resizable user list"), P_OFFINTNL(paned_userlist),0,0,0},*/
 	{ST_MENU,	N_("User list sorted by:"), P_OFFINTNL(userlist_sort), 0, ulmenutext, 0},
 	{ST_MENU,	N_("Show user list at:"), P_OFFINTNL(gui_ulist_pos), 0, ulpos, 1},
@@ -2130,6 +2131,8 @@ setup_apply (struct xchatprefs *pr)
 
 #define DIFF(a) (pr->a != prefs.a)
 
+	if (DIFF (gui_ulist_texticons))
+		noapply = TRUE;
 	if (DIFF (paned_userlist))
 		noapply = TRUE;
 	if (DIFF (lagometer))

--- a/src/fe-gtk/userlistgui.c
+++ b/src/fe-gtk/userlistgui.c
@@ -356,7 +356,7 @@ fe_userlist_insert (session *sess, struct User *newuser, int row, int sel)
 		do_away = FALSE;
 
 	nick = newuser->nick;
-	if (prefs.gui_tweaks & 64)
+	if (prefs.gui_ulist_texticons)
 	{
 		nick = malloc (strlen (newuser->nick) + 2);
 		nick[0] = newuser->prefix[0];
@@ -377,7 +377,7 @@ fe_userlist_insert (session *sess, struct User *newuser, int row, int sel)
 										:	(NULL),
 								  -1);
 
-	if (prefs.gui_tweaks & 64)
+	if (prefs.gui_ulist_texticons)
 		free (nick);
 
 	/* is it me? */


### PR DESCRIPTION
This patch adds an option in the gui to use text based status icons as opposed to bitmaps. It moves the setting from gui_tweaks to its own variable (gui_ulist_texticons). It's not exactly backward compatible, but at least now the setting is easy to change for anyone.
