### PR TITLE
Correct a translation with the wrong meaning

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -3205,7 +3205,7 @@ msgstr "_Buscar"
 
 #: ../src/fe-gtk/chanlist.c:800
 msgid "_Download List"
-msgstr "Lista de _descarga"
+msgstr "_Descargar lista"
 
 #: ../src/fe-gtk/chanlist.c:806
 msgid "Save _List..."


### PR DESCRIPTION
In Spanish, "Download list" is "Descargar lista", not "Lista de descarga":  an itemization of things to download, not the intended meaning in the menu entry.