### PR TITLE
Correctly check SSL_get_verify_result()

### DIFF
--- a/src/common/server.c
+++ b/src/common/server.c
@@ -570,8 +570,6 @@ ssl_do_connect (server * serv)
 		} else
 		{
 			g_snprintf (buf, sizeof (buf), " * No Certificate");
-			EMIT_SIGNAL (XP_TE_SSLMESSAGE, serv->server_session, buf, NULL, NULL,
-							 NULL, 0);
 			goto conn_fail;
 		}
 

--- a/src/common/server.c
+++ b/src/common/server.c
@@ -572,6 +572,7 @@ ssl_do_connect (server * serv)
 			g_snprintf (buf, sizeof (buf), " * No Certificate");
 			EMIT_SIGNAL (XP_TE_SSLMESSAGE, serv->server_session, buf, NULL, NULL,
 							 NULL, 0);
+			goto conn_fail;
 		}
 
 		chiper_info = _SSL_get_cipher_info (serv->ssl);	/* static buffer */
@@ -590,8 +591,6 @@ ssl_do_connect (server * serv)
 		case X509_V_OK:
 			{
 				X509 *cert = SSL_get_peer_certificate (serv->ssl);
-				if (!cert)
-					goto conn_fail;
 
 				int hostname_err;
 				if ((hostname_err = _SSL_check_hostname(cert, serv->hostname)) != 0)

--- a/src/common/server.c
+++ b/src/common/server.c
@@ -590,6 +590,9 @@ ssl_do_connect (server * serv)
 		case X509_V_OK:
 			{
 				X509 *cert = SSL_get_peer_certificate (serv->ssl);
+				if (!cert)
+					goto conn_fail;
+
 				int hostname_err;
 				if ((hostname_err = _SSL_check_hostname(cert, serv->hostname)) != 0)
 				{
@@ -1649,7 +1652,7 @@ server_set_encoding (server *serv, char *new_encoding)
 	if (new_encoding)
 	{
 		serv->encoding = g_strdup (new_encoding);
-		/* the serverlist GUI might have added a space 
+		/* the serverlist GUI might have added a space
 			and short description - remove it. */
 		space = strchr (serv->encoding, ' ');
 		if (space)


### PR DESCRIPTION
According to OpenSSL document (https://www.openssl.org/docs/manmaster/ssl/SSL_get_verify_result.html),
when using SSL_get_verify_result(), the existence of certificate
needs to be checked. However, in current code, it does not.
Therefore, certificate existence check is required for correctly
handling the exception.