### PR TITLE
Add global option to suppress nick change events

### DIFF
--- a/src/common/cfgfiles.c
+++ b/src/common/cfgfiles.c
@@ -509,6 +509,7 @@ const struct prefs vars[] =
 	{"irc_cap_server_time", P_OFFINT (hex_irc_cap_server_time), TYPE_BOOL},
 	{"irc_conf_mode", P_OFFINT (hex_irc_conf_mode), TYPE_BOOL},
 	{"irc_extra_hilight", P_OFFSET (hex_irc_extra_hilight), TYPE_STR},
+	{"irc_hide_nickchange", P_OFFINT (hex_irc_hide_nickchange), TYPE_BOOL},
 	{"irc_hide_version", P_OFFINT (hex_irc_hide_version), TYPE_BOOL},
 	{"irc_hidehost", P_OFFINT (hex_irc_hidehost), TYPE_BOOL},
 	{"irc_id_ntext", P_OFFSET (hex_irc_id_ntext), TYPE_STR},

--- a/src/common/hexchat.h
+++ b/src/common/hexchat.h
@@ -217,6 +217,7 @@ struct hexchatprefs
 	unsigned int hex_irc_auto_rejoin;
 	unsigned int hex_irc_conf_mode;
 	unsigned int hex_irc_hidehost;
+	unsigned int hex_irc_hide_nickchange;
 	unsigned int hex_irc_hide_version;
 	unsigned int hex_irc_invisible;
 	unsigned int hex_irc_logging;

--- a/src/common/text.c
+++ b/src/common/text.c
@@ -2172,6 +2172,12 @@ text_emit (int index, session *sess, char *a, char *b, char *c, char *d,
 		if (sess->alert_tray == SET_ON)
 			fe_tray_set_icon (FE_ICON_MESSAGE);
 		break;
+
+	/* ===Nick change message=== */
+	case XP_TE_CHANGENICK:
+		if (prefs.hex_irc_hide_nickchange)
+			return;
+		break;
 	}
 
 	sound_play_event (index);

--- a/src/fe-gtk/setup.c
+++ b/src/fe-gtk/setup.c
@@ -476,6 +476,7 @@ static const setting general_settings[] =
 	{ST_TOGGLE,	N_("Display MODEs in raw form"), P_OFFINTNL(hex_irc_raw_modes), 0, 0, 0},
 	{ST_TOGGLE,	N_("WHOIS on notify"), P_OFFINTNL(hex_notify_whois_online), N_("Sends a /WHOIS when a user comes online in your notify list."), 0, 0},
 	{ST_TOGGLE,	N_("Hide join and part messages"), P_OFFINTNL(hex_irc_conf_mode), N_("Hide channel join/part messages by default."), 0, 0},
+	{ST_TOGGLE,	N_("Hide nick change messages"), P_OFFINTNL(hex_irc_hide_nickchange), 0, 0, 0},
 
 	{ST_END, 0, 0, 0, 0, 0}
 };


### PR DESCRIPTION
Might as well add a per-channel option, too but for me that seems a bit unnecessary.
