### PR TITLE
some Typos causing lintian moaning: {R,r}eciev.. -> {R,r}eceiv..

### DIFF
--- a/plugins/perl/perl.c
+++ b/plugins/perl/perl.c
@@ -458,7 +458,7 @@ server_cb (char *word[], char *word_eol[], void *userdata)
 		return HEXCHAT_EAT_NONE;
 
 	/*               hexchat_printf (ph, */
-	/*                               "Recieved %d words in server callback", av_len (wd)); */
+	/*                               "Received %d words in server callback", av_len (wd)); */
 	PUSHMARK (SP);
 	XPUSHs (newRV_noinc ((SV *) array2av (word)));
 	XPUSHs (newRV_noinc ((SV *) array2av (word_eol)));
@@ -506,7 +506,7 @@ command_cb (char *word[], char *word_eol[], void *userdata)
 	if (data->depth)
 		return HEXCHAT_EAT_NONE;
 
-	/*               hexchat_printf (ph, "Recieved %d words in command callback", */
+	/*               hexchat_printf (ph, "Received %d words in command callback", */
 	/*                               av_len (wd)); */
 	PUSHMARK (SP);
 	XPUSHs (newRV_noinc ((SV *) array2av (word)));
@@ -584,7 +584,7 @@ print_cb (char *word[], void *userdata)
 		}
 	}
 
-	/*hexchat_printf (ph, "Recieved %d words in print callback", av_len (wd)+1); */
+	/*hexchat_printf (ph, "Received %d words in print callback", av_len (wd)+1); */
 	PUSHMARK (SP);
 	XPUSHs (newRV_noinc ((SV *) wd));
 	XPUSHs (data->userdata);

--- a/plugins/sysinfo/xsys.c
+++ b/plugins/sysinfo/xsys.c
@@ -598,7 +598,7 @@ netdata_cb (char *word[], char *word_eol[], void *userdata)
 	bytes_recv /= 1024;
 	bytes_sent /= 1024;
 	
-	snprintf (netdata, bsize, "%s: %.1f MB Recieved, %.1f MB Sent", word[2], (double)bytes_recv/1024.0, (double)bytes_sent/1024.0);
+	snprintf (netdata, bsize, "%s: %.1f MB Received, %.1f MB Sent", word[2], (double)bytes_recv/1024.0, (double)bytes_sent/1024.0);
 	hexchat_pluginpref_get_str (ph, "format", format);
 	format_output ("Netdata", netdata, format);
 

--- a/src/common/dcc.c
+++ b/src/common/dcc.c
@@ -394,7 +394,7 @@ dcc_close (struct DCC *dcc, int dccstat, int destroy)
 
 		if(dccstat == STAT_DONE)
 		{
-			/* if we just completed a dcc recieve, move the */
+			/* if we just completed a dcc receive, move the */
 			/* completed file to the completed directory */
 			if(dcc->type == TYPE_RECV)
 			{			

--- a/src/common/dcc.h
+++ b/src/common/dcc.h
@@ -87,7 +87,7 @@ struct DCC
 	unsigned char dccstat;	  /* 0 = QUEUED  1 = ACTIVE  2 = FAILED  3 = DONE */
 	unsigned int resume_sent:1;	/* resume request sent */
 	unsigned int fastsend:1;
-	unsigned int ackoffset:1;	/* is reciever sending acks as an offset from */
+	unsigned int ackoffset:1;	/* is receiver sending acks as an offset from */
 										/* the resume point? */
 	unsigned int throttled:2;	/* 0x1 = per send/get throttle
 											0x2 = global throttle */


### PR DESCRIPTION
nothing substantial, but lintian is moaning ...
