### PR TITLE
Unable to highlight on words which contain "@"

### DIFF
--- a/src/common/inbound.c
+++ b/src/common/inbound.c
@@ -259,13 +259,6 @@ alert_match_text (char *text, char *masks)
 	while (1)
 	{
 
-		/* allow highlight on '@all' */
-		if (*p == '@')
-		{
-			p++;
-			continue;
-		}
-
 		if (*p >= '0' && *p <= '9')
 		{
 			p++;
@@ -278,6 +271,13 @@ alert_match_text (char *text, char *masks)
 		case '-': case '[': case ']': case '\\':
 		case '`': case '^': case '{': case '}':
 		case '_': case '|':
+			p++;
+			continue;
+		}
+
+		/* allow highlight on word which contains @ */
+		if (*p == '@')
+		{
 			p++;
 			continue;
 		}


### PR DESCRIPTION
```
/set irc_extra_hilight @all
```

This never works because `@` is considered as a separator.
