### PR TITLE
Do not append to user variables CFLAGS and LDFLAGS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,6 @@
 ## Process this file with automake to produce Makefile.in
+AM_CFLAGS = @hexchat_def_CFLAGS@
+AM_LDFLAGS = @hexchat_def_LDFLAGS@
 
 ACLOCAL_AMFLAGS = -I m4
 

--- a/configure.ac
+++ b/configure.ac
@@ -631,19 +631,19 @@ AX_APPEND_COMPILE_FLAGS([\
 	-Werror=date-time \
 	-Werror=implicit-function-declaration \
 	-Werror=pointer-arith \
-])
+], hexchat_def_CFLAGS)
 
 AS_IF([test "$stack_protector" = "yes"], [
 	AX_APPEND_COMPILE_FLAGS([ \
 		-fstack-protector-strong \
-	])
+	], [hexchat_def_CFLAGS])
 ])
 
 AX_APPEND_LINK_FLAGS([ \
 	-pie \
 	-Wl,-z,relro \
 	-Wl,-z,now \
-])
+], [hexchat_def_LDFLAGS])
 
 dnl *********************************************************************
 dnl ** FUNCTIONS/LIBS/CFLAGS ********************************************
@@ -697,6 +697,8 @@ LIBS="$LIBS $INTLLIBS"
 GUI_LIBS="$GUI_LIBS $COMMON_LIBS"
 
 dnl make these visible to all Makefiles
+AC_SUBST(hexchat_def_CFLAGS)
+AC_SUBST(hexchat_def_LDFLAGS)
 AC_SUBST(GUI_LIBS)
 AC_SUBST(GUI_CFLAGS)
 AC_SUBST(COMMON_LIBS)

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -1,3 +1,6 @@
+AM_CFLAGS = @hexchat_def_CFLAGS@
+AM_LDFLAGS = @hexchat_def_LDFLAGS@
+
 SUBDIRS =
 
 if DO_PLUGIN

--- a/data/icons/Makefile.am
+++ b/data/icons/Makefile.am
@@ -1,3 +1,6 @@
+AM_CFLAGS = @hexchat_def_CFLAGS@
+AM_LDFLAGS = @hexchat_def_LDFLAGS@
+
 icon_DATA = hexchat.png
 icondir = $(datadir)/icons/hicolor/48x48/apps
 

--- a/data/man/Makefile.am
+++ b/data/man/Makefile.am
@@ -1,3 +1,6 @@
+AM_CFLAGS = @hexchat_def_CFLAGS@
+AM_LDFLAGS = @hexchat_def_LDFLAGS@
+
 man_MANS = hexchat.1
 
 EXTRA_DIST = hexchat.1.in

--- a/data/misc/Makefile.am
+++ b/data/misc/Makefile.am
@@ -1,3 +1,5 @@
+AM_CFLAGS = @hexchat_def_CFLAGS@
+AM_LDFLAGS = @hexchat_def_LDFLAGS@
 
 appdatadir = $(datadir)/appdata
 appdata_in_files =

--- a/data/pkgconfig/Makefile.am
+++ b/data/pkgconfig/Makefile.am
@@ -1,3 +1,6 @@
+AM_CFLAGS = @hexchat_def_CFLAGS@
+AM_LDFLAGS = @hexchat_def_LDFLAGS@
+
 pkgcfgdir = $(pkgconfigdir)
 pkgcfg_DATA = hexchat-plugin.pc
 

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -1,3 +1,6 @@
+AM_CFLAGS = @hexchat_def_CFLAGS@
+AM_LDFLAGS = @hexchat_def_LDFLAGS@
+
 if DO_LUA
 lua = lua
 endif

--- a/plugins/checksum/Makefile.am
+++ b/plugins/checksum/Makefile.am
@@ -1,8 +1,11 @@
+AM_CFLAGS = @hexchat_def_CFLAGS@
+AM_LDFLAGS = @hexchat_def_LDFLAGS@
+
 libdir = $(hexchatlibdir)
 
 lib_LTLIBRARIES = checksum.la
 checksum_la_SOURCES = checksum.c
-checksum_la_LDFLAGS = $(PLUGIN_LDFLAGS) -module
+checksum_la_LDFLAGS = $(PLUGIN_LDFLAGS) -module @hexchat_def_LDFLAGS@
 checksum_la_LIBADD = $(GLIB_LIBS)
 checksum_la_CPPFLAGS = -I$(top_srcdir)/src/common
-checksum_la_CFLAGS = $(GLIB_CFLAGS)
+checksum_la_CFLAGS = $(GLIB_CFLAGS) @hexchat_def_CFLAGS@

