### PR TITLE
Fix autogen.sh shebang line

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 have_automake=false
 
 if automake --version < /dev/null > /dev/null 2>&1 ; then


### PR DESCRIPTION
/bin/bash does not exist on many systems.  In addition this script appears to be POSIX compatible so just use the appropriate shebang line.
