### PR TITLE
Generate and upload AppImage of each commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,12 @@ language: c
 cache: apt
 compiler: clang
 script:
-    - ./autogen.sh --enable-textfe --with-theme-manager --enable-static-analysis
+    - ./autogen.sh --enable-textfe --with-theme-manager --enable-static-analysis --prefix=/app
     - make V=1 -j$(nproc)
+    - sudo make install
+    - find /app || true
+after_success:
+    - bash -e linux/appimage.sh
 notifications:
     irc:
         channels: "chat.freenode.net#hexchat-devel"

--- a/linux/appimage.sh
+++ b/linux/appimage.sh
@@ -38,7 +38,7 @@ get_icon
 ########################################################################
 
 cp usr/share/icons/hicolor/scalable/apps/hexchat.svg .
-rm -rf squashfs-root/usr/lib/hexchat/plugins/{python,perl}.so
+rm -f usr/lib/hexchat/plugins/{python,perl}.so
 
 ########################################################################
 # Copy in the dependencies that cannot be assumed to be available

--- a/linux/appimage.sh
+++ b/linux/appimage.sh
@@ -38,6 +38,7 @@ get_icon
 ########################################################################
 
 cp usr/share/icons/hicolor/scalable/apps/hexchat.svg .
+rm -rf squashfs-root/usr/lib/hexchat/plugins/{python,perl}.so
 
 ########################################################################
 # Copy in the dependencies that cannot be assumed to be available

--- a/linux/appimage.sh
+++ b/linux/appimage.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+########################################################################
+# Package the binaries built on Travis-CI as an AppImage
+# By Simon Peter 2016
+# For more information, see http://appimage.org/
+########################################################################
+
+export ARCH=$(arch)
+VER1=$(git describe --tags --always --abbrev=7)
+
+APP=HexChat
+LOWERAPP=${APP,,}
+
+mkdir -p $HOME/$APP/$APP.AppDir/usr/
+
+cd $HOME/$APP/
+
+wget -q https://github.com/probonopd/AppImages/raw/master/functions.sh -O ./functions.sh
+. ./functions.sh
+
+cd $APP.AppDir
+
+sudo chown -R $USER /app/
+
+cp -r /app/* ./usr/
+
+########################################################################
+# Copy desktop and icon file to AppDir for AppRun to pick them up
+########################################################################
+
+get_apprun
+get_desktop
+get_icon
+
+########################################################################
+# Other appliation-specific finishing touches
+########################################################################
+
+cp usr/share/icons/hicolor/scalable/apps/hexchat.svg .
+
+########################################################################
+# Copy in the dependencies that cannot be assumed to be available
+# on all target systems
+########################################################################
+
+copy_deps
+
+########################################################################
+# Delete stuff that should not go into the AppImage
+########################################################################
+
+# Delete dangerous libraries; see
+# https://github.com/probonopd/AppImages/blob/master/excludelist
+delete_blacklisted
+
+########################################################################
+# desktopintegration asks the user on first run to install a menu item
+########################################################################
+
+get_desktopintegration $LOWERAPP
+
+########################################################################
+# Determine the version of the app; also include needed glibc version
+########################################################################
+
+GLIBC_NEEDED=$(glibc_needed)
+VERSION=$VER1-glibc$GLIBC_NEEDED
+
+########################################################################
+# Patch away absolute paths; it would be nice if they were relative
+########################################################################
+
+find usr/ -type f -exec sed -i -e 's|/app|././|g' {} \;
+find usr/ -type f -exec sed -i -e 's|/usr|././|g' {} \;
+find usr/ -type f -exec sed -i -e 's@././/bin/env@/usr/bin/env@g' {} \;
+
+########################################################################
+# AppDir complete
+# Now packaging it as an AppImage
+########################################################################
+
+cd .. # Go out of AppImage
+
+mkdir -p ../out/
+generate_type2_appimage
+
+########################################################################
+# Upload the AppDir
+########################################################################
+
+transfer ../out/*
+echo "AppImage has been uploaded to the URL above; use something like GitHub Releases for permanent storage"

--- a/linux/appimage.sh
+++ b/linux/appimage.sh
@@ -7,7 +7,7 @@
 ########################################################################
 
 export ARCH=$(arch)
-VER1=$(git describe --tags --always --abbrev=7)
+VER1=$(git describe --tags --always --abbrev=7 | sed -e 's|v||g')
 
 APP=HexChat
 LOWERAPP=${APP,,}


### PR DESCRIPTION
This PR, when merged, will generate and upload an [AppImage](http://appimage.org/) of each commit. It does so by bundling HexChat and auxiliary files that cannot be expected to be part of each target system in the AppImage.

The URL of the AppImage can be found in the Travis CI build log, it is beginning with `http://bintray...`. Of course you can change this to use the GitHub Releases mechanism for hosting the binaries instead.

The resulting AppImage is known to run on
* CentOS-7-x86_64-LiveGNOME-1511.iso
* debian-live-8.4.0-amd64-gnome-desktop.iso
* elementaryos-0.4-stable-amd64.20160921.iso
* Fedora-Workstation-Live-x86_64-24-1.2.iso
* openSUSE-Tumbleweed-GNOME-Live-x86_64-Snapshot20160921-Media.iso
* ubuntu-14.04.1-desktop-amd64.iso
* xubuntu-16.04.1-desktop-amd64.iso

amongst others.

Closes #1891.