### PR TITLE
Configure display of plugin load/unload messages.

### DIFF
--- a/plugins/checksum/checksum.c
+++ b/plugins/checksum/checksum.c
@@ -38,6 +38,7 @@ static hexchat_plugin *ph;									/* plugin handle */
 static char name[] = "Checksum";
 static char desc[] = "Calculate checksum for DCC file transfers";
 static char version[] = "3.1";
+static int show_plugin_messages = 0;
 
 static void
 set_limit (char *size)
@@ -253,13 +254,23 @@ hexchat_plugin_init (hexchat_plugin *plugin_handle, char **plugin_name, char **p
 	hexchat_hook_print (ph, "DCC RECV Complete", HEXCHAT_PRI_NORM, dccrecv_cb, NULL);
 	hexchat_hook_print (ph, "DCC Offer", HEXCHAT_PRI_NORM, dccoffer_cb, NULL);
 
-	hexchat_printf (ph, "%s plugin loaded\n", name);
+	hexchat_get_prefs (ph, "gui_show_plugin_messages", NULL, &show_plugin_messages);
+
+	if (show_plugin_messages)
+	{
+		hexchat_printf (ph, "%s plugin loaded\n", name);
+	}
+
 	return 1;
 }
 
 int
 hexchat_plugin_deinit (void)
 {
-	hexchat_printf (ph, "%s plugin unloaded\n", name);
+	if (show_plugin_messages)
+	{
+		hexchat_printf (ph, "%s plugin unloaded\n", name);
+	}
+
 	return 1;
 }

--- a/plugins/exec/exec.c
+++ b/plugins/exec/exec.c
@@ -29,6 +29,7 @@ static hexchat_plugin *ph;   /* plugin handle */
 static char name[] = "Exec";
 static char desc[] = "Execute commands inside HexChat";
 static char version[] = "1.2";
+static int show_plugin_messages = 0;
 
 static int
 run_command (char *word[], char *word_eol[], void *userdata)
@@ -147,7 +148,13 @@ hexchat_plugin_init (hexchat_plugin *plugin_handle, char **plugin_name, char **p
 	*plugin_version = version;
 
 	hexchat_hook_command (ph, "EXEC", HEXCHAT_PRI_NORM, run_command, "Usage: /EXEC [-O] - execute commands inside HexChat", 0);
-	hexchat_printf (ph, "%s plugin loaded\n", name);
+
+	hexchat_get_prefs (ph, "gui_show_plugin_messages", NULL, &show_plugin_messages);
+
+	if (show_plugin_messages)
+	{
+		hexchat_printf (ph, "%s plugin loaded\n", name);
+	}
 
 	return 1;       /* return 1 for success */
 }
