### PR TITLE
Reorder includes to avoid installed headers

### DIFF
--- a/plugins/checksum/Makefile.am
+++ b/plugins/checksum/Makefile.am
@@ -4,4 +4,5 @@ lib_LTLIBRARIES = checksum.la
 checksum_la_SOURCES = checksum.c
 checksum_la_LDFLAGS = $(PLUGIN_LDFLAGS) -module
 checksum_la_LIBADD = $(GLIB_LIBS)
-checksum_la_CFLAGS = $(GLIB_CFLAGS) -I$(top_srcdir)/src/common
+checksum_la_CPPFLAGS = -I$(top_srcdir)/src/common
+checksum_la_CFLAGS = $(GLIB_CFLAGS)

--- a/plugins/doat/Makefile.am
+++ b/plugins/doat/Makefile.am
@@ -4,5 +4,6 @@ lib_LTLIBRARIES = doat.la
 doat_la_SOURCES = doat.c
 doat_la_LDFLAGS = $(PLUGIN_LDFLAGS) -module
 doat_la_LIBADD = $(GLIB_LIBS)
-doat_la_CFLAGS = $(GLIB_CFLAGS) -I$(top_srcdir)/src/common
+doat_la_CPPFLAGS = -I$(top_srcdir)/src/common
+doat_la_CFLAGS = $(GLIB_CFLAGS)
 

--- a/plugins/fishlim/Makefile.am
+++ b/plugins/fishlim/Makefile.am
@@ -6,4 +6,5 @@ lib_LTLIBRARIES = fishlim.la
 fishlim_la_SOURCES = fish.c irc.c keystore.c plugin_hexchat.c
 fishlim_la_LDFLAGS = $(PLUGIN_LDFLAGS) -module
 fishlim_la_LIBADD = $(GLIB_LIBS) $(OPENSSL_LIBS)
-fishlim_la_CFLAGS = $(GLIB_CFLAGS) $(OPENSSL_CFLAGS) -I$(top_srcdir)/src/common
+fishlim_la_CPPFLAGS = -I$(top_srcdir)/src/common
+fishlim_la_CFLAGS = $(GLIB_CFLAGS) $(OPENSSL_CFLAGS)

--- a/plugins/perl/Makefile.am
+++ b/plugins/perl/Makefile.am
@@ -8,7 +8,8 @@ lib_LTLIBRARIES = perl.la
 perl_la_SOURCES = perl.c
 perl_la_LDFLAGS = $(PERL_LDFLAGS) $(PLUGIN_LDFLAGS) -module
 perl_la_LIBADD = $(GLIB_LIBS)
-perl_la_CFLAGS = $(PERL_CFLAGS) $(GLIB_CFLAGS) -I$(top_srcdir)/src/common
+perl_la_CPPFLAGS = -I$(top_srcdir)/src/common
+perl_la_CFLAGS = $(PERL_CFLAGS) $(GLIB_CFLAGS)
 
 BUILT_SOURCES = hexchat.pm.h irc.pm.h
 CLEANFILES = $(BUILT_SOURCES)

--- a/plugins/python/Makefile.am
+++ b/plugins/python/Makefile.am
@@ -4,6 +4,6 @@ lib_LTLIBRARIES = python.la
 python_la_SOURCES = python.c
 python_la_LDFLAGS = $(PLUGIN_LDFLAGS) -module
 python_la_LIBADD = $(PYTHON_LIBS) $(GLIB_LIBS)
-python_la_CPPFLAGS = $(PYTHON_CPPFLAGS)
-python_la_CFLAGS = $(GLIB_CFLAGS) -I$(top_srcdir)/src/common
+python_la_CPPFLAGS = -I$(top_srcdir)/src/common $(PYTHON_CPPFLAGS)
+python_la_CFLAGS = $(GLIB_CFLAGS)
 

--- a/plugins/sysinfo/Makefile.am
+++ b/plugins/sysinfo/Makefile.am
@@ -14,4 +14,4 @@ lib_LTLIBRARIES = sysinfo.la
 sysinfo_la_SOURCES = $(sources)
 sysinfo_la_LDFLAGS = $(PLUGIN_LDFLAGS) -module
 sysinfo_la_LIBADD = $(LIBPCI_LIBS) $(GLIB_LIBS)
-AM_CPPFLAGS = $(LIBPCI_CFLAGS) $(GLIB_CFLAGS) -I$(top_srcdir)/src/common -I$(srcdir)/shared
+AM_CPPFLAGS = -I$(top_srcdir)/src/common -I$(srcdir)/shared $(LIBPCI_CFLAGS) $(GLIB_CFLAGS)

--- a/src/common/dbus/Makefile.am
+++ b/src/common/dbus/Makefile.am
@@ -15,7 +15,7 @@ BUILT_SOURCES =				\
 
 CLEANFILES = $(BUILT_SOURCES)
 
-AM_CPPFLAGS = $(COMMON_CFLAGS) $(DBUS_CFLAGS) -I$(top_srcdir)/src/common
+AM_CPPFLAGS = -I$(top_srcdir)/src/common $(COMMON_CFLAGS) $(DBUS_CFLAGS)
 
 noinst_PROGRAMS = example
 example_SOURCES = example.c

--- a/src/fe-gtk/Makefile.am
+++ b/src/fe-gtk/Makefile.am
@@ -45,7 +45,7 @@ hexchat_SOURCES = ascii.c banlist.c chanlist.c chanview.c custom-list.c \
 	maingui.c notifygui.c $(notify_c) palette.c pixmaps.c plugin-tray.c $(plugingui_c) \
 	plugin-notification.c rawlog.c servlistgui.c setup.c $(iso_codes_c) \
 	sexy-spell-entry.c textgui.c urlgrab.c userlistgui.c xtext.c
-hexchat_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_builddir)/src/common
+hexchat_CPPFLAGS = -I$(top_builddir)/src/common $(AM_CPPFLAGS)
 
 resources_files = $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(top_srcdir)/data --generate-dependencies $(top_srcdir)/data/hexchat.gresource.xml)
 


### PR DESCRIPTION
When hexchat is already installed into a non-default prefix, a new build
could pick up ${prefix}/include/hexchat-plugin.h from the installed
version instead of the local header, as configuration variables such as
$(GLIB_CFLAGS) would point to -I${prefix}/include.

Reordering the includes and moving -I arguments to CPPFLAGS prevents
this, as it ensures the local directories are always searched first.

This was no problem when compiling for /usr or /usr/local as these
directories in the compiler search path are always searched last.

This problem [originated at MacPorts](https://trac.macports.org/ticket/52384) and was initially reported by @Ionic.