### PR TITLE
Removed ctrl+w keybinding

### DIFF
--- a/src/fe-gtk/menu.c
+++ b/src/fe-gtk/menu.c
@@ -1761,7 +1761,7 @@ static struct mymenu mymenu[] = {
 #define DETACH_OFFSET (12)
 	{0, menu_detach, GTK_STOCK_REDO, M_MENUSTOCK, 0, 0, 1},	/* 12 */
 #define CLOSE_OFFSET (13)
-	{0, menu_close, GTK_STOCK_CLOSE, M_MENUSTOCK, 0, 0, 1, GDK_KEY_w},
+	{0, menu_close, GTK_STOCK_CLOSE, M_MENUSTOCK, 0, 0, 1},
 	{0, 0, 0, M_SEP, 0, 0, 0},
 	{N_("_Quit"), menu_quit, GTK_STOCK_QUIT, M_MENUSTOCK, 0, 0, 1, GDK_KEY_q},	/* 15 */
 


### PR DESCRIPTION
Multiple of my friends and I are big HexChat users and we always run into the issue of hitting ctrl+w accidentally (same shortcut as closing a browser window) as we misjudge the current in-focus window. As a result, many annoyances were shed. 

It seems like many other users share this gripe as well: https://github.com/hexchat/hexchat/issues/397

I understand better key-binding optimization may or may not come, so the proposal here is to disable it as a behavior overall. Perhaps when better key-binding customization is supported, users can choose themselves whether or not to enable this shortcut. 

Note this has nothing to do with the ctrl+q behavior.