### PR TITLE
Improve timer behavior for more effective power management

### DIFF
--- a/src/common/cfgfiles.c
+++ b/src/common/cfgfiles.c
@@ -1046,6 +1046,11 @@ save_config (void)
 				return 0;
 			}
 		}
+
+		if (vars[i].after_update != NULL)
+		{
+			vars[i].after_update();
+		}
 		i++;
 	}
 	while (vars[i].name);
@@ -1292,6 +1297,11 @@ cmd_set (struct session *sess, char *tbuf, char *word[], char *word_eol[])
 				else
 				{
 					set_showval (sess, &vars[i], tbuf);
+				}
+
+				if (vars[i].after_update != NULL)
+				{
+					vars[i].after_update();
 				}
 				break;
 			}

--- a/src/common/cfgfiles.c
+++ b/src/common/cfgfiles.c
@@ -532,7 +532,7 @@ const struct prefs vars[] =
 	{"net_auto_reconnectonfail", P_OFFINT (hex_net_auto_reconnectonfail), TYPE_BOOL},
 #endif
 	{"net_bind_host", P_OFFSET (hex_net_bind_host), TYPE_STR},
-	{"net_ping_timeout", P_OFFINT (hex_net_ping_timeout), TYPE_INT},
+	{"net_ping_timeout", P_OFFINT (hex_net_ping_timeout), TYPE_INT, hexchat_reinit_timers},
 	{"net_proxy_auth", P_OFFINT (hex_net_proxy_auth), TYPE_BOOL},
 	{"net_proxy_host", P_OFFSET (hex_net_proxy_host), TYPE_STR},
 	{"net_proxy_pass", P_OFFSET (hex_net_proxy_pass), TYPE_STR},

--- a/src/common/cfgfiles.h
+++ b/src/common/cfgfiles.h
@@ -71,6 +71,11 @@ struct prefs
 	unsigned short offset;
 	unsigned short len;
 	unsigned short type;
+	/*
+	 * an optional function which will be called after the preference value has
+	 * been updated.
+	 */
+	void (*after_update)(void);
 };
 
 #define TYPE_STR 0

--- a/src/common/dcc.c
+++ b/src/common/dcc.c
@@ -2234,7 +2234,7 @@ new_dcc (void)
 	dcc_list = g_slist_prepend (dcc_list, dcc);
 	if (! (timeout_timer > 0))
 	{
-		timeout_timer = fe_timeout_add (1000, dcc_check_timeouts, NULL);
+		timeout_timer = fe_timeout_add_seconds (1, dcc_check_timeouts, NULL);
 	}
 	return dcc;
 }

--- a/src/common/dcc.c
+++ b/src/common/dcc.c
@@ -233,7 +233,7 @@ is_dcc_completed (struct DCC *dcc)
 	return FALSE;
 }
 
-/* this is called from hexchat.c:hexchat_misc_checks() every 1 second. */
+/* this is called from hexchat.c:hexchat_check_dcc() every 1 second. */
 
 void
 dcc_check_timeouts (void)

--- a/src/common/dcc.h
+++ b/src/common/dcc.h
@@ -110,7 +110,6 @@ gboolean is_dcc_completed (struct DCC *dcc);
 void dcc_abort (session *sess, struct DCC *dcc);
 void dcc_get (struct DCC *dcc);
 int dcc_resume (struct DCC *dcc);
-void dcc_check_timeouts (void);
 void dcc_change_nick (server *serv, char *oldnick, char *newnick);
 void dcc_notify_kill (struct server *serv);
 struct DCC *dcc_write_chat (char *nick, char *text);

--- a/src/common/fe.h
+++ b/src/common/fe.h
@@ -50,6 +50,7 @@ void fe_main (void);
 void fe_cleanup (void);
 void fe_exit (void);
 int fe_timeout_add (int interval, void *callback, void *userdata);
+int fe_timeout_add_seconds (int interval, void *callback, void *userdata);
 void fe_timeout_remove (int tag);
 void fe_new_window (struct session *sess, int focus);
 void fe_new_server (struct server *serv);

--- a/src/common/hexchat.c
+++ b/src/common/hexchat.c
@@ -354,13 +354,6 @@ doover:
 	return 1;
 }
 
-static int
-hexchat_check_dcc (void)	/* this gets called every 1 second */
-{
-	dcc_check_timeouts ();
-	return 1;
-}
-
 /* these are only run if the lagometer is enabled */
 static int
 hexchat_lag_check (void)   /* this gets called every 30 seconds */
@@ -406,7 +399,6 @@ irc_init (session *sess)
 					     notify_checklist, NULL);
 
 	fe_timeout_add (prefs.hex_away_timeout * 1000, away_check, NULL);
