### PR TITLE
Add support for migration from xchat configuration

### DIFF
--- a/src/common/cfgfiles.c
+++ b/src/common/cfgfiles.c
@@ -950,6 +950,38 @@ make_dcc_dirs (void)
 	return 0;
 }
 
+void migrate_from_xchat (void)
+{
+	char *servlist_conf, *logs_xchat;
+	char *xchat_dir = g_build_filename (g_get_home_dir (), ".xchat2", NULL);
+	if (!g_file_test (xchat_dir, G_FILE_TEST_EXISTS))
+	{
+		g_free (xchat_dir);
+		return;
+	}
+	servlist_conf = g_build_filename (xchat_dir, "servlist_.conf", NULL);
+	if (g_file_test (servlist_conf, G_FILE_TEST_EXISTS))
+	{
+		char *servlist_target = g_build_filename (get_xdir (), "servlist_.conf", NULL);
+                if (g_rename(servlist_conf, servlist_target) == -1)
+			g_error("Error while renaming %s to %s", servlist_conf, servlist_target);
+		g_free (servlist_target);
+	}
+	g_free (servlist_conf);
+
+	logs_xchat = g_build_filename (xchat_dir, "xchatlogs", NULL);
+	if (g_file_test (logs_xchat, G_FILE_TEST_EXISTS))
+	{
+		char *logs_hexchat = g_build_filename (get_xdir (), "logs", NULL);
+		if (g_rename (logs_xchat, logs_hexchat) == -1)
+			g_error("Error while renaming %s to %s", logs_xchat, logs_hexchat);
+		g_free (logs_hexchat);
+	}
+	g_free (logs_xchat);
+
+	g_free (xchat_dir);
+}
+
 int
 load_config (void)
 {

--- a/src/common/cfgfiles.h
+++ b/src/common/cfgfiles.h
@@ -41,6 +41,7 @@ int check_config_dir (void);
 void load_default_config (void);
 int make_config_dirs (void);
 int make_dcc_dirs (void);
+void migrate_from_xchat (void);
 int load_config (void);
 int save_config (void);
 void list_free (GSList ** list);

--- a/src/common/hexchat.c
+++ b/src/common/hexchat.c
@@ -1087,6 +1087,7 @@ main (int argc, char *argv[])
 		load_default_config ();
 		make_config_dirs ();
 		make_dcc_dirs ();
+		migrate_from_xchat ();
 	}
 
 	/* we MUST do this after load_config () AND before fe_init (thus gtk_init) otherwise it will fail */


### PR DESCRIPTION
If user starts hexchat for the first time and yet he still has some
xchat2 configuration around we should reuse it thus saving the user
some time.

We in SUSE/openSUSE switched the default from xchat2 to hexchat and thus want the users to be able to use their irc right after the distribution update.
