### PR TITLE
Use AC_CHECK_FUNCS to find functions not in LibreSSL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -374,6 +374,9 @@ AS_IF([test "$openssl" != no], [
 		openssl=yes
 		COMMON_LIBS="$COMMON_LIBS $OPENSSL_LIBS"
 		COMMON_CFLAGS="$COMMON_CFLAGS $OPENSSL_CFLAGS"
+		dnl Test for various functions that are not available in LibreSSL
+		AC_CHECK_FUNCS(SSL_CTX_get_ssl_method, have_ssl_ctx_get_ssl_method=yes)
+		AC_CHECK_FUNCS(X509_get_signature_nid, have_x509_get_signature_nid=yes)
 	], [
 		unset openssl_path ac_cv_lib_ssl_SSL_new ac_cv_header_openssl_ssl_h
 		AS_IF([test "$openssl" != yes], [

--- a/src/common/ssl.c
+++ b/src/common/ssl.c
@@ -176,7 +176,7 @@ _SSL_get_cert_info (struct cert_info *cert_info, SSL * ssl)
 		return 1;
 
 	alg = OBJ_obj2nid (algor->algorithm);
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#ifndef HAVE_X509_GET_SIGNATURE_NID
 	sign_alg = OBJ_obj2nid (peer_cert->sig_alg->algorithm);
 #else
 	sign_alg = X509_get_signature_nid (peer_cert);
@@ -306,7 +306,7 @@ _SSL_socket (SSL_CTX *ctx, int sd)
 
 	SSL_set_fd (ssl, sd);
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#ifndef HAVE_SSL_CTX_GET_SSL_METHOD
 	method = ctx->method;
 #else
 	method = SSL_CTX_get_ssl_method (ctx);


### PR DESCRIPTION
LibreSSL might not have all functions of OpenSSL 1.1.0 so use AC_CHECK_FUNCS to find them first before using them.

This should fix LibreSSL builds as described in #1898.