### PR TITLE
Fix email address pattern, it can starts with digit

### DIFF
--- a/src/common/url.c
+++ b/src/common/url.c
@@ -601,7 +601,7 @@ re_url (void)
 }
 
 /*	EMAIL description --- */
-#define EMAIL "[a-z][._%+-a-z0-9]+@" "(" HOST_URL ")"
+#define EMAIL "[a-z0-9][._%+-a-z0-9]+@" "(" HOST_URL ")"
 
 static const GRegex *
 re_email (void)


### PR DESCRIPTION
I can't found any documents about "email address can not starts with digit".  And in the real world, email address that starts with digit is widely used (such as qq mail provided by Tencent).