### PR TITLE
Delete space in the beginning and the end of the hostname.

### DIFF
--- a/src/fe-gtk/servlistgui.c
+++ b/src/fe-gtk/servlistgui.c
@@ -1319,7 +1319,7 @@ servlist_sanitize_hostname (char *host)
 	if (c && c == e)
 		*c = '/';
 
-	return ret;
+	return g_strstrip(ret);
 }
 
 /* remove leading slash */


### PR DESCRIPTION
Hi HexChat developers,

This patch try to trim the hostname.
Because hostname with space is invalid. And sometimes it is difficult to observe there is one space in the beginning or the end of the hostname.

Thanks for the great job on HexChat. :-)