### PR TITLE
fixes issue leeter/hexchat#3 chanopts not saved if user uses /quit before exiting

### DIFF
--- a/src/common/chanopt.c
+++ b/src/common/chanopt.c
@@ -119,7 +119,7 @@ chanopt_command (session *sess, char *tbuf, char *word[], char *word_eol[])
 	if (!quiet)
 		PrintTextf (sess, "\002Network\002: %s \002Channel\002: %s\n",
 						sess->server->network ? server_get_network (sess->server, TRUE) : _("<none>"),
-						sess->channel[0] ? sess->channel : _("<none>"));
+						sess->session_name[0] ? sess->session_name : _("<none>"));
 
 	while (i < sizeof (chanopt) / sizeof (channel_options))
 	{
@@ -298,7 +298,7 @@ chanopt_load (session *sess)
 	chanopt_in_memory *co;
 	char *network;
 
-	if (sess->channel[0] == 0)
+	if (sess->session_name[0] == 0)
 		return;
 
 	network = server_get_network (sess->server, FALSE);
@@ -311,7 +311,7 @@ chanopt_load (session *sess)
 		chanopt_load_all ();
 	}
 
-	co = chanopt_find (network, sess->channel, FALSE);
+	co = chanopt_find (network, sess->session_name, FALSE);
 	if (!co)
 		return;
 
@@ -334,7 +334,7 @@ chanopt_save (session *sess)
 	chanopt_in_memory *co;
 	char *network;
 
-	if (sess->channel[0] == 0)
+	if (sess->session_name[0] == 0)
 		return;
 
 	network = server_get_network (sess->server, FALSE);
@@ -343,7 +343,7 @@ chanopt_save (session *sess)
 
 	/* 2. reconcile sess with what we loaded from disk */
 
-	co = chanopt_find (network, sess->channel, TRUE);
+	co = chanopt_find (network, sess->session_name, TRUE);
 
 	i = 0;
 	while (i < sizeof (chanopt) / sizeof (channel_options))

--- a/src/common/hexchat.c
+++ b/src/common/hexchat.c
@@ -488,7 +488,10 @@ session_new (server *serv, char *from, int type, int focus)
 	sess->lastact_idx = LACT_NONE;
 
 	if (from != NULL)
-		safe_strcpy (sess->channel, from, CHANLEN);
+	{
+		safe_strcpy(sess->channel, from, CHANLEN);
+		safe_strcpy(sess->session_name, from, CHANLEN);
+	}
 
 	sess_list = g_slist_prepend (sess_list, sess);
 

--- a/src/common/hexchat.h
+++ b/src/common/hexchat.h
@@ -388,6 +388,7 @@ typedef struct session
 	char channel[CHANLEN];
 	char waitchannel[CHANLEN];		  /* waiting to join channel (/join sent) */
 	char willjoinchannel[CHANLEN];	  /* will issue /join for this channel */
+	char session_name[CHANLEN];		 /* the name of the session, should not modified */
 	char channelkey[64];			  /* XXX correct max length? */
 	int limit;						  /* channel user limit */
 	int logfd;


### PR DESCRIPTION
fixes issue leeter/hexchat#3 chanopts not saved if user uses `/quit` before exiting. This is the C fix, unfortunately a proper fix, e.g. removing the dependency on `session_name` all together is a much vaster refactor outside the scope of this bugfix. More importantly the dependency on `session::channel` which is cleared by the `/quit` command to indicate that the session is no longer active.
