### PR TITLE
Fix issue with /server command

### DIFF
--- a/src/common/outbound.c
+++ b/src/common/outbound.c
@@ -3249,6 +3249,7 @@ cmd_server (struct session *sess, char *tbuf, char *word[], char *word_eol[])
 	if (*pass)
 	{
 		safe_strcpy (serv->password, pass, sizeof (serv->password));
+		serv->loginmethod = LOGIN_PASS;
 	}
 #ifdef USE_OPENSSL
 	serv->use_ssl = use_ssl;


### PR DESCRIPTION
Passing a password to the /server command was ignored because the login method
was not set.