--- a/plugins/fishlim/Makefile.am
+++ b/plugins/fishlim/Makefile.am
@@ -1,10 +1,13 @@
+AM_CFLAGS = @hexchat_def_CFLAGS@
+AM_LDFLAGS = @hexchat_def_LDFLAGS@
+
 EXTRA_DIST = LICENSE fish.h irc.h keystore.h plugin_hexchat.h dh1080.h
 
 libdir = $(hexchatlibdir)
 
 lib_LTLIBRARIES = fishlim.la
 fishlim_la_SOURCES = fish.c irc.c keystore.c plugin_hexchat.c dh1080.c
-fishlim_la_LDFLAGS = $(PLUGIN_LDFLAGS) -module
+fishlim_la_LDFLAGS = $(PLUGIN_LDFLAGS) -module @hexchat_def_LDFLAGS@
 fishlim_la_LIBADD = $(GLIB_LIBS) $(OPENSSL_LIBS)
 fishlim_la_CPPFLAGS = -I$(top_srcdir)/src/common
-fishlim_la_CFLAGS = $(GLIB_CFLAGS) $(OPENSSL_CFLAGS)
+fishlim_la_CFLAGS = $(GLIB_CFLAGS) $(OPENSSL_CFLAGS) @hexchat_def_CFLAGS@

--- a/plugins/lua/Makefile.am
+++ b/plugins/lua/Makefile.am
@@ -1,9 +1,12 @@
+AM_CFLAGS = @hexchat_def_CFLAGS@
+AM_LDFLAGS = @hexchat_def_LDFLAGS@
+
 libdir = $(hexchatlibdir)
 
 lib_LTLIBRARIES = lua.la
 lua_la_SOURCES = lua.c
-lua_la_LDFLAGS = $(PLUGIN_LDFLAGS) -module
+lua_la_LDFLAGS = $(PLUGIN_LDFLAGS) -module @hexchat_def_LDFLAGS@
 lua_la_LIBADD = $(LUA_LIBS) $(GLIB_LIBS)
 lua_la_CPPFLAGS = -I$(top_srcdir)/src/common
-lua_la_CFLAGS = $(GLIB_CFLAGS) $(LUA_CFLAGS)
+lua_la_CFLAGS = $(GLIB_CFLAGS) $(LUA_CFLAGS) @hexchat_def_CFLAGS@
 

--- a/plugins/perl/Makefile.am
+++ b/plugins/perl/Makefile.am
@@ -1,3 +1,5 @@
+AM_CFLAGS = @hexchat_def_CFLAGS@
+AM_LDFLAGS = @hexchat_def_LDFLAGS@
 
 EXTRA_DIST=generate_header lib/HexChat.pm lib/Xchat.pm lib/HexChat/Embed.pm lib/HexChat/List/Network.pm \
 	lib/HexChat/List/Network/Entry.pm lib/HexChat/List/Network/AutoJoin.pm lib/IRC.pm
@@ -6,10 +8,10 @@ libdir = $(hexchatlibdir)
 
 lib_LTLIBRARIES = perl.la
 perl_la_SOURCES = perl.c
-perl_la_LDFLAGS = $(PERL_LDFLAGS) $(PLUGIN_LDFLAGS) -module
+perl_la_LDFLAGS = $(PERL_LDFLAGS) $(PLUGIN_LDFLAGS) -module @hexchat_def_LDFLAGS@
 perl_la_LIBADD = $(GLIB_LIBS)
 perl_la_CPPFLAGS = -I$(top_srcdir)/src/common
-perl_la_CFLAGS = $(PERL_CFLAGS) $(GLIB_CFLAGS)
+perl_la_CFLAGS = $(PERL_CFLAGS) $(GLIB_CFLAGS) @hexchat_def_CFLAGS@
 
 BUILT_SOURCES = hexchat.pm.h irc.pm.h
 CLEANFILES = $(BUILT_SOURCES)

--- a/plugins/python/Makefile.am
+++ b/plugins/python/Makefile.am
@@ -1,9 +1,12 @@
+AM_CFLAGS = @hexchat_def_CFLAGS@
+AM_LDFLAGS = @hexchat_def_LDFLAGS@
+
 libdir = $(hexchatlibdir)
 
 lib_LTLIBRARIES = python.la
 python_la_SOURCES = python.c
 python_la_LDFLAGS = $(PLUGIN_LDFLAGS) -module
-python_la_LIBADD = $(PYTHON_LIBS) $(GLIB_LIBS)
+python_la_LIBADD = $(PYTHON_LIBS) $(GLIB_LIBS) @hexchat_def_LDFLAGS@
 python_la_CPPFLAGS = -I$(top_srcdir)/src/common $(PYTHON_CPPFLAGS)
-python_la_CFLAGS = $(GLIB_CFLAGS)
+python_la_CFLAGS = $(GLIB_CFLAGS) @hexchat_def_CFLAGS@
 

