### PR TITLE
Server aware nickname and channel matching

### DIFF
--- a/src/common/url.c
+++ b/src/common/url.c
@@ -251,7 +251,10 @@ match_nick (const char *word, int *start, int *end)
 	str = g_strndup (&word[*start], *end - *start);
 
 	if (!userlist_find (current_sess, str))
+	{
+		g_free (str);
 		return FALSE;
+	}
 
 	g_free (str);
 


### PR DESCRIPTION
Take into account the nickname/channel prefixes when matching word in `url.c`.

Fixes #655.
