### PR TITLE
Remove unnecessary information from the CTCP VERSION response.

### DIFF
--- a/src/common/ctcp.c
+++ b/src/common/ctcp.c
@@ -138,14 +138,7 @@ ctcp_handle (session *sess, char *to, char *nick, char *ip,
 
 	if (!g_ascii_strcasecmp (msg, "VERSION") && !prefs.hex_irc_hide_version)
 	{
-#ifdef WIN32
-		g_snprintf (outbuf, sizeof (outbuf), "VERSION HexChat "PACKAGE_VERSION" [x%d] / %s",
-					 get_cpu_arch (), get_sys_str (1));
-#else
-		g_snprintf (outbuf, sizeof (outbuf), "VERSION HexChat "PACKAGE_VERSION" / %s",
-					 get_sys_str (1));
-#endif
-		serv->p_nctcp (serv, nick, outbuf);
+		serv->p_nctcp (serv, nick, "VERSION HexChat "PACKAGE_VERSION);
 	}
 
 	if (!ctcp_check (sess, nick, word, word_eol, word[4] + ctcp_offset))


### PR DESCRIPTION
CTCP VERSION is for version information about the client not the system. There is no legitimate reason to expose information about the system in it.