### PR TITLE
Remove unnecessary port from Snoonet in server list, fixes user bug

### DIFF
--- a/src/common/servlist.c
+++ b/src/common/servlist.c
@@ -407,7 +407,7 @@ static const struct defaultserver def[] =
 #ifdef USE_OPENSSL
 	{0,			"irc.snoonet.org/+6697"},
 #endif
-	{0,			"irc.snoonet.org/6667"},
+	{0,			"irc.snoonet.org"},
 
 	{"Snyde", 0},
 	{0,			"irc.snyde.net/6667"},


### PR DESCRIPTION
To fix reported issue with server list:

```
[20:21:22] <TsuDoughNym> Hi, I keep receiving the following error when trying to connect via HexChat.  It's worked fine for me in the past, and haven't changed any settings.
[20:21:22] <TsuDoughNym> Connection failed. Error: (336031996) error:140770FC:SSL routines:SSL23_GET_SERVER_HELLO:unknown protocol
[20:21:51] <rdv> you're trying to connect using SSL
[20:21:59] <rdv> are you connecting to irc.snoonet.org 6697?
[20:22:04] <rdv> port has to be 6697
[20:22:29] <TsuDoughNym> looks like it was trying 6667
[20:22:42] <TsuDoughNym> one of the two default servers in hexchat when I select 'snoonet" from the network list
[20:25:52] <TsuDoughNym> that worked, thanks for the help
```
