### PR TITLE
Don't flush the chanopt_list when saving it

### DIFF
--- a/src/common/chanopt.c
+++ b/src/common/chanopt.c
@@ -396,7 +396,7 @@ chanopt_save_one_channel (chanopt_in_memory *co, int fh)
 }
 
 void
-chanopt_save_all (void)
+chanopt_save_all (const int flush)
 {
 	int i;
 	int num_saved;
@@ -438,15 +438,19 @@ chanopt_save_all (void)
 		}
 
 cont:
-		g_free (co->network);
-		g_free (co->channel);
-		g_free (co);
+		if (flush) {
+			g_free (co->network);
+			g_free (co->channel);
+			g_free (co);
+		}
 	}
 
 	close (fh);
 
-	g_slist_free (chanopt_list);
-	chanopt_list = NULL;
+	if (flush) {
+		g_slist_free (chanopt_list);
+		chanopt_list = NULL;
+	}
 
 	chanopt_open = FALSE;
 	chanopt_changed = FALSE;

--- a/src/common/chanopt.h
+++ b/src/common/chanopt.h
@@ -22,7 +22,7 @@
 
 int chanopt_command (session *sess, char *tbuf, char *word[], char *word_eol[]);
 gboolean chanopt_is_set (unsigned int global, guint8 per_chan_setting);
-void chanopt_save_all (void);
+void chanopt_save_all (const int flush);
 void chanopt_save (session *sess);
 void chanopt_load (session *sess);
 

--- a/src/common/hexchat.c
+++ b/src/common/hexchat.c
@@ -960,7 +960,7 @@ hexchat_exit (void)
 	notify_save ();
 	ignore_save ();
 	free_sessions ();
-	chanopt_save_all ();
+	chanopt_save_all (TRUE);
 	servlist_cleanup ();
 	fe_exit ();
 }

--- a/src/common/outbound.c
+++ b/src/common/outbound.c
@@ -581,7 +581,7 @@ cmd_chanopt (struct session *sess, char *tbuf, char *word[], char *word_eol[])
 	
 	/* chanopt.c */
 	ret = chanopt_command (sess, tbuf, word, word_eol);
-	chanopt_save_all ();
+	chanopt_save_all (FALSE);
 	
 	return ret;
 }

--- a/src/fe-gtk/maingui.c
+++ b/src/fe-gtk/maingui.c
@@ -1514,7 +1514,7 @@ mg_set_guint8 (GtkCheckMenuItem *item, guint8 *setting)
 		log_open_or_close (sess);
 
 	chanopt_save (sess);
-	chanopt_save_all ();
+	chanopt_save_all (FALSE);
 }
 
 static void


### PR DESCRIPTION
Fixes #1134 for me, `chanopt_save_all` was flushing the list every time an option was toggled