### PR TITLE
Add editorconfig, describing what indenting style to use.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*.{c,cpp,h,hpp,m}]
+indent_style = tab
+indent_size = 4
+end_of_line = lf
+
+[*.cs]
+indent_style = space
+indent_size = 4
+end_of_line = lf


### PR DESCRIPTION
This allows multiple editors (see http://editorconfig.org/ for the full list) to automatically use the correct indenting style.