-	fe_timeout_add (1000, hexchat_check_dcc, NULL);
 	if (prefs.hex_gui_lagometer)
 	{
 		fe_timeout_add (500, hexchat_lag_check_update, NULL);

--- a/src/common/hexchat.c
+++ b/src/common/hexchat.c
@@ -395,14 +395,14 @@ irc_init (session *sess)
 #endif
 
 	if (prefs.hex_notify_timeout)
-		notify_tag = fe_timeout_add (prefs.hex_notify_timeout * 1000,
-					     notify_checklist, NULL);
+		notify_tag = fe_timeout_add_seconds (prefs.hex_notify_timeout,
+						     notify_checklist, NULL);
 
-	fe_timeout_add (prefs.hex_away_timeout * 1000, away_check, NULL);
+	fe_timeout_add_seconds (prefs.hex_away_timeout, away_check, NULL);
 	if (prefs.hex_gui_lagometer)
 	{
 		fe_timeout_add (500, hexchat_lag_check_update, NULL);
-		fe_timeout_add (30000, hexchat_lag_check, NULL);
+		fe_timeout_add_seconds (30, hexchat_lag_check, NULL);
 	}
 
 	if (arg_url != NULL)

--- a/src/common/hexchat.c
+++ b/src/common/hexchat.c
@@ -377,26 +377,44 @@ hexchat_reinit_timers (void)
 	static int lag_check_tag = 0;
 	static int away_tag = 0;
 
-	if (prefs.hex_notify_timeout)
+	/* notify timeout */
+	if (prefs.hex_notify_timeout && notify_tag == 0)
 	{
 		notify_tag = fe_timeout_add_seconds (prefs.hex_notify_timeout,
 						     notify_checklist, NULL);
 	} else
 	{
 		fe_timeout_remove (notify_tag);
+		notify_tag = 0;
 	}
 
+	/* away status tracking */
 	fe_timeout_remove (away_tag);
-	away_tag = fe_timeout_add_seconds (prefs.hex_away_timeout, away_check, NULL);
+	away_tag = 0;
+	if (prefs.hex_away_track)
+	{
+		away_tag = fe_timeout_add_seconds (prefs.hex_away_timeout, away_check, NULL);
+	}
 
-	if (prefs.hex_gui_lagometer)
+	/* lag-o-meter */
+	if (prefs.hex_gui_lagometer && lag_check_update_tag == 0)
 	{
 		lag_check_update_tag = fe_timeout_add (500, hexchat_lag_check_update, NULL);
-		lag_check_tag = fe_timeout_add_seconds (30, hexchat_lag_check, NULL);
 	} else
 	{
 		fe_timeout_remove (lag_check_update_tag);
+		lag_check_update_tag = 0;
+	}
+
+	/* network timeouts and lag-o-meter */
+	if ((prefs.hex_net_ping_timeout != 0 || prefs.hex_gui_lagometer)
+	    && lag_check_tag == 0)
+	{
+		lag_check_tag = fe_timeout_add_seconds (30, hexchat_lag_check, NULL);
+	} else
+	{
 		fe_timeout_remove (lag_check_tag);
+		lag_check_tag = 0;
 	}
 }
 

--- a/src/common/hexchatc.h
+++ b/src/common/hexchatc.h
@@ -50,6 +50,7 @@ extern GList *sess_list_by_lastact[];
 session * find_channel (server *serv, char *chan);
 session * find_dialog (server *serv, char *nick);
 session * new_ircwindow (server *serv, char *name, int type, int focus);
+void hexchat_reinit_timers (void);
 void lastact_update (session * sess);
 session * lastact_getfirst (int (*filter) (session *sess));
 int is_session (session * sess);

--- a/src/common/ignore.c
+++ b/src/common/ignore.c
@@ -410,7 +410,7 @@ flood_check (char *nick, char *ip, server *serv, session *sess, int what)	/*0=ct
 					{
 						prefs.hex_gui_autoopen_dialog = 0;
 						/* turn it back on in 30 secs */
-						fe_timeout_add (30000, flood_autodialog_timeout, NULL);
+						fe_timeout_add_seconds (30, flood_autodialog_timeout, NULL);
 					}
 					return 0;
 				}

