### PR TITLE
Retrieve reachable addresses only.

### DIFF
--- a/src/common/network.c
+++ b/src/common/network.c
@@ -205,7 +205,7 @@ net_resolve (netstore * ns, char *hostname, int port, char **real_host)
 
 	memset (&hints, 0, sizeof (struct addrinfo));
 	hints.ai_family = PF_UNSPEC; /* support ipv6 and ipv4 */
-	hints.ai_flags = AI_CANONNAME;
+	hints.ai_flags = AI_CANONNAME | AI_ADDRCONFIG;
 	hints.ai_socktype = SOCK_STREAM;
 
 	if (port == 0)


### PR DESCRIPTION
AI_ADDRCONFIG helps not to try to connect unreachable ipv6 address if
user doesn't have ipv6 network stack.
