### PR TITLE
Channel joiner dialog does not allow you to join a valid channel

### DIFF
--- a/src/fe-gtk/joind.c
+++ b/src/fe-gtk/joind.c
@@ -86,7 +86,7 @@ joind_ok_cb (GtkWidget *ok, server *serv)
 	if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (serv->gui->joind_radio2)))
 	{
 		char *text = (char *)gtk_entry_get_text (GTK_ENTRY (serv->gui->joind_entry));
-		if (strlen (text) < 2)
+		if (strlen (text) < 1)
 		{
 			fe_message (_("Channel name too short, try again."), FE_MSG_ERROR);
 			return;


### PR DESCRIPTION
The initial popup when connecting to a server:

![cc-complete](https://f.cloud.github.com/assets/855009/1233479/93b75106-292c-11e3-9964-c542fbeb632c.png)

Will not allow you to join the channel "#", which is valid everywhere and in the RFC 1459. 

   Channels names are strings (beginning with a '&' or '#' character) of
   length up to 200 characters.  Apart from the the requirement that the
   first character being either '&' or '#'; the only restriction on a
   channel name is that it may not contain any spaces (' '), a control G
   (^G or ASCII 7), or a comma (',' which is used as a list item
   separator by the protocol)

Additionally, the join channel dialog (not the one that appears on server connection) allows you to join '#' as it should. So this behavior just puts the initial connection dialog into line with behavior present elsewhere.
