### PR TITLE
Server list: Add Cuff-Link.

### DIFF
--- a/src/common/servlist.c
+++ b/src/common/servlist.c
@@ -117,6 +117,12 @@ static const struct defaultserver def[] =
 	/* Self signed */
 	{0,			"irc.criten.net"},
 
+	{"Cuff-Link", 0, 0, 0, LOGIN_SASL},
+#ifdef USE_OPENSSL
+	{0,			"irc.cuff-link.me/+6697"},
+#endif
+	{0,			"irc.cuff-link.me"},
+
 	{"DALnet", 0, 0, 0, LOGIN_NICKSERV},
 	/* Self signed */
 	{0,			"us.dal.net"},


### PR DESCRIPTION
A full list of hostnames can be found at http://blog.cuff-link.me/chat/

User statistics can be found at http://search.mibbit.com/networks/Cuff-Link

More information about our network: http://irc.netsplit.de/networks/Cuff-Link/