--- a/plugins/sysinfo/Makefile.am
+++ b/plugins/sysinfo/Makefile.am
@@ -1,3 +1,6 @@
+AM_CFLAGS = @hexchat_def_CFLAGS@
+AM_LDFLAGS = @hexchat_def_LDFLAGS@
+
 libdir = $(hexchatlibdir)
 
 sources = sysinfo.c format.c shared/df.c
@@ -12,6 +15,6 @@ EXTRA_DIST = osx unix win32 shared format.h sysinfo.h sysinfo-backend.h
 
 lib_LTLIBRARIES = sysinfo.la
 sysinfo_la_SOURCES = $(sources)
-sysinfo_la_LDFLAGS = $(PLUGIN_LDFLAGS) -module
+sysinfo_la_LDFLAGS = $(PLUGIN_LDFLAGS) -module @hexchat_def_LDFLAGS@
 sysinfo_la_LIBADD = $(LIBPCI_LIBS) $(GLIB_LIBS)
 AM_CPPFLAGS = -I$(top_srcdir)/src/common -I$(srcdir)/shared $(LIBPCI_CFLAGS) $(GLIB_CFLAGS)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,6 @@
 ## Process this file with automake to produce Makefile.in
+AM_CFLAGS = @hexchat_def_CFLAGS@
+AM_LDFLAGS = @hexchat_def_LDFLAGS@
 
 EXTRA_DIST = version-script
 

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -1,4 +1,6 @@
 ## Process this file with automake to produce Makefile.in
+AM_CFLAGS = @hexchat_def_CFLAGS@
+AM_LDFLAGS = @hexchat_def_LDFLAGS@
 
 include $(top_srcdir)/m4/clang-analyze.am
 
@@ -64,7 +66,7 @@ libhexchatcommon_a_SOURCES = cfgfiles.c chanopt.c ctcp.c dcc.c hexchat.c \
 	history.c ignore.c inbound.c marshal.c modes.c network.c notify.c \
 	outbound.c plugin.c plugin-identd.c plugin-timer.c proto-irc.c server.c servlist.c \
 	$(ssl_c) text.c tree.c url.c userlist.c util.c
-libhexchatcommon_a_CFLAGS = $(LIBPROXY_CFLAGS)
+libhexchatcommon_a_CFLAGS = $(LIBPROXY_CFLAGS) $(hexchat_def_CFLAGS)
 
 textenums.h: textevents.h
 

--- a/src/common/dbus/Makefile.am
+++ b/src/common/dbus/Makefile.am
@@ -1,3 +1,6 @@
+AM_CFLAGS = @hexchat_def_CFLAGS@
+AM_LDFLAGS = @hexchat_def_LDFLAGS@
+
 noinst_LIBRARIES = libhexchatdbus.a
 libhexchatdbus_a_SOURCES =			\
 	dbus-plugin.c				\

--- a/src/fe-gtk/Makefile.am
+++ b/src/fe-gtk/Makefile.am
@@ -1,3 +1,5 @@
+AM_CFLAGS = @hexchat_def_CFLAGS@
+AM_LDFLAGS = @hexchat_def_LDFLAGS@
 
 include $(top_srcdir)/m4/clang-analyze.am
 
@@ -33,7 +35,7 @@ notify_c = notifications/notification-libnotify.c
 else
 if HAVE_GTK_MAC
 notify_c = notifications/notification-osx.m
-hexchat_LDFLAGS = -framework Foundation
+hexchat_LDFLAGS = -framework Foundation @hexchat_def_LDFLAGS@
 else
 notify_c = notifications/notification-dummy.c
 endif

--- a/src/fe-text/Makefile.am
+++ b/src/fe-text/Makefile.am
@@ -1,3 +1,6 @@
+AM_CFLAGS = @hexchat_def_CFLAGS@
+AM_LDFLAGS = @hexchat_def_LDFLAGS@
+
 localedir = $(datadir)/locale
 
 bin_PROGRAMS = hexchat-text

--- a/src/htm/Makefile.am
+++ b/src/htm/Makefile.am
@@ -1,3 +1,6 @@
+AM_CFLAGS = @hexchat_def_CFLAGS@
+AM_LDFLAGS = @hexchat_def_LDFLAGS@
+
 theme_SCRIPTS = thememan.exe thememan
 themedir = $(bindir)
 


### PR DESCRIPTION
Per GNU automake documentation recommendations, user variables should
not be appended to.  This allows the user final say over the
configuration without removing compiler flags needed to properly build
hexchat.

To properly follow this recommendation, hexchat_def_CFLAGS and
hexchat_def_LDFLAGS are defined and populated with the flags that were
previously appended CFLAGS and LDFLAGS.  AM_CFLAGS and AM_LDFLAGS along
with the various "mumble_CFLAGS" and "mumble_LDFLAGS" are updated to use
the hexchat_def_CFLAGS and hexchat_def_LDFLAGS.  The end result is that
any user building hexchat can now set CFLAGS and LDFLAGS to control the
build.