### PR TITLE
Allow numerals in TLDs also

### DIFF
--- a/src/common/url.c
+++ b/src/common/url.c
@@ -347,7 +347,7 @@ do_an_re(const char *word,int *start, int *end, int *type)
 }
 
 /*	Miscellaneous description --- */
-#define DOMAIN "[-a-z0-9]+(\\.[-a-z0-9]+)*\\.[a-z]+"
+#define DOMAIN "[-a-z0-9]+(\\.[-a-z0-9]+)*\\.[a-z0-9]+"
 #define IPADDR "[0-9]+(\\.[0-9]+){3}"
 #define HOST "(" DOMAIN "|" IPADDR ")"
 #define OPT_PORT "(:[1-9][0-9]{0,4})?"


### PR DESCRIPTION
Alternate networks can/do use numerals in their custom TLD's
for example the I2P network uses host.i2p
