### PR TITLE
Removing "Techman's World IRC" - network no longer exists

### DIFF
--- a/src/common/servlist.c
+++ b/src/common/servlist.c
@@ -465,12 +465,6 @@ static const struct defaultserver def[] =
 #endif
 	{0, "irc.synirc.net/6667"},
 
-	{"Techman's World IRC",	0, 0, 0, LOGIN_SASL},
-#ifdef USE_OPENSSL
-	{0,			"irc.techmansworld.com/+6697"},
-#endif
-	{0,			"irc.techmansworld.com/6667"},
-
 	{"TinyCrab", 0, 0, 0, LOGIN_SASL},
 	{0,			"irc.tinycrab.net"},
 


### PR DESCRIPTION
As above. Network no longer exists as "Techman's World IRC."
