### PR TITLE
Add hackint to the network list.

### DIFF
--- a/src/common/servlist.c
+++ b/src/common/servlist.c
@@ -262,6 +262,11 @@ static const struct defaultserver def[] =
 	{0,			"irc.gimp.org"},
 	{0,			"irc.gnome.org"},
 
+#ifdef USE_OPENSSL
+	{"hackint", 0, 0, 0, LOGIN_SASL},
+	{0,			"irc.hackint.org/+9999"},
+#endif
+
 	{"Hashmark",	0},
 	{0,			"irc.hashmark.net"},
 


### PR DESCRIPTION
Hi, I'd like to add the hackint irc network to the default list of available networks of hexchat if possible.

Hackint is around since ~2008 under that name. We are ircv3.1 compatible. Since non-ssl usage is discouraged, I've enclosed the whole hackint definition inside the ifdef{} block, hope that's okay.

Hackint website: http://www.hackint.org
