### PR TITLE
banlist: display/clear only bans, exempts, or both

### DIFF
--- a/src/fe-gtk/banlist.c
+++ b/src/fe-gtk/banlist.c
@@ -56,9 +56,9 @@ enum
 };
 
 static short view_mode;	/* 1=ban 2=exempt 3=both */
-#define VIEW_BAN 1
+#define VIEW_BAN    1
 #define VIEW_EXEMPT 2
-#define VIEW_BOTH VIEW_BAN | VIEW_EXEMPT
+#define VIEW_BOTH   (VIEW_BAN | VIEW_EXEMPT)
 
 typedef struct
 {
@@ -436,9 +436,9 @@ banlist_opengui (struct session *sess)
 		return;
 	}
 	
-	viewmode_banlist *viewmode_both = malloc(sizeof(viewmode_banlist));
-	viewmode_banlist *viewmode_ban = malloc(sizeof(viewmode_banlist));
-	viewmode_banlist *viewmode_exempt = malloc(sizeof(viewmode_banlist));
+	viewmode_banlist *viewmode_both = malloc (sizeof (viewmode_banlist));
+	viewmode_banlist *viewmode_ban = malloc (sizeof (viewmode_banlist));
+	viewmode_banlist *viewmode_exempt = malloc (sizeof (viewmode_banlist));
 	
 	snprintf (tbuf, sizeof tbuf, _(DISPLAY_NAME": Ban List (%s)"),
 					sess->server->servername);


### PR DESCRIPTION
Using the same layout as the dcc windows (radio buttons), we can show only the bans or the exempts (or both) in the ban list windows. The "clear" button acts accordingly, clearing only the bans, the exempts or both.

It should fix issue #303 (without requiring a new option).

Of course I'm willing to fix any issue in my own code - I'm asking for review :) especially since I'm not sure about some things like the viewmode_banlist struct I created.
