### PR TITLE
Fixed null pointer deref when we try to autojoin a channel

### DIFF
--- a/src/common/inbound.c
+++ b/src/common/inbound.c
@@ -1093,8 +1093,7 @@ check_autojoin_channels (server *serv)
 				strcpy (sess->waitchannel, sess->willjoinchannel);
 				sess->willjoinchannel[0] = 0;
 
-				/* Is this channel in our favorites? */
-				fav = servlist_favchan_find (serv->network, sess->waitchannel, NULL);
+				fav = servlist_favchan_find (serv->network, sess->waitchannel, NULL);	/* Is this channel in our favorites? */
 
 				/* session->channelkey is initially unset for channels joined from the favorites. You have to fill them up manually from favorites settings. */
 				if (fav)


### PR DESCRIPTION
Fixed null pointer deref when we try to autojoin a channel of a network not in the network list.
(We check the favchans of the network to get the key the channel may require.)
