### PR TITLE
TLS: Set SNI hostname before connect

### DIFF
--- a/src/common/server.c
+++ b/src/common/server.c
@@ -487,6 +487,10 @@ ssl_do_connect (server * serv)
 	char buf[128];
 
 	g_sess = serv->server_session;
+
+	/* Set SNI hostname before connect */
+	SSL_set_tlsext_host_name(serv->ssl, serv->hostname);
+
 	if (SSL_connect (serv->ssl) <= 0)
 	{
 		char err_buf[128];


### PR DESCRIPTION
This is needed so the server can choose the right certificate to send, or so it knows what host or service to forward the connection to.

I didn't bother checking the function return status because it doesn't really matter, it'd only fail for SSLv3 or lower connections which no one should be using anyway, though the program should still proceed just without SNI.