### PR TITLE
Added help text to sysinfo

### DIFF
--- a/plugins/sysinfo/sysinfo.cpp
+++ b/plugins/sysinfo/sysinfo.cpp
@@ -31,6 +31,7 @@ static hexchat_plugin *ph;   /* plugin handle */
 static char name[] = "SysInfo";
 static char desc[] = "Display info about your hardware and OS";
 static char version[] = "1.1";
+static char helptext[] = "USAGE: /sysinfo - Sends info about your hardware and OS to current channel.";
 static int firstRun;
 static char *wmiOs;
 static char *wmiCpu;
@@ -397,7 +398,7 @@ hexchat_plugin_init (hexchat_plugin *plugin_handle, char **plugin_name, char **p
 
 	firstRun = 1;
 
-	hexchat_hook_command (ph, "SYSINFO", HEXCHAT_PRI_NORM, printInfo, NULL, NULL);
+	hexchat_hook_command (ph, "SYSINFO", HEXCHAT_PRI_NORM, printInfo, helptext, NULL);
 	hexchat_command (ph, "MENU -ishare\\system.png ADD \"Window/Display System Info\" \"SYSINFO\"");
 
 	hexchat_printf (ph, "%s plugin loaded\n", name);


### PR DESCRIPTION
Help text for a single function plugin because... reasons. (maybe lets them know it sends a message to the channel instead of assuming it just prints in the window)
