### PR TITLE
Add Volatile to default networks list

### DIFF
--- a/src/common/servlist.c
+++ b/src/common/servlist.c
@@ -501,9 +501,15 @@ static const struct defaultserver def[] =
 	{0,			"irc.lirex.com"},
 	{0,			"irc.naturella.com"},
 	{0,			"irc.techno-link.com"},
-	
+
 	{"ValleyNode", 0, 0, 0, LOGIN_SASL},
 	{0,			"irc.valleynode.net"},
+
+	{"Volatile", 0, 0, 0, LOGIN_CUSTOM, "MSG UserServ!bot@volatile.services login %u %p"},
+#ifdef USE_OPENSSL
+	{0,			"irc.volatile.club/+9999"},
+#endif
+	{0,			"irc.volatile.club"},
 
 	{"Worldnet",		0},
 	{0,			"irc.worldnet.net"},


### PR DESCRIPTION
Website at http://volatile.club/ with server list and webchat. Allows Tor and proxies, Unicode nicknames, and #&+ prefixed channels. Will eventually have a Python-powered services bot to replace what we have now.