### PR TITLE
Fixed URL fe-gtk parsing issue

### DIFF
--- a/src/common/url.c
+++ b/src/common/url.c
@@ -208,11 +208,11 @@ url_check_word (const char *word)
 	} m[] = {
 	   { match_url,     WORD_URL },
 	   { match_email,   WORD_EMAIL },
-	   { match_nick,    WORD_NICK },
 	   { match_channel, WORD_CHANNEL },
 	   { match_host6,   WORD_HOST6 },
 	   { match_host,    WORD_HOST },
 	   { match_path,    WORD_PATH },
+	   { match_nick,    WORD_NICK },
 	   { NULL,          0}
 	};
 	int i;

--- a/src/common/url.h
+++ b/src/common/url.h
@@ -23,11 +23,11 @@
 extern void *url_tree;
 
 #define WORD_URL     1
-#define WORD_NICK    2
-#define WORD_CHANNEL 3
-#define WORD_HOST    4
-#define WORD_HOST6   5
-#define WORD_EMAIL   6
+#define WORD_CHANNEL 2
+#define WORD_HOST    3
+#define WORD_HOST6   4
+#define WORD_EMAIL   5
+#define WORD_NICK    6
 /* anything >0 will be displayed as a link by gtk_xtext_motion_notify() */
 #define WORD_DIALOG  -1
 #define WORD_PATH    -2


### PR DESCRIPTION
The url_check_word's struct for matching click-able text items was badly ordered such that URLs (and possibly emails) containing a nick would erroneously only parse the preceding nick (i.e. nickname.org wherein only nickname is click-able) instead of nickname.org itself being a URL.
