### PR TITLE
Allow the special colors 32..41 in %Cfg,bg

### DIFF
--- a/src/fe-gtk/xtext.c
+++ b/src/fe-gtk/xtext.c
@@ -3204,6 +3204,7 @@ gtk_xtext_render_str (GtkXText * xtext, int y, textentry * ent,
 					if (col_num == 99)	/* mIRC lameness */
 						col_num = XTEXT_FG;
 					else
+					if (col_num > XTEXT_MAX_COLOR)
 						col_num = col_num % XTEXT_MIRC_COLS;
 					xtext->col_fore = col_num;
 					if (!mark)
@@ -3230,6 +3231,7 @@ gtk_xtext_render_str (GtkXText * xtext, int y, textentry * ent,
 						if (col_num == 99)	/* mIRC lameness */
 							col_num = XTEXT_BG;
 						else
+						if (col_num > XTEXT_MAX_COLOR)
 							col_num = col_num % XTEXT_MIRC_COLS;
 						if (col_num == XTEXT_BG)
 							xtext->backcolor = FALSE;
@@ -3243,6 +3245,7 @@ gtk_xtext_render_str (GtkXText * xtext, int y, textentry * ent,
 						if (col_num == 99)	/* mIRC lameness */
 							col_num = XTEXT_FG;
 						else
+						if (col_num > XTEXT_MAX_COLOR)
 							col_num = col_num % XTEXT_MIRC_COLS;
 						if (!mark)
 							xtext_set_fg (xtext, gc, col_num);

--- a/src/fe-gtk/xtext.h
+++ b/src/fe-gtk/xtext.h
@@ -58,6 +58,7 @@
 #define XTEXT_FG 34
 #define XTEXT_BG 35
 #define XTEXT_MARKER 36		/* for marker line */
+#define XTEXT_MAX_COLOR 41
 
 typedef struct _GtkXText GtkXText;
 typedef struct _GtkXTextClass GtkXTextClass;


### PR DESCRIPTION
Text events allow %Cfg,bg as decribed in "Theming" on
https://hexchat.readthedocs.org/en/latest/appearance.html?#theming

That section describes mIRC colors 0-15 and local colors 16-31, but
when selecting background colors, the 9 special internal colors are
extremely useful, like %C20,33 will do bright red on the selected
text background color.

As the documentation is on-line, this patch has no doc-change.
Ideally, the color-codes should show in the colored squares in the
preferences color-dialog just as with colors 0-31

Signed-off-by: H.Merijn Brand h.m.brand@xs4all.nl
