### PR TITLE
Set buf->scrollbar_down conditionally when vertically resizing text wind...

### DIFF
--- a/src/fe-gtk/xtext.c
+++ b/src/fe-gtk/xtext.c
@@ -484,7 +484,10 @@ gtk_xtext_adjustment_set (xtext_buffer *buf, int fire_signal)
 		adj->page_increment = adj->page_size;
 
 		if (adj->value > adj->upper - adj->page_size)
+		{
+			buf->scrollbar_down = TRUE;
 			adj->value = adj->upper - adj->page_size;
+		}
 
 		if (adj->value < 0)
 			adj->value = 0;


### PR DESCRIPTION
...ow

If resize to enlarge appears to go to last line, set buf->scrollbar_down to be sure.

Fixes #1151.
