### PR TITLE
Fixes #881  Fix two bugs --

### DIFF
--- a/src/fe-gtk/xtext.c
+++ b/src/fe-gtk/xtext.c
@@ -1321,6 +1321,11 @@ gtk_xtext_selection_draw (GtkXText * xtext, GdkEventMotion * event, gboolean ren
 			ent = ent->next;
 		}
 	}
+	else
+	{
+		if (xtext->mark_stamp)
+			offset_start = 0;
+	}
 
 	if (render)
 		gtk_xtext_selection_render (xtext, ent_start, offset_start, ent_end, offset_end);


### PR DESCRIPTION
```
gtk_xtext_find_char() adjust negative y for int typecast
gtk_xtext_find_x() return out_of_bounds TRUE if line outside windodw
gtk_xtext_selection_draw() recognize TRUE out_of_bounds
```
