### PR TITLE
that malloc should have been made bigger when renaming xchat.conf to hex...

### DIFF
--- a/src/common/cfgfiles.c
+++ b/src/common/cfgfiles.c
@@ -381,7 +381,7 @@ default_file (void)
 
 	if (!dfile)
 	{
-		dfile = malloc (strlen (get_xdir_fs ()) + 12);
+		dfile = malloc (strlen (get_xdir_fs ()) + 14);
 		sprintf (dfile, "%s/hexchat.conf", get_xdir_fs ());
 	}
 	return dfile;


### PR DESCRIPTION
...chat.conf

I was having problems with segfaults when i didn't have any config files, and when I did have config files, I wasn't able to save any of them. After some research I found that [this](https://github.com/hexchat/hexchat/commit/87aa65653b0c00495d18995be444d9435305509c) commit broke it on my system. It was really weird, since it only failed under the user name "daniel", so I thought it was a permissions issue on my system. Seems like the dfile malloc wasn't adapted to the change of the config file, so I have added 2 to it accordingly for the 2 characters added in the config file name.
