### PR TITLE
Build failure: fix undefined reference to `g_type_init'

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -211,8 +211,6 @@ fi
 
 if test "$gtkfe" != yes; then
 	gnome=no
-	COMMON_LIBS="$GLIB_LIBS"
-	COMMON_CFLAGS="$GLIB_CFLAGS"
 fi
 
 dnl *********************************************************************


### PR DESCRIPTION
These two assignments have no place here and will overwrite the
previous COMMON_LIBS="$COMMON_LIBS -lgmodule-2.0 -lgobject-2.0".
This can lead to build failure during linking stage depending on
the chosen configure options.