@@ -155,6 +162,10 @@ hexchat_plugin_init (hexchat_plugin *plugin_handle, char **plugin_name, char **p
 int
 hexchat_plugin_deinit (void)
 {
-	hexchat_printf (ph, "%s plugin unloaded\n", name);
+	if (show_plugin_messages)
+	{
+		hexchat_printf (ph, "%s plugin unloaded\n", name);
+	}
+
 	return 1;
 }

--- a/plugins/fishlim/plugin_hexchat.c
+++ b/plugins/fishlim/plugin_hexchat.c
@@ -40,6 +40,7 @@
 static const char plugin_name[] = "FiSHLiM";
 static const char plugin_desc[] = "Encryption plugin for the FiSH protocol. Less is More!";
 static const char plugin_version[] = "0.1.0";
+static int show_plugin_messages = 0;
 
 static const char usage_setkey[] = "Usage: SETKEY [<nick or #channel>] <password>, sets the key for a channel or nick";
 static const char usage_delkey[] = "Usage: DELKEY <nick or #channel>, deletes the key for a channel or nick";
@@ -562,7 +563,13 @@ int hexchat_plugin_init(hexchat_plugin *plugin_handle,
 
     pending_exchanges = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
 
-    hexchat_printf(ph, "%s plugin loaded\n", plugin_name);
+    hexchat_get_prefs (ph, "gui_show_plugin_messages", NULL, &show_plugin_messages);
+
+    if (show_plugin_messages)
+    {
+        hexchat_printf(ph, "%s plugin loaded\n", plugin_name);
+    }
+
     /* Return success */
     return 1;
 }
@@ -571,7 +578,11 @@ int hexchat_plugin_deinit(void) {
     g_clear_pointer(&pending_exchanges, g_hash_table_destroy);
     dh1080_deinit();
 
-    hexchat_printf(ph, "%s plugin unloaded\n", plugin_name);
+    if (show_plugin_messages)
+    {
+        hexchat_printf(ph, "%s plugin unloaded\n", plugin_name);
+    }
+
     return 1;
 }
 

--- a/plugins/lua/lua.c
+++ b/plugins/lua/lua.c
@@ -38,6 +38,7 @@
 static char plugin_name[] = "Lua";
 static char plugin_description[] = "Lua scripting interface";
 static char plugin_version[16] = "1.3";
+static int show_plugin_messages = 0;
 
 static char console_tab[] = ">>lua<<";
 static char command_help[] =
@@ -1705,7 +1706,12 @@ G_MODULE_EXPORT int hexchat_plugin_init(hexchat_plugin *plugin_handle, char **na
 	hexchat_hook_command(ph, "RELOAD", HEXCHAT_PRI_NORM, command_reload, NULL, NULL);
 	hexchat_hook_command(ph, "lua", HEXCHAT_PRI_NORM, command_lua, command_help, NULL);
 
-	hexchat_printf(ph, "%s version %s loaded.\n", plugin_name, plugin_version);
+	hexchat_get_prefs (ph, "gui_show_plugin_messages", NULL, &show_plugin_messages);
+
+	if (show_plugin_messages)
+	{
+		hexchat_printf(ph, "%s version %s loaded.\n", plugin_name, plugin_version);
+	}
 
 	scripts = g_ptr_array_new_with_free_func((GDestroyNotify)destroy_script);
 	create_interpreter();

--- a/plugins/mpcinfo/mpcInfo.c
+++ b/plugins/mpcinfo/mpcInfo.c
@@ -16,6 +16,7 @@
 
 //static int DEBUG=0;
 static char *VERSION="0.0.6";
+static int show_plugin_messages = 0;
 
 #include <windows.h>
 #include <stdlib.h>
@@ -146,7 +147,13 @@ int hexchat_plugin_init(hexchat_plugin *plugin_handle, char **plugin_name, char 
 
 	themeInit();
 	loadThemes();
-	hexchat_printf(ph, "%s plugin loaded\n", *plugin_name);
+
+	hexchat_get_prefs (ph, "gui_show_plugin_messages", NULL, &show_plugin_messages);
+
+	if (show_plugin_messages)
+	{
+		hexchat_printf(ph, "%s plugin loaded\n", *plugin_name);
+	}
 
 	return 1;
 }
@@ -155,6 +162,10 @@ int
 hexchat_plugin_deinit (void)
 {
 	hexchat_command (ph, "MENU DEL \"Window/Display Current Song (MPC)\"");
-	hexchat_print (ph, "mpcInfo plugin unloaded\n");
+	if (show_plugin_messages)
+	{
+		hexchat_print (ph, "mpcInfo plugin unloaded\n");
+	}
+
 	return 1;
 }

--- a/plugins/perl/perl.c
+++ b/plugins/perl/perl.c
@@ -1593,6 +1593,7 @@ hexchat_plugin_get_info (char **name, char **desc, char **version,
 /* Reinit safeguard */
 
 static int initialized = 0;
+static int show_plugin_messages = 0;
 
 int
 hexchat_plugin_init (hexchat_plugin * plugin_handle, char **plugin_name,
@@ -1628,7 +1629,12 @@ hexchat_plugin_init (hexchat_plugin * plugin_handle, char **plugin_name,
 	/*perl_init (); */
 	hexchat_hook_timer (ph, 0, perl_auto_load, NULL );
 
-	hexchat_print (ph, "Perl interface loaded\n");
+	hexchat_get_prefs (ph, "gui_show_plugin_messages", NULL, &show_plugin_messages);
+
+	if (show_plugin_messages)
+	{
+		hexchat_print (ph, "Perl interface loaded\n");
+	}
 
 	return 1;
 }
@@ -1639,7 +1645,11 @@ hexchat_plugin_deinit (hexchat_plugin * plugin_handle)
 	perl_end ();
 
 	initialized = 0;
-	hexchat_print (plugin_handle, "Perl interface unloaded\n");
+
+	if (show_plugin_messages)
+	{
+		hexchat_print (plugin_handle, "Perl interface unloaded\n");
+	}
 
 	return 1;
 }

--- a/plugins/python/python.c
+++ b/plugins/python/python.c
@@ -2671,6 +2671,7 @@ Command_Unload(char *word[], char *word_eol[], void *userdata)
 
 static int initialized = 0;
 static int reinit_tried = 0;
+static int show_plugin_messages = 0;
 
 void
 hexchat_plugin_get_info(char **name, char **desc, char **version, void **reserved)
@@ -2770,7 +2771,12 @@ hexchat_plugin_init(hexchat_plugin *plugin_handle,
 	thread_timer = hexchat_hook_timer(ph, 300, Callback_ThreadTimer, NULL);
 #endif
 
-	hexchat_print(ph, "Python interface loaded\n");
+	hexchat_get_prefs (ph, "gui_show_plugin_messages", NULL, &show_plugin_messages);
+
+	if (show_plugin_messages)
+	{
+		hexchat_print(ph, "Python interface loaded\n");
+	}
 
 	Util_Autoload();
 	return 1;
@@ -2824,7 +2830,11 @@ hexchat_plugin_deinit(void)
 	PyThread_free_lock(xchat_lock);
 #endif
 
-	hexchat_print(ph, "Python interface unloaded\n");
+	if (show_plugin_messages)
+	{
+		hexchat_print(ph, "Python interface unloaded\n");
+	}
+
 	initialized = 0;
 
 	return 1;

--- a/plugins/sysinfo/sysinfo.c
+++ b/plugins/sysinfo/sysinfo.c
@@ -42,6 +42,7 @@ static char name[] = "Sysinfo";
 static char desc[] = "Display info about your hardware and OS";
 static char version[] = "1.0";
 static char sysinfo_help[] = "SysInfo Usage:\n  /SYSINFO [-e|-o] [CLIENT|OS|CPU|RAM|DISK|VGA|SOUND|ETHERNET|UPTIME], print various details about your system or print a summary without arguments\n  /SYSINFO SET <variable>\n";
+static int show_plugin_messages = 0;
 
 typedef struct
 {
@@ -264,7 +265,14 @@ hexchat_plugin_init (hexchat_plugin *plugin_handle, char **plugin_name, char **p
 	hexchat_hook_command (ph, "SYSINFO", HEXCHAT_PRI_NORM, sysinfo_cb, sysinfo_help, NULL);
 
 	hexchat_command (ph, "MENU ADD \"Window/Send System Info\" \"SYSINFO\"");
-	hexchat_printf (ph, _("%s plugin loaded\n"), name);
+
+	hexchat_get_prefs (ph, "gui_show_plugin_messages", NULL, &show_plugin_messages);
+
+	if (show_plugin_messages)
+	{
+		hexchat_printf (ph, _("%s plugin loaded\n"), name);
+	}
+
 	return 1;
 }
 
@@ -272,6 +280,11 @@ int
 hexchat_plugin_deinit (void)
 {
 	hexchat_command (ph, "MENU DEL \"Window/Display System Info\"");
-	hexchat_printf (ph, _("%s plugin unloaded\n"), name);
+
+	if (show_plugin_messages)
+	{
+		hexchat_printf (ph, _("%s plugin unloaded\n"), name);
+	}
+
 	return 1;
 }

--- a/plugins/upd/upd.c
+++ b/plugins/upd/upd.c
@@ -31,6 +31,7 @@ static char name[] = "Update Checker";
 static char desc[] = "Check for HexChat updates automatically";
 static char version[] = "5.0";
 static const char upd_help[] = "Update Checker Usage:\n  /UPDCHK, check for HexChat updates\n";
+static int show_plugin_messages = 0;
 
 static int
 check_cmd (char *word[], char *word_eol[], void *userdata)
@@ -54,7 +55,13 @@ hexchat_plugin_init (hexchat_plugin *plugin_handle, char **plugin_name, char **p
 
 	hexchat_hook_command (ph, "UPDCHK", HEXCHAT_PRI_NORM, check_cmd, upd_help, NULL);
 	hexchat_command (ph, "MENU -ishare\\download.png ADD \"Help/Check for Updates\" \"UPDCHK\"");
-	hexchat_printf (ph, "%s plugin loaded\n", name);
+
+	hexchat_get_prefs (ph, "gui_show_plugin_messages", NULL, &show_plugin_messages);
+
+	if (show_plugin_messages)
+	{
+		hexchat_printf (ph, "%s plugin loaded\n", name);
+	}
 
 	return 1;
 }
@@ -64,7 +71,11 @@ hexchat_plugin_deinit (void)
 {
 	win_sparkle_cleanup ();
 
-	hexchat_command (ph, "MENU DEL \"Help/Check for updates\"");
-	hexchat_printf (ph, "%s plugin unloaded\n", name);
+	hexchat_command (ph, "MENU DEL \"Help/Check for updates\"");    
+	if (show_plugin_messages)
+	{
+		hexchat_printf (ph, "%s plugin unloaded\n", name);
+	}
+
 	return 1;
 }

--- a/plugins/winamp/winamp.c
+++ b/plugins/winamp/winamp.c
@@ -21,6 +21,7 @@
 #define PAUSED 3
 
 static hexchat_plugin *ph;   /* plugin handle */
+static int show_plugin_messages = 0;
 
 static int
 winamp(char *word[], char *word_eol[], void *userdata)
@@ -140,7 +141,12 @@ hexchat_plugin_init(hexchat_plugin *plugin_handle,
 	hexchat_hook_command (ph, "WINAMP", HEXCHAT_PRI_NORM, winamp, "Usage: /WINAMP [PAUSE|PLAY|STOP|NEXT|PREV|START] - control Winamp or show what's currently playing", 0);
    	hexchat_command (ph, "MENU -ishare\\music.png ADD \"Window/Display Current Song (Winamp)\" \"WINAMP\"");
 
-	hexchat_print (ph, "Winamp plugin loaded\n");
+	hexchat_get_prefs (ph, "gui_show_plugin_messages", NULL, &show_plugin_messages);
+
+	if (show_plugin_messages)
+	{
+		hexchat_print (ph, "Winamp plugin loaded\n");
+	}
 
 	return 1;	   /* return 1 for success */
 }
@@ -149,6 +155,10 @@ int
 hexchat_plugin_deinit(void)
 {
 	hexchat_command (ph, "MENU DEL \"Window/Display Current Song (Winamp)\"");
-	hexchat_print (ph, "Winamp plugin unloaded\n");
+	if (show_plugin_messages)
+	{
+		hexchat_print (ph, "Winamp plugin unloaded\n");
+	}
+
 	return 1;
 }

--- a/src/common/cfgfiles.c
+++ b/src/common/cfgfiles.c
@@ -426,6 +426,7 @@ const struct prefs vars[] =
 	{"gui_quit_dialog", P_OFFINT (hex_gui_quit_dialog), TYPE_BOOL},
 	{"gui_search_pos", P_OFFINT (hex_gui_search_pos), TYPE_INT},
 	/* {"gui_single", P_OFFINT (hex_gui_single), TYPE_BOOL}, */
+	{"gui_show_plugin_messages", P_OFFINT (hex_gui_show_plugin_messages), TYPE_BOOL},
 	{"gui_slist_fav", P_OFFINT (hex_gui_slist_fav), TYPE_BOOL},
 	{"gui_slist_select", P_OFFINT (hex_gui_slist_select), TYPE_INT},
 	{"gui_slist_skip", P_OFFINT (hex_gui_slist_skip), TYPE_BOOL},

--- a/src/common/hexchat.h
+++ b/src/common/hexchat.h
@@ -112,6 +112,7 @@ struct hexchatprefs
 	unsigned int hex_gui_autoopen_recv;
 	unsigned int hex_gui_autoopen_send;
 	unsigned int hex_gui_compact;
+	unsigned int hex_gui_show_plugin_messages;
 	unsigned int hex_gui_filesize_iec;
 	unsigned int hex_gui_focus_omitalerts;
 	unsigned int hex_gui_hide_menu;

--- a/src/fe-gtk/setup.c
+++ b/src/fe-gtk/setup.c
@@ -581,6 +581,12 @@ static const setting advanced_settings[] =
 	{ST_END, 0, 0, 0, 0, 0}
 };
 
+static const setting developer_settings[] =
+{
+	{ST_TOGGLE,	N_("Display plugin/extension load/unload messages"), P_OFFINTNL(hex_gui_show_plugin_messages), N_("Display plugin/extension load/unload messages."), 0, 0},
+	{ST_END, 0, 0, 0, 0, 0}
+};
+
 static const setting logging_settings[] =
 {
 	{ST_HEADER,	N_("Logging"),0,0,0},
@@ -1882,6 +1888,7 @@ static const char *const cata[] =
 		N_("Sounds"),
 		N_("Logging"),
 		N_("Advanced"),
+		N_("Developer"),
 		NULL,
 	N_("Network"),
 		N_("Network setup"),
@@ -1926,10 +1933,11 @@ setup_create_pages (GtkWidget *box)
 	setup_add_page (cata[10], book, setup_create_sound_page ());
 	setup_add_page (cata[11], book, setup_create_page (logging_settings));
 	setup_add_page (cata[12], book, setup_create_page (advanced_settings));
+	setup_add_page (cata[13], book, setup_create_page (developer_settings));
 
-	setup_add_page (cata[15], book, setup_create_page (network_settings));
-	setup_add_page (cata[16], book, setup_create_page (filexfer_settings));
-	setup_add_page (cata[17], book, setup_create_page (identd_settings));
+	setup_add_page (cata[16], book, setup_create_page (network_settings));
+	setup_add_page (cata[17], book, setup_create_page (filexfer_settings));
+	setup_add_page (cata[18], book, setup_create_page (identd_settings));
 
 	gtk_notebook_set_show_tabs (GTK_NOTEBOOK (book), FALSE);
 	gtk_notebook_set_show_border (GTK_NOTEBOOK (book), FALSE);


### PR DESCRIPTION
This change adds a checkbox "Display plugin/extension load/unload messages" under Settings->preferences->Chatting->Developer (also a new section).

If the checkbox is unchecked, those startup messages (like "Perl interface loaded") will not show up.