### PR TITLE
configure: fix --disable-python

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -302,7 +302,7 @@ dnl *********************************************************************
 dnl ** PYTHON ***********************************************************
 dnl *********************************************************************
 
-AS_IF([test "x$python" != xno], [
+AS_IF([test "x$python" != "xno"], [
 	AC_MSG_CHECKING(for plugin interface used by Python)
 	AS_IF([test "$plugin" = yes], [
 		AC_MSG_RESULT([yes])


### PR DESCRIPTION
Due to missing quotes on one side of this shell comparison the --disable-python argument is not working as expected. python2 was always included in the build.