### PR TITLE
Fixes #409.  Improve select accelerator.  Fix bottom, top lags.

### DIFF
--- a/src/fe-gtk/xtext.c
+++ b/src/fe-gtk/xtext.c
@@ -1309,15 +1309,28 @@ gtk_xtext_selection_draw (GtkXText * xtext, GdkEventMotion * event, gboolean ren
 		gtk_xtext_selection_render (xtext, ent_start, offset_start, ent_end, offset_end);
 }
 
+/*
+ * Return 200, 100, 50, 25, 12.5 milliseconds
+ * depending on how far the pointer is
+ * past the text window's top / bottom margin
+ */
 static int
 gtk_xtext_timeout_ms (GtkXText *xtext, int pixes)
 {
 	int apixes = abs(pixes);
+	static int base =  200;
+	int ms;
 
-	if (apixes < 6) return 100;
-	if (apixes < 12) return 50;
-	if (apixes < 20) return 20;
-	return 10;
+	ms = base;
+	switch (apixes / xtext->fontsize)
+	{
+		default:	ms >>= 1;
+		case 3:	ms >>= 1;
+		case 2:	ms >>= 1;
+		case 1:	ms >>= 1;
+		case 0:	break;
+	}
+	return ms;
 }
 
 static gint
@@ -1328,41 +1341,36 @@ gtk_xtext_scrolldown_timeout (GtkXText * xtext)
 	GtkAdjustment *adj = xtext->adj;
 	textentry *ent;
 
-	if (buf->last_ent_end == NULL)	/* If context has changed */
+	gdk_window_get_pointer (GTK_WIDGET (xtext)->window, 0, &p_y, 0);
+	gdk_drawable_get_size (GTK_WIDGET (xtext)->window, 0, &win_height);
+
+	if (buf->last_ent_end == NULL ||	/* If context has changed OR */
+		 buf->pagetop_ent == 0 ||		/* pagetop_ent is reset OR */
+		 p_y <= win_height ||			/* pointer not below bottom margin OR */
+		 adj->value >= adj->upper - adj->page_size) 	/* we're scrolled to bottom */
 	{
 		xtext->scroll_tag = 0;
 		return 0;
 	}
 
-	gdk_window_get_pointer (GTK_WIDGET (xtext)->window, 0, &p_y, 0);
-	gdk_drawable_get_size (GTK_WIDGET (xtext)->window, 0, &win_height);
-
-	if (p_y > win_height &&
-		 xtext->adj->value < (xtext->adj->upper - xtext->adj->page_size))
+	ent = buf->pagetop_ent->next;
+	xtext->select_start_y -= xtext->fontsize;
+	xtext->select_start_adj++;
+	adj->value++;
+	gtk_adjustment_value_changed (adj);
+	gtk_xtext_selection_draw (xtext, NULL, TRUE);
+	if (ent)
 	{
-		xtext->adj->value += buf->pagetop_ent->lines_taken;
-		ent = buf->last_ent_end->next;
-		if (ent)
-		{
-			gtk_adjustment_value_changed (xtext->adj);
-		}
-		else
-		{
-			buf->scrollbar_down = TRUE;
-		}
-		xtext->scroll_tag = g_timeout_add (gtk_xtext_timeout_ms (xtext, p_y - win_height),
-														(GSourceFunc)
-														gtk_xtext_scrolldown_timeout,
-														xtext);
-		xtext->select_start_y -= (adj->value - xtext->select_start_adj) * xtext->fontsize;
-		xtext->select_start_adj = adj->value;
-		gtk_xtext_selection_draw (xtext, NULL, TRUE);
 		gtk_xtext_render_ents (xtext, ent, buf->last_ent_end);
 	}
-	else
+	if (adj->upper - adj->value < adj->page_size)
 	{
-		xtext->scroll_tag = 0;
+		buf->scrollbar_down = TRUE;
 	}
+	xtext->scroll_tag = g_timeout_add (gtk_xtext_timeout_ms (xtext, p_y - win_height),
+													(GSourceFunc)
+													gtk_xtext_scrolldown_timeout,
+													xtext);
 
 	return 0;
 }
@@ -1375,36 +1383,27 @@ gtk_xtext_scrollup_timeout (GtkXText * xtext)
 	GtkAdjustment *adj = xtext->adj;
 	textentry *ent;
 
-	if (buf->last_ent_start == NULL)	/* If context has changed */
+	gdk_window_get_pointer (GTK_WIDGET (xtext)->window, 0, &p_y, 0);
+
+	if (buf->last_ent_start == NULL ||	/* If context has changed OR */
+		 p_y >= 0 ||							/* not above top margin OR */
+		 adj->value == 0)						/* we're scrolled to the top */
 	{
 		xtext->scroll_tag = 0;
 		return 0;
 	}
 
-	gdk_window_get_pointer (GTK_WIDGET (xtext)->window, 0, &p_y, 0);
-
-	if (p_y < 0 && adj->value >= 0)
-	{
-		buf->scrollbar_down = FALSE;
-		ent = buf->last_ent_start->prev;
-		if (ent)
-		{
-			adj->value -= ent->lines_taken;
-			gtk_adjustment_value_changed (adj);
-		}
-		xtext->select_start_y -= (adj->value - xtext->select_start_adj) * xtext->fontsize;
-		xtext->select_start_adj = adj->value;
-		gtk_xtext_selection_draw (xtext, NULL, TRUE);
-		gtk_xtext_render_ents (xtext, ent, buf->last_ent_end);
-		xtext->scroll_tag = g_timeout_add (gtk_xtext_timeout_ms (xtext, p_y),
-														(GSourceFunc)
-														gtk_xtext_scrollup_timeout,
-														xtext);
-	}
-	else
-	{
-		xtext->scroll_tag = 0;
-	}
+	ent = buf->pagetop_ent->prev;
+	xtext->select_start_y += xtext->fontsize;
+	xtext->select_start_adj--;
+	adj->value--;
+	gtk_adjustment_value_changed (adj);
+	gtk_xtext_selection_draw (xtext, NULL, TRUE);
+	gtk_xtext_render_ents (xtext, ent, buf->last_ent_end);
+	xtext->scroll_tag = g_timeout_add (gtk_xtext_timeout_ms (xtext, p_y),
+													(GSourceFunc)
+													gtk_xtext_scrollup_timeout,
+													xtext);
 
 	return 0;
 }


### PR DESCRIPTION
This pull request addresses issue 409.  It explicitly fixes the second part of 409, which states "you can't scroll to the most recent line" when selecting causes a scrolldown.  The same problem occurs when selecting causes a scrollup.  Both problems are fixed by this pull request.

The first part of issue 409 is not reproducible, and until it becomes so, I will not address it.  If you can reproduce it with this fix (or even without), please open a new issue and supply files with it:  (1) hexchat.conf and (2) at least one file from scrollback/<network>/<channel>.txt and I will try myself to reproduce the problem on that network with that channel and scrollback.  I don't run windows so please try reproducing on a linux distro, preferably Fedora.
