### PR TITLE
Session of numeric events passed to text_emit() for nicks with open query dialogs

### DIFF
--- a/src/common/proto-irc.c
+++ b/src/common/proto-irc.c
@@ -938,16 +938,21 @@ process_numeric (session * sess, int n,
 		}
 
 	def:
-		if (is_channel (serv, word[4]))
 		{
-			session *realsess = find_channel (serv, word[4]);
-			if (!realsess)
-				realsess = serv->server_session;
-			EMIT_SIGNAL (XP_TE_SERVTEXT, realsess, text, word[1], word[2], NULL, 0);
-		} else
-		{
-			EMIT_SIGNAL (XP_TE_SERVTEXT, serv->server_session, text, word[1],
-							 word[2], NULL, 0);
+			session *sess;
+		
+			if (is_channel (serv, word[4]))
+			{
+				sess = find_channel (serv, word[4]);
+				if (!sess)
+					sess = serv->server_session;
+			}
+			else if ((sess=find_dialog (serv,word[4]))) /* user with an open dialog */
+				;
+			else
+				sess=serv->server_session;
+			
+			EMIT_SIGNAL (XP_TE_SERVTEXT, sess, text, word[1], word[2], NULL, 0);
 		}
 	}
 }


### PR DESCRIPTION
Now process_numeric() passes the right session context to text_emit() when an
numeric event occurs regarding a nick with a open dialog.

Since this session context is potentially passed to plugins this can change the
behavior of plugins, but I think this is the intended semantics
(http://docs.hexchat.org/en/latest/script_python.html#context-theory).

Another consequence is that event messages will be displayed in the query dialog
of the nick in question (if a query dialog is open, of course), which I think is
sensible. (The initial intention of this patch was actually to report the
"No such nick" message in the query dialog when sending a message to a user that
has quit.)
