### PR TITLE
chug event loop after printing text

### DIFF
--- a/src/fe-gtk/fe-gtk.c
+++ b/src/fe-gtk/fe-gtk.c
@@ -637,6 +637,8 @@ fe_print_text (struct session *sess, char *text, time_t stamp,
 			   gboolean no_activity)
 {
 	PrintTextRaw (sess->res->buffer, (unsigned char *)text, prefs.hex_text_indent, stamp);
+	while (gtk_events_pending ())
+	      gtk_main_iteration ();
 
 	if (!no_activity && !sess->new_data && sess != current_tab &&
 		sess->gui->is_tab && !sess->nick_said)


### PR DESCRIPTION
Some irc proxies send a large amount of scrollback when first
connecting. During this time hexchat freezes up because the
I/O blocks the main loop from running.

As a workaround, this commit makes sure to explicitly chug
the main loop after each line is added.

This keeps things interactive when first connecting to znc.