### PR TITLE
.travis.yml: add clang & CPUs & fast_finish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: c
-compiler: gcc
+compiler: 
+    - gcc
+    - clang
 before_script:
     - sudo apt-get update
     - sudo apt-get build-dep -qq xchat
@@ -7,9 +9,11 @@ before_script:
 script: 
     - ./autogen.sh
     - ./configure --enable-textfe --with-theme-manager
-    - make V=1
+    - make V=1 -j$(nproc)
 notifications:
     irc:
         channels: "chat.freenode.net#hexchat-devel"
         template: "Build #%{build_number} (%{commit}) by %{author}: %{message}"
         on_success: change
+matrix:
+     fast_finish: true


### PR DESCRIPTION
HexChat seems to compile fine with clang so why to not test it too.
-j$(nproc) seems to work with HexChat and fast-finish marks build as
failed if one job fails.

Fast finish won't stop jobs that aren't finished at the time of failure.
