### PR TITLE
Fix autojoin translation

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -3954,7 +3954,7 @@ msgstr "Cycler canal"
 
 #: ../src/fe-gtk/menu.c:1077
 msgid "_Autojoin"
-msgstr "Rejoindre automatiquement si expulsé"
+msgstr "Rejoindre automatiquement"
 
 #: ../src/fe-gtk/menu.c:1079
 msgid "Autojoin Channel"


### PR DESCRIPTION
It was translated by "autojoin if kicked" but this checkbox also
allow autojoin at connection.
