### PR TITLE
Fix lag time

### DIFF
--- a/src/common/hexchat.c
+++ b/src/common/hexchat.c
@@ -371,10 +371,7 @@ hexchat_misc_checks (void)		/* this gets called every 1/2 second */
 		dcc_check_timeouts ();	/* every 1 second */
 
 	if (count % 2)				/* every 1 second*/
-	{
-		if (prefs.hex_gui_lagometer)
-			lag_check ();
-	}
+		lag_check ();
 	
 	if (count > 3600)
 	{

--- a/src/common/hexchat.h
+++ b/src/common/hexchat.h
@@ -530,6 +530,7 @@ typedef struct server
 	/*time_t connect_time;*/				/* when did it connect? */
 	unsigned long lag_sent;   /* we are still waiting for this ping response*/
 	time_t ping_recv;					/* when we last got a ping reply */
+	time_t socket_recv;					/* when we last received something from the socket */
 	time_t away_time;					/* when we were marked away */
 
 	char *encoding;

--- a/src/common/server.c
+++ b/src/common/server.c
@@ -313,6 +313,8 @@ server_read (GIOChannel *source, GIOCondition condition, server *serv)
 			}
 			return TRUE;
 		}
+		
+		serv->socket_recv = time (NULL);
 
 		i = 0;
 


### PR DESCRIPTION
prefs.hex_net_ping_timeout is currently more or less entirely useless.

Timeout should be based on when the last successful recv() occurred, not based on ping round trip times.