### PR TITLE
Fixed colour parsing

### DIFF
--- a/src/fe-gtk/sexy-spell-entry.c
+++ b/src/fe-gtk/sexy-spell-entry.c
@@ -949,12 +949,10 @@ check_color:
 				else
 					parsing_color = 5;
 			}
-			else
-			{
-				/* don't parse background color without a comma */
-				if (parsing_color == 3 && text[i - 1] != ',')
-					parsing_color = 5;
-			}
+
+			/* don't parse background color without a comma */
+			else if (parsing_color == 3 && text[i - 1] != ',')
+				parsing_color = 5;
 
 			switch (parsing_color)
 			{


### PR DESCRIPTION
- Background colour is only parsed when there's a comma
- Offset for background color is incorrectly calculated (there's no
  control character, just a comma)
