### PR TITLE
Ignore Untrusted Cert error when reconnecting

### DIFF
--- a/src/common/server.c
+++ b/src/common/server.c
@@ -732,6 +732,7 @@ ssl_do_connect (server * serv)
 		case X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT:
 		case X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN:
 		case X509_V_ERR_CERT_HAS_EXPIRED:
+                case X509_V_ERR_CERT_UNTRUSTED:
 			if (serv->accept_invalid_cert)
 			{
 				snprintf (buf, sizeof (buf), "* Verify E: %s.? (%d) -- Ignored",


### PR DESCRIPTION
on osx mavericks, i am getting the following error when hexchat tries to reconnect when network goes down.

Connection failed. Error: certificate not trusted.? (27)

With this change, we just ignore that error and will see the following message instead

 Verify E: certificate not trusted.? (27) -- Ignored
