### PR TITLE
Add MadIRC to default networks list

### DIFF
--- a/src/common/servlist.c
+++ b/src/common/servlist.c
@@ -286,6 +286,12 @@ static const struct defaultserver def[] =
 	{"Serenity-IRC",	0},
 	{0,			"irc.serenity-irc.net"},
 
+	{"Shivering-Isles", 0, 0, 0, LOGIN_SASL, 0, TRUE},
+#ifdef USE_OPENSSL
+	{0,				"irc.shivering-isles.de/+6697"},
+#endif
+	{0,				"irc.shivering-isles.de"},
+	
 	{"SlashNET",	0},
 	{0,			"irc.slashnet.org"},
 

--- a/src/common/servlist.c
+++ b/src/common/servlist.c
@@ -286,11 +286,11 @@ static const struct defaultserver def[] =
 	{"Serenity-IRC",	0},
 	{0,			"irc.serenity-irc.net"},
 
-	{"Shivering-Isles", 0, 0, 0, LOGIN_SASL, 0, TRUE},
+	{"MadIRC", 0, 0, 0, LOGIN_SASL, 0, TRUE},
 #ifdef USE_OPENSSL
-	{0,				"irc.shivering-isles.de/+6697"},
+	{0,				"irc.madirc.net/+6697"},
 #endif
-	{0,				"irc.shivering-isles.de"},
+	{0,				"irc.madirc.net"},
 	
 	{"SlashNET",	0},
 	{0,			"irc.slashnet.org"},


### PR DESCRIPTION
To check the FAQ "should" ideas:

`A maintained website listing servers.`
https://stats.madirc.net

`Has been around for a while.`
Founded on 4.6.2014

`A decent amount of active users.`
There are 30-50 Users around

`Doesn’t block large groups of users.`
Well, checkout by yourself :D

