### PR TITLE
Fixed munging of whitespace in sysinfo's matching functions

### DIFF
--- a/plugins/sysinfo/match.c
+++ b/plugins/sysinfo/match.c
@@ -65,17 +65,21 @@ char *pretty_freespace(const char *desc, unsigned long long *free_k, unsigned lo
         return result;
 }
 
-
 void remove_leading_whitespace(char *buffer)
 {
     char * buffer2 = NULL;
-    buffer2 = (char*) malloc(strlen(buffer)*(sizeof(char)));
-    if (buffer2 == NULL) { return; }
-    memset(buffer2,(char) 0,strlen(buffer));
     int i = 0, j = 0,ews = 0;
-    while (i < strlen(buffer)) {
-        // count tabs, spaces as whitespace.
-        if (!(buffer[i] == (char) 32 || buffer[i] == (char) 9) || ews == 1) {
+
+    buffer2 = (char*) malloc(strlen(buffer)*(sizeof(char)));
+    if (buffer2 == NULL) 
+        return;
+    
+    memset(buffer2,(char) 0,strlen(buffer));
+    while (i < strlen(buffer))
+    {
+        /* count tabs and spaces until we hit a non-whitespace character. */
+        if (!(buffer[i] == (char) 32 || buffer[i] == (char) 9) || ews == 1)
+        {
             ews = 1;
             buffer2[j] = buffer[i];
             j++;


### PR DESCRIPTION
basically, remove_leading_whitespace is unable to get a proper result without munging its input, this fixes that.

YAY NO MORE "GenuieIIntel"
