### PR TITLE
Fixed: Add Anthrochat, Furnet to network list

### DIFF
--- a/src/common/servlist.c
+++ b/src/common/servlist.c
@@ -245,12 +245,6 @@ static const struct defaultserver def[] =
 	{0,				"irc.freenode.net"},
 
 	{"Furnet",	0},
-#ifdef USE_IPV6
-#ifdef USE_OPENSSL
-	{0,			"ipv6.furnet.org/+6697"},
-#endif
-	{0,			"ipv6.furnet.org"},
-#endif
 #ifdef USE_OPENSSL
 	{0,			"irc.furnet.org/+6697"},
 #endif


### PR DESCRIPTION
Let's try this again, properly this time:
Reversed the superfluous synIRC changes from my previous pull request and merged upstream commit so this should finally merge easily. Apologies for the earlier inconvenience and not being able to get back to this earlier.

From my previous pull request:
I added two networks: Anthrochat ( http://anthrochat.net/status/ ) and Furnet ( http://furnet.org/ ).
These are two medium-sized IRC networks tailored at the on-line "furry" community.
