### PR TITLE
fix issue #491 - opt-in/opt-out of scrollback per channel

### DIFF
--- a/src/common/hexchat.c
+++ b/src/common/hexchat.c
@@ -505,8 +505,8 @@ new_ircwindow (server *serv, char *name, int type, int focus)
 	}
 
 	irc_init (sess);
-	scrollback_load (sess);
 	chanopt_load (sess);
+	scrollback_load (sess);
 	plugin_emit_dummy_print (sess, "Open Context");
 
 	return sess;


### PR DESCRIPTION
A simple fix to issue #491. Opting in / opting out of scrollback per channel wasn't working because HexChat loaded the scrollback file before checking the channel options.
