### PR TITLE
Change is_del to remove ATTR_BOLD, ATTR_RESET -- closes issue 435

### DIFF
--- a/src/fe-gtk/xtext.c
+++ b/src/fe-gtk/xtext.c
@@ -90,15 +90,8 @@
 #endif
 
 /* is delimiter */
-#if 0
-/* () is used by Wikipedia */
 #define is_del(c) \
-	(c == ' ' || c == '\n' || c == ')' || c == '(' || \
-	 c == '>' || c == '<' || c == ATTR_RESET || c == ATTR_BOLD || c == 0)
-#endif
-#define is_del(c) \
-	(c == ' ' || c == '\n' || c == '>' || c == '<' || \
-	 c == ATTR_RESET || c == ATTR_BOLD || c == 0)
+	(c == ' ' || c == '\n' || c == '>' || c == '<' || c == 0)
 
 #ifdef SCROLL_HACK
 /* force scrolling off */


### PR DESCRIPTION
Change the is_del() macro to not regard ATTR_BOLD nor ATTR_RESET as delimiters.

Remove old iffed-out version of is_del() as well, as a cleanup step; that change
was for not regarding left and right parens as delimiters.  With this change,
mousing over a nickname will underline it even if it contains embedded formatting
data; it used to work with all formatting data but bold and reset; now it
works for all.
