### PR TITLE
manpage has useless whatis-entry

### DIFF
--- a/man/hexchat.1
+++ b/man/hexchat.1
@@ -1,6 +1,6 @@
 .TH HEXCHAT "1" "April 2013" "HexChat 2.9.5" "User Commands"
 .SH NAME
-HexChat \- manual page for HexChat 2.9.5
+HexChat \- GTK+-based IRC client
 .SH DESCRIPTION
 .SS "Usage:"
 .IP


### PR DESCRIPTION
The title of the man page could be a bit more informative - Debian uses a program called lintian to find both bigger problems and minor (like this one). See the info on the tag from lintian here:
http://lintian.debian.org/tags/manpage-has-useless-whatis-entry.html

One suggestion is in the commit in this pull-request, but I am open for other suggestions and ideas - It might be a good idea to not mention GTK+ in the description, since we have fe-text too...
