### PR TITLE
included stdlib.h in dbus-client.c to fix compile error

### DIFF
--- a/src/common/dbus/dbus-client.c
+++ b/src/common/dbus/dbus-client.c
@@ -22,6 +22,7 @@
 #include "config.h"
 
 #define GLIB_DISABLE_DEPRECATION_WARNINGS
+#include <stdlib.h>
 #include <dbus/dbus-glib.h>
 #include "dbus-client.h"
 #include "hexchat.h"


### PR DESCRIPTION
included stdlib.h in dbus-client.c to fix "Implicit declaration of function exit" compile error.