### PR TITLE
Closes issue 350.  Fix stat64 and malloc.h problems

### DIFF
--- a/plugins/checksum/checksum.c
+++ b/plugins/checksum/checksum.c
@@ -23,7 +23,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <malloc.h>
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/src/version/version.c
+++ b/src/version/version.c
@@ -23,7 +23,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <malloc.h>
 #include "../../config-win32.h"
 
 char *


### PR DESCRIPTION
Fix the stat64 issue in plugins/checksum/checksum.c and remove the include of malloc.h in both that and src/version/version.c.  The caused problems in freebsd. 
