### PR TITLE
Improved server_get_network()

### DIFF
--- a/src/common/server.c
+++ b/src/common/server.c
@@ -1903,8 +1903,13 @@ server_set_defaults (server *serv)
 char *
 server_get_network (server *serv, gboolean fallback)
 {
+	/* check the network list */
 	if (serv->network)
 		return ((ircnet *)serv->network)->name;
+
+	/* check the network name given in 005 NETWORK=... */
+	if (serv->server_session && *serv->server_session->channel)
+		return serv->server_session->channel;
 
 	if (fallback)
 		return serv->servername;


### PR DESCRIPTION
Improved server_get_network(): if we don't have the current network in the
network list use the server name in received in event 005.
(This fixes the problem that the network (%n) in the log file names would be
"NETWORK" instead of the real network name (this happened if the network was
not in the network list).)
