### PR TITLE
Print{,_attr} and server{,_attr} hooks priority fix

### DIFF
--- a/src/common/dcc.c
+++ b/src/common/dcc.c
@@ -557,8 +557,7 @@ dcc_chat_line (struct DCC *dcc, char *line)
 	for (i = 5; i < PDIWORDS; i++)
 		word[i] = "\000";
 
-	ret = plugin_emit_print (sess, word) 
-		+ plugin_emit_print_attrs (sess, word, 0);
+	ret = plugin_emit_print (sess, word, 0);
 
 	/* did the plugin close it? */
 	if (!g_slist_find (dcc_list, dcc))

--- a/src/common/plugin.h
+++ b/src/common/plugin.h
@@ -170,11 +170,9 @@ int plugin_kill (char *name, int by_filename);
 void plugin_kill_all (void);
 void plugin_auto_load (session *sess);
 int plugin_emit_command (session *sess, char *name, char *word[], char *word_eol[]);
-int plugin_emit_server (session *sess, char *name, char *word[], char *word_eol[]);
-int plugin_emit_server_attrs (session *sess, char *name, char *word[],
-							  char *word_eol[], time_t server_time);
-int plugin_emit_print (session *sess, char *word[]);
-int plugin_emit_print_attrs (session *sess, char *word[], time_t server_time);
+int plugin_emit_server (session *sess, char *name, char *word[], char *word_eol[],
+						time_t server_time);
+int plugin_emit_print (session *sess, char *word[], time_t server_time);
 int plugin_emit_dummy_print (session *sess, char *name);
 int plugin_emit_keypress (session *sess, unsigned int state, unsigned int keyval, int len, char *string);
 GList* plugin_command_list(GList *tmp_list);

--- a/src/common/proto-irc.c
+++ b/src/common/proto-irc.c
@@ -1503,9 +1503,6 @@ irc_inline (server *serv, char *buf, int len)
 
 	if (buf[0] == ':')
 	{
-		int eat1;
-		int eat2;
-
 		/* find a context for this message */
 		if (is_channel (serv, word[3]))
 		{
@@ -1520,11 +1517,8 @@ irc_inline (server *serv, char *buf, int len)
 		word[0] = type;
 		word_eol[1] = buf;	/* keep the ":" for plugins */
 
-		eat1 = plugin_emit_server (sess, type, word, word_eol);
-		eat2 = plugin_emit_server_attrs (sess, type, word, word_eol, 
-										 tags_data.timestamp);
-
-		if (eat1 || eat2)
+		if (plugin_emit_server (sess, type, word, word_eol,
+								tags_data.timestamp))
 			goto xit;
 
 		word[1]++;
@@ -1532,16 +1526,10 @@ irc_inline (server *serv, char *buf, int len)
 
 	} else
 	{
-		int eat1;
-		int eat2;
-
 		word[0] = type = word[1];
 
-		eat1 = plugin_emit_server (sess, type, word, word_eol);
-		eat2 = plugin_emit_server_attrs (sess, type, word, word_eol,
-										 tags_data.timestamp);
-
-		if (eat1 || eat2)
+		if (plugin_emit_server (sess, type, word, word_eol,
+								tags_data.timestamp))
 			goto xit;
 	}
 

--- a/src/common/text.c
+++ b/src/common/text.c
@@ -2074,8 +2074,6 @@ text_emit (int index, session *sess, char *a, char *b, char *c, char *d,
 	int i;
 	unsigned int stripcolor_args = (chanopt_is_set (prefs.hex_text_stripcolor_msg, sess->text_strip) ? 0xFFFFFFFF : 0);
 	char tbuf[NICKLEN + 4];
-	int eat1;
-	int eat2;
 
 	if (prefs.hex_text_color_nicks && (index == XP_TE_CHANACTION || index == XP_TE_CHANMSG))
 	{
@@ -2092,10 +2090,7 @@ text_emit (int index, session *sess, char *a, char *b, char *c, char *d,
 	for (i = 5; i < PDIWORDS; i++)
 		word[i] = "\000";
 
-	eat1 = plugin_emit_print (sess, word);
-	eat2 = plugin_emit_print_attrs (sess, word, timestamp);
-
-	if (eat1 || eat2)
+	if (plugin_emit_print (sess, word, timestamp))
 		return;
 
 	/* If a plugin's callback executes "/close", 'sess' may be invalid */


### PR DESCRIPTION
Print{,_attr} and server{,_attr} hooks were incorrectly handled when both
version existed (regular and attrs).  Specifically, the priority was not
respected, and both versions were run even when EAT_PLUGIN was returned.

Fixes #847.
