### PR TITLE
Fix key exchange and decrypting private messages

### DIFF
--- a/plugins/fishlim/dh1080.c
+++ b/plugins/fishlim/dh1080.c
@@ -189,6 +189,7 @@ dh1080_compute_key (const char *priv_key, const char *pub_key, char **secret_key
 	char *pub_key_data;
 	gsize pub_key_len;
 	BIGNUM *pk;
+	BIGNUM *temp_pub_key = BN_new();
 	DH *dh;
 
   	g_assert (secret_key != NULL);
@@ -217,7 +218,7 @@ dh1080_compute_key (const char *priv_key, const char *pub_key, char **secret_key
 #ifndef HAVE_DH_SET0_KEY
 		dh->priv_key = priv_key_num;
 #else
-		DH_set0_key (dh, NULL, priv_key_num);
+		DH_set0_key (dh, temp_pub_key, priv_key_num);
 #endif
 
 		shared_len = DH_compute_key (shared_key, pk, dh);

--- a/plugins/fishlim/plugin_hexchat.c
+++ b/plugins/fishlim/plugin_hexchat.c
@@ -138,7 +138,7 @@ static int handle_outgoing(char *word[], char *word_eol[], void *userdata) {
 static int handle_incoming(char *word[], char *word_eol[], hexchat_event_attrs *attrs, void *userdata) {
     const char *prefix;
     const char *command;
-    const char *recipient;
+    const char *channel = hexchat_get_info(ph, "channel");
     const char *encrypted;
     const char *peice;
     char *sender_nick;
@@ -166,11 +166,10 @@ static int handle_incoming(char *word[], char *word_eol[], hexchat_event_attrs *
   has_encrypted_data: ;
     /* Extract sender nick and recipient nick/channel */
     sender_nick = irc_prefix_get_nick(prefix);
-    recipient = word[w];
     
     /* Try to decrypt with these (the keys are searched for in the key store) */
     encrypted = word[ew+1];
-    decrypted = fish_decrypt_from_nick(recipient, encrypted);
+    decrypted = fish_decrypt_from_nick(channel, encrypted);
     if (!decrypted) decrypted = fish_decrypt_from_nick(sender_nick, encrypted);
     
     /* Check for error */


### PR DESCRIPTION
Clients will recieve the proper shared secret.

Eliminates error message:
SSL_read: error:05066064:Diffie-Hellman routines:compute_key:no private value

Decrypts private messages with the proper nick, and channel decryption has higher priority.