### PR TITLE
Update grammar in two messages of es.po

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -4999,11 +4999,11 @@ msgstr "Formato de inserción de hora:"
 
 #: src/fe-gtk/setup.c:180 src/fe-gtk/setup.c:553
 msgid "See the strftime MSDN article for details."
-msgstr "Ver el strftime del artículo MSDN para más información."
+msgstr "Léa el artículo de MSDN sobre strftime para más información."
 
 #: src/fe-gtk/setup.c:182 src/fe-gtk/setup.c:555
 msgid "See the strftime manpage for details."
-msgstr "Ver el strftime de la página del manual para más información."
+msgstr "Léa la página de manual strftime(3) para más información."
 
 #: src/fe-gtk/setup.c:185
 msgid "Title Bar"


### PR DESCRIPTION
Correct the translation of src/fe-gtk/setup.c:180 src/fe-gtk/setup.c:553 and src/fe-gtk/setup.c:182 src/fe-gtk/setup.c:555 to be grammatically and syntactically correct Spanish.
