### PR TITLE
Add missing dependencies for glib's g_spawn on windows

### DIFF
--- a/win32/hexchat.props
+++ b/win32/hexchat.props
@@ -58,6 +58,8 @@ copy "$(DepsRoot)\bin\gio-2.0.dll" "$(HexChatRel)"
 copy "$(DepsRoot)\bin\glib-2.0.dll" "$(HexChatRel)"
 copy "$(DepsRoot)\bin\gmodule-2.0.dll" "$(HexChatRel)"
 copy "$(DepsRoot)\bin\gobject-2.0.dll" "$(HexChatRel)
+copy "$(DepsRoot)\bin\gspawn-win$(PlatformArchitecture)-helper.exe" "$(HexChatRel)"
+copy "$(DepsRoot)\bin\gspawn-win$(PlatformArchitecture)-helper-console.exe" "$(HexChatRel)"
 copy "$(DepsRoot)\bin\gthread-2.0.dll" "$(HexChatRel)"
 copy "$(DepsRoot)\bin\gtk-win32-2.0.dll" "$(HexChatRel)"
 copy "$(DepsRoot)\bin\harfbuzz.dll" "$(HexChatRel)"

--- a/win32/installer/hexchat.iss.tt
+++ b/win32/installer/hexchat.iss.tt
@@ -124,6 +124,13 @@ Source: "gio-2.0.dll"; DestDir: "{app}"; Flags: ignoreversion; Components: libs
 Source: "glib-2.0.dll"; DestDir: "{app}"; Flags: ignoreversion; Components: libs
 Source: "gmodule-2.0.dll"; DestDir: "{app}"; Flags: ignoreversion; Components: libs
 Source: "gobject-2.0.dll"; DestDir: "{app}"; Flags: ignoreversion; Components: libs
+#if APPARCH == "x64"
+Source: "gspawn-win64-helper.exe"; DestDir: "{app}"; Flags: ignoreversion; Components: libs
+Source: "gspawn-win64-helper-console.exe"; DestDir: "{app}"; Flags: ignoreversion; Components: libs
+#else
+Source: "gspawn-win32-helper.exe"; DestDir: "{app}"; Flags: ignoreversion; Components: libs
+Source: "gspawn-win32-helper-console.exe"; DestDir: "{app}"; Flags: ignoreversion; Components: libs
+#endif
 Source: "gthread-2.0.dll"; DestDir: "{app}"; Flags: ignoreversion; Components: libs
 Source: "gtk-win32-2.0.dll"; DestDir: "{app}"; Flags: ignoreversion; Components: libs
 Source: "harfbuzz.dll"; DestDir: "{app}"; Flags: ignoreversion; Components: libs


### PR DESCRIPTION
On windows, glib's g_spawn family of functions require a couple of helper applications. Without them, custom url handlers won't work.
