### PR TITLE
MAKE: backwards compat for old libtool

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,7 @@
 ## Process this file with automake to produce Makefile.in
 
+ACLOCAL_AMFLAGS = -I m4
+
 SUBDIRS = po intl src plugins man share
 
 EXTRA_DIST = autogen.sh

--- a/autogen.sh
+++ b/autogen.sh
@@ -78,7 +78,7 @@ if test "$?" != "0"; then
 	exit 2
 fi
 echo running libtoolize...
-libtoolize --force
+libtoolize --copy --force --install
 if test "$?" != "0"; then
 	echo libtoolize failed, stopping.
 	exit 3
@@ -90,7 +90,7 @@ if test "$?" != "0"; then
 	exit 4
 fi
 echo running $AUTOMAKE...
-$AUTOMAKE -a
+$AUTOMAKE -a -c
 if test "$?" != "0"; then
 	echo automake failed, stopping.
 	exit 5

--- a/configure.ac
+++ b/configure.ac
@@ -8,8 +8,9 @@ AC_COPYRIGHT([Copyright (C) 1998-2010 Peter Zelezny])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_SRCDIR([configure.ac])
 
-AM_INIT_AUTOMAKE([1.11 dist-bzip2 subdir-objects no-define foreign])
+AC_CONFIG_MACRO_DIR([m4])
 
+AM_INIT_AUTOMAKE([1.11 dist-bzip2 subdir-objects no-define foreign])
 AM_SILENT_RULES([yes])
 
 AC_USE_SYSTEM_EXTENSIONS


### PR DESCRIPTION
as discussed in issue #658
this will fix backwards compatibility with libtool-2.4 when you create the tarball with libtool-2.4.2
