### PR TITLE
Added detection for Windows 8.1.

### DIFF
--- a/src/common/util.c
+++ b/src/common/util.c
@@ -749,6 +749,7 @@ get_sys_str (int with_cpu)
 					if (osvi.wProductType == VER_NT_WORKSTATION)
 					{
 						strcpy (winver, "8");
+						strcpy (winver, "8.1");
 					}
 					else
 					{


### PR DESCRIPTION
I have implemented detection for the Windows 8.1 operating system so that instead of showing Windows 8 in the about box when in fact you are running Windows 8.1, it will actually display if you are running Windows 8.1 or not.

I know it's a small change, but it's an important one.
