### PR TITLE
Single click open URLs in urlgrabber

### DIFF
--- a/src/fe-gtk/urlgrab.c
+++ b/src/fe-gtk/urlgrab.c
@@ -69,7 +69,7 @@ url_treeview_url_clicked_cb (GtkWidget *view, GdkEventButton *event,
 	switch (event->button)
 	{
 		case 1:
-			if (event->type == GDK_2BUTTON_PRESS)
+			if (event->type == GDK_BUTTON_PRESS || event->type == GDK_2BUTTON_PRESS)
 				fe_open_url (url);
 			break;
 		case 3:


### PR DESCRIPTION
One of the most annoying things about switching to hexchat is that you can't single click links to open them. Whenever I try to open a url, I always fumble around trying some combination of clicks until the thing finally works.

This makes urls also open with a single click, which makes everything much more bearable for me. It may be useful for other people.

I don't know if this is a sort of patch that you accept, or if there's a more standard way to do this sort of patch.
