### PR TITLE
fix configure error related to Python headers on Ubuntu 13.04

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -341,7 +341,8 @@ if test "$python" = yes; then
                 changequote(<<, >>)dnl
                 PY_VER=`$pythonpath -c 'import distutils.sysconfig; print distutils.sysconfig.get_config_vars("VERSION")[0];'`
                 PY_LIB=`$pythonpath -c 'import distutils.sysconfig; print distutils.sysconfig.get_python_lib(standard_lib=1);'`
-                PY_INC=`$pythonpath -c 'import distutils.sysconfig; print distutils.sysconfig.get_config_vars("INCLUDEPY")[0];'`
+                PY_INC=`$pythonpath -c 'import distutils.sysconfig; print distutils.sysconfig.get_python_inc();'`
+                PYPLAT_INC=`$pythonpath -c 'import distutils.sysconfig; print distutils.sysconfig.get_python_inc(plat_specific=True);'`
                 $pythonpath -c "import sys; map(int,sys.version[:3].split('.')) >= [2,2] or sys.exit(1)"
                 changequote([, ])dnl
                 AC_MSG_RESULT($PY_VER)
@@ -349,9 +350,9 @@ if test "$python" = yes; then
                         AC_MSG_CHECKING(Python compile flags)
                         PY_PREFIX=`$pythonpath -c 'import sys; print sys.prefix'`
                         PY_EXEC_PREFIX=`$pythonpath -c 'import sys; print sys.exec_prefix'`
-                        if test -f $PY_INC/Python.h; then
+                        if test -f $PY_INC/Python.h || test -f $PYPLAT_INC/Python.h; then
                                 PY_LIBS="-L$PY_LIB/config -lpython$PY_VER -lpthread -lutil"
-                                PY_CFLAGS="-I$PY_INC"
+                                PY_CFLAGS="-I$PY_INC -I$PYPLAT_INC"
                                 AC_MSG_RESULT(ok)
                         else
                                 python=no


### PR DESCRIPTION
HexChat fails to compile (if the Python plugin interface is selected in the configure script, which it is by default) with Ubuntu 13.04. This commit fixes the issue.

Saw the issue and fix first for X-Chat:

https://bugs.launchpad.net/ubuntu/+source/xchat/+bug/1090842
http://sourceforge.net/tracker/?func=detail&aid=3596543&group_id=239&atid=100239

ignore the travis build notice below; was messing about earlier and forgot to turn it off
