### PR TITLE
Always keep the scrollbar at the bottom if it was before

### DIFF
--- a/src/fe-gtk/xtext.c
+++ b/src/fe-gtk/xtext.c
@@ -4962,6 +4962,14 @@ gtk_xtext_buffer_show (GtkXText *xtext, xtext_buffer *buf, int render)
 	dontscroll (buf);	/* force scrolling off */
 	xtext->adj->value = buf->old_value;
 	xtext->adj->upper = buf->num_lines;
+
+	/* if the scrollbar was down, keep it down */
+	if (xtext->buffer->scrollbar_down && xtext->adj->value <
+		xtext->adj->upper - xtext->adj->page_size)
+	{
+		xtext->adj->value = xtext->adj->upper - xtext->adj->page_size;
+	}
+
 	if (xtext->adj->upper == 0)
 		xtext->adj->upper = 1;
 	/* sanity check */


### PR DESCRIPTION
This patch hopefully solves a bug that causes that when a tab (channel or private) is left with the scrollbar at the bottom, and some new text arrives, and then we select again that tab, sometimes the scrollbar is not completely down and there is hidden text and we have to scroll manually to the bottom to show all text.
This was previously submitted as an issue in: https://github.com/hexchat/hexchat/issues/1948
Maybe it isn't the ideal way to solve it, but at least I tested it and it seems to work.