### PR TITLE
Update usercount in title and userlist label only once

### DIFF
--- a/src/common/inbound.c
+++ b/src/common/inbound.c
@@ -1122,6 +1122,7 @@ inbound_nameslist_end (server *serv, char *chan,
 			{
 				sess->end_of_names = TRUE;
 				sess->ignore_names = FALSE;
+				fe_userlist_numbers (sess);
 			}
 			list = list->next;
 		}
@@ -1132,6 +1133,7 @@ inbound_nameslist_end (server *serv, char *chan,
 	{
 		sess->end_of_names = TRUE;
 		sess->ignore_names = FALSE;
+		fe_userlist_numbers (sess);
 		return TRUE;
 	}
 	return FALSE;

--- a/src/common/userlist.c
+++ b/src/common/userlist.c
@@ -416,7 +416,8 @@ userlist_add (struct session *sess, char *name, char *hostname,
 		sess->me = user;
 
 	fe_userlist_insert (sess, user, FALSE);
-	fe_userlist_numbers (sess);
+	if(sess->end_of_names)
+		fe_userlist_numbers (sess);
 }
 
 static int


### PR DESCRIPTION
Only update usercount once instead of the (number of users) times per nameslist in channels.