### PR TITLE
Fix bug in url.c at re_host().

### DIFF
--- a/src/common/url.c
+++ b/src/common/url.c
@@ -371,6 +371,9 @@ re_host (void)
 {
 	static GRegex *host_ret;
 	char *grist;
+
+	if (host_ret) return host_ret;
+
 	grist = g_strdup_printf (
 		"("	/* HOST */
 			HOST OPT_PORT


### PR DESCRIPTION
Unlike the other re_foo() functions it was not checking immediately
and returning if host_ret had already been filled in.  This would
causes a memory leak since the previous GRegex would be lost.
