### PR TITLE
servlist: skip empty lines.

### DIFF
--- a/src/common/servlist.c
+++ b/src/common/servlist.c
@@ -1005,6 +1005,8 @@ servlist_load (void)
 	while (fgets (buf, sizeof (buf) - 2, fp))
 	{
 		len = strlen (buf);
+		if (!len)
+			continue;
 		buf[len] = 0;
 		buf[len-1] = 0;	/* remove the trailing \n */
 		if (net)


### PR DESCRIPTION
Should fix out of range from #1999