### PR TITLE
Removed SeionIRC from the serverlist

### DIFF
--- a/src/common/servlist.c
+++ b/src/common/servlist.c
@@ -280,9 +280,6 @@ static const struct defaultserver def[] =
 	{"SeilEn.de",	0},
 	{0,			"irc.seilen.de"},
 
-	{"SeionIRC", 0, 0, 0, LOGIN_SASL, 0, TRUE},
-	{0,			"irc.seion.us"},
-
 	{"Serenity-IRC",	0},
 	{0,			"irc.serenity-irc.net"},
 


### PR DESCRIPTION
I'm removing Seion from the serverlist because it's now mostly a defunct network. One of the servers is completely broken in regards to ipv6 connectivity and SSL, the webchat server hasn't worked for months, and I shut down my server (fox.seion.us) a few days ago.