--- a/src/common/inbound.c
+++ b/src/common/inbound.c
@@ -1594,7 +1594,7 @@ inbound_login_end (session *sess, char *text, const message_tags_data *tags_data
 			&& ((((ircnet *)serv->network)->pass && inbound_nickserv_login (serv))
 				|| ((ircnet *)serv->network)->commandlist))
 		{
-			serv->joindelay_tag = fe_timeout_add (prefs.hex_irc_join_delay * 1000, check_autojoin_channels, serv);
+			serv->joindelay_tag = fe_timeout_add_seconds (prefs.hex_irc_join_delay, check_autojoin_channels, serv);
 		}
 		else
 		{

--- a/src/common/server.c
+++ b/src/common/server.c
@@ -249,7 +249,7 @@ static void
 close_socket (int sok)
 {
 	/* close the socket in 5 seconds so the QUIT message is not lost */
-	fe_timeout_add (5000, close_socket_cb, GINT_TO_POINTER (sok));
+	fe_timeout_add_seconds (5, close_socket_cb, GINT_TO_POINTER (sok));
 }
 
 /* handle 1 line of text received from the server */

--- a/src/fe-gtk/fe-gtk.c
+++ b/src/fe-gtk/fe-gtk.c
@@ -345,6 +345,12 @@ fe_timeout_add (int interval, void *callback, void *userdata)
 	return g_timeout_add (interval, (GSourceFunc) callback, userdata);
 }
 
+int
+fe_timeout_add_seconds (int interval, void *callback, void *userdata)
+{
+	return g_timeout_add_seconds (interval, (GSourceFunc) callback, userdata);
+}
+
 void
 fe_timeout_remove (int tag)
 {

--- a/src/fe-gtk/menu.c
+++ b/src/fe-gtk/menu.c
@@ -1646,6 +1646,7 @@ menu_metres_off (GtkWidget *item, gpointer none)
 	{
 		prefs.hex_gui_lagometer = 0;
 		prefs.hex_gui_throttlemeter = 0;
+		hexchat_reinit_timers ();
 		menu_setting_foreach (menu_apply_metres_cb, -1, 0);
 	}
 }
@@ -1657,6 +1658,7 @@ menu_metres_text (GtkWidget *item, gpointer none)
 	{
 		prefs.hex_gui_lagometer = 2;
 		prefs.hex_gui_throttlemeter = 2;
+		hexchat_reinit_timers ();
 		menu_setting_foreach (menu_apply_metres_cb, -1, 0);
 	}
 }
@@ -1668,6 +1670,7 @@ menu_metres_graph (GtkWidget *item, gpointer none)
 	{
 		prefs.hex_gui_lagometer = 1;
 		prefs.hex_gui_throttlemeter = 1;
+		hexchat_reinit_timers ();
 		menu_setting_foreach (menu_apply_metres_cb, -1, 0);
 	}
 }
@@ -1679,6 +1682,7 @@ menu_metres_both (GtkWidget *item, gpointer none)
 	{
 		prefs.hex_gui_lagometer = 3;
 		prefs.hex_gui_throttlemeter = 3;
+		hexchat_reinit_timers ();
 		menu_setting_foreach (menu_apply_metres_cb, -1, 0);
 	}
 }

--- a/src/fe-gtk/setup.c
+++ b/src/fe-gtk/setup.c
@@ -2132,6 +2132,7 @@ setup_apply_real (int new_pix, int do_ulist, int do_layout, int do_identd)
 
 	mg_apply_setup ();
 	tray_apply_setup ();
+	hexchat_reinit_timers ();
 
 	if (do_layout)
 		menu_change_layout ();

--- a/src/fe-text/fe-text.c
+++ b/src/fe-text/fe-text.c
@@ -415,6 +415,12 @@ fe_timeout_add (int interval, void *callback, void *userdata)
 	return g_timeout_add (interval, (GSourceFunc) callback, userdata);
 }
 
+int
+fe_timeout_add_seconds (int interval, void *callback, void *userdata)
+{
+	return g_timeout_add_seconds (interval, (GSourceFunc) callback, userdata);
+}
+
 void
 fe_input_remove (int tag)
 {


### PR DESCRIPTION
Currently Hexchat is a remarkable power hog. Not only does it make no attempt to consolidate wake-ups (to maximize processor sleep state residency) but it also has a number timers that are entirely superfluous. For this reason Hexchat is consistently one of the biggest wake-up sources on my laptop. This can be observed using either `powertop` or `/proc/timer_stats` directly.

This branch is an attempt to fix this. It does a few things,

 * break up the `hexchat_misc_checks` callback to separate unrelated timers
 * disable the lag-o-meter timer entirely when this feature is not in use
 * use `g_timeout_add_seconds` wherever possible to allow the operating system to choose wake-up times more appropriately
 * disable the DCC timeout timer when there are no DCC connections active
 * a bit of miscellaneous refactoring in DCC-land

One remaining violator that I don't really know how to handle is the `python` plugin, which registers a 300ms timer to allow Python's threading mechanism to do its thing. It's not really clear to me what to do about this and I don't use this plugin myself.

After unloading `python` these changes place `hexchat` well down the list of wake-up sources, where it belongs.