### PR TITLE
Fix colored vhosts

### DIFF
--- a/src/common/textevents.in
+++ b/src/common/textevents.in
@@ -493,7 +493,7 @@ pevt_invited_help
 Join
 XP_TE_JOIN
 pevt_join_help
-%C23*$t$1 ($3) has joined
+%C23*$t$1 ($3%C23) has joined
 3
 
 Keyword
@@ -625,13 +625,13 @@ n0
 Part
 XP_TE_PART
 pevt_part_help
-%C24*$t$1 ($2) has left
+%C24*$t$1 ($2%C24) has left
 3
 
 Part with Reason
 XP_TE_PARTREASON
 pevt_partreason_help
-%C24*$t$1 ($2) has left ($4)
+%C24*$t$1 ($2%C24) has left ($4)
 4
 
 Ping Reply


### PR DESCRIPTION
Special colored vhosts have a %O control code at the end, which breaks the text color of a few text events.
