### PR TITLE
send +R instead of +r for "registered only"

### DIFF
--- a/src/common/proto-irc.c
+++ b/src/common/proto-irc.c
@@ -666,7 +666,7 @@ process_numeric (session * sess, int n,
 			EMIT_SIGNAL_TIMESTAMP (XP_TE_CHANMODES, sess, word[4], word_eol[5],
 										  NULL, NULL, 0, tags_data->timestamp);
 		fe_update_mode_buttons (sess, 'c', '-');
-		fe_update_mode_buttons (sess, 'r', '-');
+		fe_update_mode_buttons (sess, 'R', '-');
 		fe_update_mode_buttons (sess, 't', '-');
 		fe_update_mode_buttons (sess, 'n', '-');
 		fe_update_mode_buttons (sess, 'i', '-');

--- a/src/fe-gtk/maingui.c
+++ b/src/fe-gtk/maingui.c
@@ -78,7 +78,7 @@ static void mg_link_irctab (session *sess, int focus);
 static session_gui static_mg_gui;
 static session_gui *mg_gui = NULL;	/* the shared irc tab */
 static int ignore_chanmode = FALSE;
-static const char chan_flags[] = { 'c', 'n', 'r', 't', 'i', 'm', 'l', 'k' };
+static const char chan_flags[] = { 'c', 'n', 'R', 't', 'i', 'm', 'l', 'k' };
 
 static chan *active_tab = NULL;	/* active tab */
 GtkWidget *parent_window = NULL;			/* the master window */
@@ -1979,7 +1979,7 @@ mg_flagbutton_cb (GtkWidget *but, char *flag)
 		return;
 
 	sess = current_sess;
-	mode = tolower ((unsigned char) flag[0]);
+	mode = flag[0];
 
 	switch (mode)
 	{
@@ -2068,7 +2068,7 @@ mg_create_chanmodebuttons (session_gui *gui, GtkWidget *box)
 {
 	gui->flag_c = mg_create_flagbutton (_("Filter Colors"), box, "c");
 	gui->flag_n = mg_create_flagbutton (_("No outside messages"), box, "n");
-	gui->flag_r = mg_create_flagbutton (_("Registered Only"), box, "r");
+	gui->flag_r = mg_create_flagbutton (_("Registered Only"), box, "R");
 	gui->flag_t = mg_create_flagbutton (_("Topic Protection"), box, "t");
 	gui->flag_i = mg_create_flagbutton (_("Invite Only"), box, "i");
 	gui->flag_m = mg_create_flagbutton (_("Moderated"), box, "m");


### PR DESCRIPTION
HexChat currently sends lowercase +r ("channel is registered", which users can't change) instead of +R (the de facto "allow registered users only" mode) when pressing the "Registered Only" button on the topic bar. It seems like this might have been an oversight made when changing the buttons from uppercase to lowercase *(Arnavion edit: https://github.com/hexchat/hexchat/commit/7ba2f1f)*, but this is what the intended behavior was, as far as I can tell...