### PR TITLE
Fix for issue #289, autocopy though no text selected

### DIFF
--- a/src/fe-gtk/xtext.c
+++ b/src/fe-gtk/xtext.c
@@ -2165,8 +2165,9 @@ gtk_xtext_set_clip_owner (GtkWidget * xtext, GdkEventButton * event)
 	str = gtk_xtext_selection_get_text (GTK_XTEXT (xtext), &len);
 	if (str)
 	{
-		gtk_clipboard_set_text (gtk_widget_get_clipboard (xtext, GDK_SELECTION_CLIPBOARD),
-										str, len);
+		if (str[0])
+			gtk_clipboard_set_text (gtk_widget_get_clipboard (xtext, GDK_SELECTION_CLIPBOARD),
+											str, len);
 		free (str);
 	}
 


### PR DESCRIPTION
All this takes place in xtext.c.

gtk_xtext_set_clip_owner() will get called always when text_autocopy_text is TRUE and the mouse button is released.  But it shouldn't perform that copy into the clipboard if there's no text selected!  This can happen when user moves mouse slightly merely to raise window.

gtk_xtext_set_clip_owner() calls gtk_xtext_selection_get_text() to obtain the string to be copied to the clipboard.  gtk_xtext_selection_get_text() examines the selection data for the current context and the timestamp flag to form a string to return.  As its last action it decolorizes this string, by calling gtk_xtext_strip_color().  This function _always_ returns a nonzero string pointer from the heap, which must be freed, but the string _can_ be a null string.

The fix is to recognize when a null string is returned and bypass the call to gtk_clipboard_set_text(); and in either case to perform free() on the returned pointer.

I note that probably the free() should be g_free().  But throughout the source tree the preponderance of such calls is free(), with 382 uses, as against g_free() with only 296 uses.
