### PR TITLE
Allow option to hide voice change messages

### DIFF
--- a/src/common/cfgfiles.c
+++ b/src/common/cfgfiles.c
@@ -502,6 +502,7 @@ const struct prefs vars[] =
 	{"irc_conf_mode", P_OFFINT (hex_irc_conf_mode), TYPE_BOOL},
 	{"irc_extra_hilight", P_OFFSET (hex_irc_extra_hilight), TYPE_STR},
 	{"irc_hide_nickchange", P_OFFINT (hex_irc_hide_nickchange), TYPE_BOOL},
+	{"irc_hide_voicechange", P_OFFINT (hex_irc_hide_voicechange), TYPE_BOOL},
 	{"irc_hide_version", P_OFFINT (hex_irc_hide_version), TYPE_BOOL},
 	{"irc_hidehost", P_OFFINT (hex_irc_hidehost), TYPE_BOOL},
 	{"irc_id_ntext", P_OFFSET (hex_irc_id_ntext), TYPE_STR},

--- a/src/common/hexchat.h
+++ b/src/common/hexchat.h
@@ -174,6 +174,7 @@ struct hexchatprefs
 	unsigned int hex_irc_conf_mode;
 	unsigned int hex_irc_hidehost;
 	unsigned int hex_irc_hide_nickchange;
+	unsigned int hex_irc_hide_voicechange;
 	unsigned int hex_irc_hide_version;
 	unsigned int hex_irc_invisible;
 	unsigned int hex_irc_logging;

--- a/src/common/text.c
+++ b/src/common/text.c
@@ -2056,6 +2056,13 @@ text_emit (int index, session *sess, char *a, char *b, char *c, char *d,
 		if (prefs.hex_irc_hide_nickchange)
 			return;
 		break;
+
+	/* ===Voice change messages=== */
+	case XP_TE_CHANVOICE:
+	case XP_TE_CHANDEVOICE:
+		if (prefs.hex_irc_hide_voicechange)
+			return;
+		break;
 	}
 
 	sound_play_event (index);

--- a/src/fe-gtk/setup.c
+++ b/src/fe-gtk/setup.c
@@ -538,6 +538,7 @@ static const setting general_settings[] =
 	{ST_TOGGLE,	N_("WHOIS on notify"), P_OFFINTNL(hex_notify_whois_online), N_("Sends a /WHOIS when a user comes online in your notify list."), 0, 0},
 	{ST_TOGGLE,	N_("Hide join and part messages"), P_OFFINTNL(hex_irc_conf_mode), N_("Hide channel join/part messages by default."), 0, 0},
 	{ST_TOGGLE,	N_("Hide nick change messages"), P_OFFINTNL(hex_irc_hide_nickchange), 0, 0, 0},
+	{ST_TOGGLE,	N_("Hide voice change messages"), P_OFFINTNL(hex_irc_hide_voicechange), 0, 0, 0},
 
 	{ST_END, 0, 0, 0, 0, 0}
 };


### PR DESCRIPTION
This patch adds an option to hide the "X gives voice to Y" and "X removes voices from Y" messages.

Screenshot of the addedoption:
![screenshot of the added option](https://cloud.githubusercontent.com/assets/466941/6649767/c6e390aa-c9c9-11e4-96c6-30990e947f1f.png)

