### PR TITLE
sysinfo: fixup 49758cafba9fd7e0663b550debfd51fb21260650.

### DIFF
--- a/plugins/sysinfo/osx/backend.m
+++ b/plugins/sysinfo/osx/backend.m
@@ -78,7 +78,7 @@ get_os (void)
 static char *
 get_os_fallback (void)
 {
-#if MAC_OS_X_VERSION_MIN_REQUIRED <= MAC_OS_X_VERSION_10_9
+#if !defined (MAC_OS_X_VERSION_10_9) || MAC_OS_X_VERSION_MAX_ALLOWED <= MAC_OS_X_VERSION_10_9
 	SInt32 ver_major = 0,
 	       ver_minor = 0,
 	       ver_patch = 0;


### PR DESCRIPTION
`MAC_OS_X_VERSION_MAX_ALLOWED` reflects the currently running OS X version
more closely than `MAC_OS_X_VERSION_MIN_REQUIRED`, given it's defined as
`max(current_version, MAC_OS_X_VERSION_MIN_REQUIRED)`.

Additionally, we should check if `MAC_OS_X_VERSION_10_9` is actually
defined, otherwise the whole macro logic breaks apart.