### PR TITLE
Fixed issue #1451

### DIFF
--- a/src/common/hexchat.h
+++ b/src/common/hexchat.h
@@ -359,6 +359,12 @@ typedef enum {
 	TAB_STATE_NEW_HILIGHT = (1 << 2),
 } tab_state_flags;
 
+typedef enum { //Works with gtkutil_window_new()
+	START_WINDOWED = 0,
+	START_ICONIFIED = 4,
+	START_ON_TRAY = 8,
+} start_type;
+
 typedef struct session
 {
 	/* Per-Channel Alerts */
@@ -419,6 +425,7 @@ typedef struct session
 	int end_of_names:1;
 	int doing_who:1;		/* /who sent on this channel */
 	int done_away_check:1;	/* done checking for away status changes */
+	start_type start_state;
 	tab_state_flags tab_state;
 	tab_state_flags last_tab_state; /* before event is handled */
 	gtk_xtext_search_flags lastlog_flags;

--- a/src/fe-gtk/chanview-tree.c
+++ b/src/fe-gtk/chanview-tree.c
@@ -264,7 +264,8 @@ cv_tree_focus (chan *ch)
 			dest_y = cell_rect.y - ((vis_rect.height - cell_rect.height) * 0.5);
 			if (dest_y < 0)
 				dest_y = 0;
-			gtk_tree_view_scroll_to_point (tree, -1, dest_y);
+			if (gtk_widget_get_realized( GTK_WIDGET (tree) )) //When Hexchat is started with the flag --minimize=2, Fixes Gtk-CRITICAL **: IA__gtk_tree_view_scroll_to_point: assertion 'gtk_widget_get_realized (GTK_WIDGET (tree_view))' failed
+				gtk_tree_view_scroll_to_point (tree, -1, dest_y);
 		}
 		/* theft done, now make it focused like */
 		gtk_tree_view_set_cursor (tree, path, NULL, FALSE);

--- a/src/fe-gtk/gtkutil.c
+++ b/src/fe-gtk/gtkutil.c
@@ -25,6 +25,7 @@
 #include <fcntl.h>
 
 #include "fe-gtk.h"
+#include "plugin-tray.h"
 
 #include <gdk/gdkkeysyms.h>
 #if defined (WIN32) || defined (__APPLE__)
@@ -598,6 +599,10 @@ gtkutil_window_new (char *title, char *role, int width, int height, int flags)
 		gtk_window_set_transient_for (GTK_WINDOW (win), GTK_WINDOW (parent_window));
 		gtk_window_set_destroy_with_parent (GTK_WINDOW (win), TRUE);
 	}
+	if (flags & START_ICONIFIED)
+		gtk_window_iconify (GTK_WINDOW (win));
+	else if (flags & START_ON_TRAY)
+		tray_toggle_visibility_win (win, TRUE);
 
 	return win;
 }

--- a/src/fe-gtk/maingui.c
+++ b/src/fe-gtk/maingui.c
@@ -3097,11 +3097,11 @@ mg_create_topwindow (session *sess)
 
 	if (sess->type == SESS_DIALOG)
 		win = gtkutil_window_new ("HexChat", NULL,
-										  prefs.hex_gui_dialog_width, prefs.hex_gui_dialog_height, 0);
+										  prefs.hex_gui_dialog_width, prefs.hex_gui_dialog_height, sess->start_state);
 	else
 		win = gtkutil_window_new ("HexChat", NULL,
 										  prefs.hex_gui_win_width,
-										  prefs.hex_gui_win_height, 0);
+										  prefs.hex_gui_win_height, sess->start_state);
 	sess->gui->window = win;
 	gtk_container_set_border_width (GTK_CONTAINER (win), GUI_BORDER);
 	gtk_window_set_opacity (GTK_WINDOW (win), (prefs.hex_gui_transparency / 255.));
@@ -3168,7 +3168,8 @@ mg_create_topwindow (session *sess)
 
 	mg_place_userlist_and_chanview (sess->gui);
 
-	gtk_widget_show (win);
+	if(sess->start_state!=START_ON_TRAY)
+		gtk_widget_show (win);
 }
 
 static gboolean
@@ -3201,7 +3202,7 @@ mg_create_tabwindow (session *sess)
 	GtkWidget *table;
 
 	win = gtkutil_window_new ("HexChat", NULL, prefs.hex_gui_win_width,
-									  prefs.hex_gui_win_height, 0);
+									  prefs.hex_gui_win_height, sess->start_state);
 	sess->gui->window = win;
 	gtk_window_move (GTK_WINDOW (win), prefs.hex_gui_win_left,
 						  prefs.hex_gui_win_top);
@@ -3262,7 +3263,8 @@ mg_create_tabwindow (session *sess)
 
 	mg_place_userlist_and_chanview (sess->gui);
 
-	gtk_widget_show (win);
+	if(sess->start_state!=START_ON_TRAY)
+		gtk_widget_show (win);
 }
 
 void

--- a/src/fe-gtk/plugin-tray.c
+++ b/src/fe-gtk/plugin-tray.c
@@ -315,21 +315,18 @@ fe_tray_set_file (const char *filename)
 }
 
 gboolean
-tray_toggle_visibility (gboolean force_hide)
+tray_toggle_visibility_win (GtkWindow *win, gboolean force_hide)
 {
 	static int x, y;
 	static GdkScreen *screen;
 	static int maximized;
 	static int fullscreen;
-	GtkWindow *win;
 
 	if (!sticon)
 		return FALSE;
 
 	/* ph may have an invalid context now */
 	hexchat_set_context (ph, hexchat_find_context (ph, NULL, NULL));
-
-	win = GTK_WINDOW (hexchat_get_info (ph, "gtkwin_ptr"));
 
 	tray_stop_flash ();
 	tray_reset_counts ();
@@ -362,6 +359,16 @@ tray_toggle_visibility (gboolean force_hide)
 	}
 
 	return TRUE;
+}
+
+gboolean
+tray_toggle_visibility (gboolean force_hide)
+{
+	GtkWindow *win;
+	win = GTK_WINDOW (hexchat_get_info (ph, "gtkwin_ptr"));
+	if (!win)
+		return FALSE;
+	return tray_toggle_visibility_win(win, force_hide);
 }
 
 static void

--- a/src/fe-gtk/plugin-tray.h
+++ b/src/fe-gtk/plugin-tray.h
@@ -23,6 +23,7 @@
 int tray_plugin_init (void *, char **, char **, char **, char *);
 int tray_plugin_deinit (void *);
 gboolean tray_toggle_visibility (gboolean force_hide);
+gboolean tray_toggle_visibility_win (GtkWindow *win, gboolean force_hide);
 void tray_apply_setup (void);
 
 #endif


### PR DESCRIPTION
When --minimize flag is specified in HexChat execution command, its window now minimizes right after it starts.

In the past, the Hexchat window often did not minimize until it finishes joining the network.