### PR TITLE
RFC: Lurk mode

### DIFF
--- a/src/common/hexchat.h
+++ b/src/common/hexchat.h
@@ -176,6 +176,7 @@ struct hexchatprefs
 	unsigned int hex_irc_hide_version;
 	unsigned int hex_irc_invisible;
 	unsigned int hex_irc_logging;
+	unsigned int hex_irc_lurk;
 	unsigned int hex_irc_raw_modes;
 	unsigned int hex_irc_servernotice;
 	unsigned int hex_irc_skip_motd;
@@ -372,6 +373,7 @@ typedef struct session
 	guint8 text_logging;
 	guint8 text_scrollback;
 	guint8 text_strip;
+	guint8 text_lurk;
 
 	struct server *server;
 	tree *usertree;					/* alphabetical tree */

--- a/src/fe-gtk/maingui.c
+++ b/src/fe-gtk/maingui.c
@@ -1500,6 +1500,7 @@ mg_create_perchannelmenu (session *sess, GtkWidget *menu)
 
 	mg_perchan_menu_item (_("_Log to Disk"), submenu, &sess->text_logging, prefs.hex_irc_logging);
 	mg_perchan_menu_item (_("_Reload Scrollback"), submenu, &sess->text_scrollback, prefs.hex_text_replay);
+	mg_perchan_menu_item (_("_Lurk mode"), submenu, &sess->text_lurk, prefs.hex_irc_lurk);
 	if (sess->type == SESS_CHANNEL)
 	{
 		mg_perchan_menu_item (_("Strip _Colors"), submenu, &sess->text_strip, prefs.hex_text_stripcolor_msg);

--- a/src/fe-gtk/maingui.c
+++ b/src/fe-gtk/maingui.c
@@ -515,7 +515,8 @@ mg_focus (session *sess)
 	/* dirty trick to avoid auto-selection */
 	SPELL_ENTRY_SET_EDITABLE (sess->gui->input_box, FALSE);
 	gtk_widget_grab_focus (sess->gui->input_box);
-	SPELL_ENTRY_SET_EDITABLE (sess->gui->input_box, TRUE);
+	if (!sess->text_lurk)
+		SPELL_ENTRY_SET_EDITABLE (sess->gui->input_box, TRUE);
 
 	sess->server->front_session = sess;
 
@@ -1474,6 +1475,8 @@ mg_set_guint8 (GtkCheckMenuItem *item, guint8 *setting)
 	/* has the logging setting changed? */
 	if (logging != sess->text_logging)
 		log_open_or_close (sess);
+
+	SPELL_ENTRY_SET_EDITABLE (sess->gui->input_box, !sess->text_lurk);
 
 	chanopt_save (sess);
 	chanopt_save_all (FALSE);

--- a/src/fe-gtk/maingui.c
+++ b/src/fe-gtk/maingui.c
@@ -781,7 +781,7 @@ mg_decide_userlist (session *sess, gboolean switch_to_current)
 		else
 			mg_userlist_showhide (sess, FALSE);	/* hide */
 		break;
-	default:		
+	default:
 		mg_userlist_showhide (sess, TRUE);	/* show */
 	}
 }
@@ -1078,7 +1078,7 @@ mg_tab_close (session *sess)
 		}
 		else
 		{
-			gtk_window_set_position (GTK_WINDOW (dialog), GTK_WIN_POS_CENTER_ON_PARENT);		
+			gtk_window_set_position (GTK_WINDOW (dialog), GTK_WIN_POS_CENTER_ON_PARENT);
 		}
 		gtk_widget_show (dialog);
 	}
@@ -1921,7 +1921,7 @@ flagk_hit (GtkWidget * wid, struct session *sess)
 
 	if (serv->connected && sess->channel[0])
 	{
-		g_snprintf (modes, sizeof (modes), "-k %s", 
+		g_snprintf (modes, sizeof (modes), "-k %s",
 			  gtk_entry_get_text (GTK_ENTRY (sess->gui->key_entry)));
 
 		if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (wid)))
@@ -2017,7 +2017,7 @@ mg_limit_entry_cb (GtkWidget * igad, gpointer userdata)
 			gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (sess->gui->flag_l), FALSE);
 			return;
 		}
-		g_snprintf (modes, sizeof(modes), "+l %d", 
+		g_snprintf (modes, sizeof(modes), "+l %d",
 				atoi (gtk_entry_get_text (GTK_ENTRY (igad))));
 		serv->p_mode (serv, sess->channel, modes);
 		serv->p_join_info (serv, sess->channel);
@@ -2860,7 +2860,7 @@ search_handle_esc (GtkWidget *win, GdkEventKey *key, session *sess)
 {
 	if (key->keyval == GDK_KEY_Escape)
 		mg_search_toggle(sess);
-			
+
 	return FALSE;
 }
 


### PR DESCRIPTION
Hello,
I'm submitting this PR early just to probe for opinions about it, even if I don't consider this finished yet.

Often I end up sending messages by mistake, for example because I think another window have focus, or because I write in the wrong channel.. Since I usually lurk on several channels, and I rarely interact, I wanted an option to disable text input on certain channels on my choose, so that it become impossible to send messages by mistake (unless you disable that option, of course :) )

This PR introduces the "lurk mode" in channel settings, so that the input box became not editable when the option is active.

I would like to make this a bit better, for example making the input box grey when in lurk mode, and/or make the channel name grey for channels in lurk mode.. Also, I haven't taken care of saving this settings in the config files yet.. But as I said I'm looking for early comments about this :)
