### PR TITLE
Fix lag meter when the server is not responding

### DIFF
--- a/src/common/hexchat.c
+++ b/src/common/hexchat.c
@@ -281,7 +281,7 @@ lag_check (void)
 								 NULL, NULL, 0);
 				if (prefs.hex_net_auto_reconnect)
 					serv->auto_reconnect (serv, FALSE, -1);
-			} else
+			} else if (!serv->lag_sent)
 			{
 				snprintf (tbuf, sizeof (tbuf), "LAG%lu", tim);
 				serv->p_ping (serv, "", tbuf);

--- a/src/fe-gtk/fe-gtk.c
+++ b/src/fe-gtk/fe-gtk.c
@@ -735,6 +735,10 @@ fe_set_lag (server *serv, int lag)
 		lag = (nowtim - serv->lag_sent) / 100000;
 	}
 
+	/* if there is no pong for >30s report the lag as +30s */
+	if (lag > 300 && serv->lag_sent)
+		lag=300;
+
 	per = (double)((double)lag / (double)10);
 	if (per > 1.0)
 		per = 1.0;


### PR DESCRIPTION
Don't send ping's to the server if we are still waiting for a pong. 

If the server don't respond in 30s just report the lag as +30s.

This fixes the bug where hexchat reset the lag meter every time a ping
was sent and no pong was received.
