### PR TITLE
Fixed issue #440

### DIFF
--- a/src/common/url.c
+++ b/src/common/url.c
@@ -508,7 +508,7 @@ re_nick (void)
 }
 
 /*	CHANNEL description --- */
-#define CHANNEL "#[^ \t\a,:]+"
+#define CHANNEL "^#[^ \t\a,:]+$"
 
 static GRegex *
 re_channel (void)


### PR DESCRIPTION
Fixed issue #440. Now the "url" #foo.baz is correctly recognized as a channel
instead of a hostname.
