### PR TITLE
Add two networks, add IPv6 entries for synIRC

### DIFF
--- a/src/common/servlist.c
+++ b/src/common/servlist.c
@@ -101,14 +101,12 @@ static const struct defaultserver def[] =
 	{0,			"lion.anthrochat.net/+6697"},
 	{0,			"otter.anthrochat.net/+6697"},
 	{0,			"snowleopard.anthrochat.net/+6697"},
-	//{0,			"panda.anthrochat.net/+6697"},		/* Server wasn't up last time I tried, still listed at the website though */
 #endif
 	{0,			"bear.anthrochat.net"},
 	{0,			"cheetah.anthrochat.net"},
 	{0,			"husky.anthrochat.net"},
 	{0,			"lion.anthrochat.net"},
 	{0,			"otter.anthrochat.net"},
-	//{0,			"panda.anthrochat.net"},			/* Server wasn't up last time I tried, still listed at the website though */
 	{0,			"snowleopard.anthrochat.net"},
 
 	{"ARCNet",	0},


### PR DESCRIPTION
Apologies for not making these changes seperate pull requests, this is my first pull request and I'm still figuring things out about Git ;)

I added two networks: Anthrochat ( http://anthrochat.net/status/ ) and Furnet ( http://furnet.org/ ).
These are two medium-sized IRC networks tailored at the on-line "furry" community.

I also added addresses of IPv6-compatible "Full Link"-servers to the synIRC entry.
