### PR TITLE
Respect browser settings regarding new window creation for the default url handler

### DIFF
--- a/src/common/hexchat.c
+++ b/src/common/hexchat.c
@@ -768,7 +768,7 @@ static char defaultconf_commands[] =
 	"NAME WII\n"			"CMD quote WHOIS %2 %2\n\n";
 
 static char defaultconf_urlhandlers[] =
-		"NAME Open Link in a new Firefox Window\n"		"CMD !firefox -new-window %s\n\n";
+		"NAME Open Link in a new Firefox Window\n"		"CMD !firefox -url %s\n\n";
 
 #ifdef USE_SIGACTION
 /* Close and open log files on SIGUSR1. Usefull for log rotating */


### PR DESCRIPTION
When `-new-window` is used sometimes Firefox won't start on Windows, or the url is not opened in an already running browser instance. Removing the option fixes this bug, and also ensures that browser settings for opening new urls in a new tab or window are respected.

https://developer.mozilla.org/en-US/docs/Mozilla/Command_Line_Options#-url_URL