### PR TITLE
change URL for "Contents" option in "Help" menu

### DIFF
--- a/src/fe-gtk/menu.c
+++ b/src/fe-gtk/menu.c
@@ -1503,7 +1503,7 @@ menu_ctcpguiopen (void)
 static void
 menu_docs (GtkWidget *wid, gpointer none)
 {
-	fe_open_url ("http://www.hexchat.org/");
+	fe_open_url ("http://docs.hexchat.org/");
 }
 
 /*static void


### PR DESCRIPTION
I propose that the address for the help contents is changed to docs.hexchat.org over simply being hexchat.org.

Furthermore, it could be good to add a link to the website from the "About" window if a link to the project page is still desireable without needing to use the docs.
