### PR TITLE
Change windows from starting with "Hexchat: " to ending with " - Hexchat"

### DIFF
--- a/po/af.po
+++ b/po/af.po
@@ -3238,7 +3238,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
+msgid "Ban List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3277,7 +3277,7 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
+msgid "Channel List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3369,7 +3369,7 @@ msgid "Cannot resume the same file from two people."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
+msgid "Uploads and Downloads - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3427,7 +3427,7 @@ msgid "Open Folder..."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
+msgid "DCC Chat List - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3624,7 +3624,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
+msgid "Keyboard Shortcuts - "
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3669,7 +3669,7 @@ msgid "Enter mask to ignore:"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
+msgid "Ignore list - "
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3705,7 +3705,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
+msgid "Connection Complete - "
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4032,7 +4032,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
+msgid "User menu - "
 msgstr ""
 
 #. sep
@@ -4153,11 +4153,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
+msgid "User Defined Commands - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
+msgid "Userlist Popup menu - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4165,23 +4165,23 @@ msgid "Replace with"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
+msgid "Replace - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
+msgid "URL Handlers - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
+msgid "Userlist buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
+msgid "Dialog buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
+msgid "CTCP Replies - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4489,7 +4489,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
+msgid "Friends List - "
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4528,7 +4528,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
+msgid "Connected to %u networks and %u channels - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4570,42 +4570,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
+msgid "Private message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
+msgid "File offer from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4621,7 +4621,7 @@ msgid "Select a Plugin or Script to load"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
+msgid "Plugins and Scripts - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4643,7 +4643,7 @@ msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4679,7 +4679,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
+msgid "Edit %s - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4771,7 +4771,7 @@ msgid "Character set:"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
+msgid "Network List - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6136,7 +6136,7 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
+msgid "Preferences - "
 msgstr ""
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6201,7 +6201,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
+msgid "URL Grabber - "
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/af.po
+++ b/po/af.po
@@ -3238,7 +3238,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
+msgid "Ban List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3277,7 +3277,7 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
+msgid "Channel List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3369,7 +3369,7 @@ msgid "Cannot resume the same file from two people."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
+msgid "Uploads and Downloads - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3427,7 +3427,7 @@ msgid "Open Folder..."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
+msgid "DCC Chat List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3624,7 +3624,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
+msgid "Keyboard Shortcuts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3669,7 +3669,7 @@ msgid "Enter mask to ignore:"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
+msgid "Ignore list - %s"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3705,7 +3705,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
+msgid "Connection Complete - %s"
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4032,7 +4032,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
+msgid "User menu - %s"
 msgstr ""
 
 #. sep
@@ -4153,11 +4153,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
+msgid "User Defined Commands - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
+msgid "Userlist Popup menu - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4165,23 +4165,23 @@ msgid "Replace with"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
+msgid "Replace - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
+msgid "URL Handlers - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
+msgid "Userlist buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
+msgid "Dialog buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
+msgid "CTCP Replies - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4489,7 +4489,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
+msgid "Friends List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4528,7 +4528,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
+msgid "Connected to %u networks and %u channels - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4570,42 +4570,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4621,7 +4621,7 @@ msgid "Select a Plugin or Script to load"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
+msgid "Plugins and Scripts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4643,7 +4643,7 @@ msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4679,7 +4679,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
+msgid "Edit %s - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4771,7 +4771,7 @@ msgid "Character set:"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
+msgid "Network List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6136,7 +6136,7 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
+msgid "Preferences - %s"
 msgstr ""
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6201,7 +6201,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
+msgid "URL Grabber - %s"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/am.po
+++ b/po/am.po
@@ -3238,7 +3238,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
+msgid "Ban List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3277,7 +3277,7 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
+msgid "Channel List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3369,7 +3369,7 @@ msgid "Cannot resume the same file from two people."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
+msgid "Uploads and Downloads - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3427,7 +3427,7 @@ msgid "Open Folder..."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
+msgid "DCC Chat List - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3624,7 +3624,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
+msgid "Keyboard Shortcuts - "
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3669,7 +3669,7 @@ msgid "Enter mask to ignore:"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
+msgid "Ignore list - "
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3705,7 +3705,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
+msgid "Connection Complete - "
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4032,7 +4032,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
+msgid "User menu - "
 msgstr ""
 
 #. sep
@@ -4153,11 +4153,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
+msgid "User Defined Commands - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
+msgid "Userlist Popup menu - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4165,23 +4165,23 @@ msgid "Replace with"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
+msgid "Replace - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
+msgid "URL Handlers - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
+msgid "Userlist buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
+msgid "Dialog buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
+msgid "CTCP Replies - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4489,7 +4489,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
+msgid "Friends List - "
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4528,7 +4528,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
+msgid "Connected to %u networks and %u channels - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4570,42 +4570,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
+msgid "Private message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
+msgid "File offer from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4621,7 +4621,7 @@ msgid "Select a Plugin or Script to load"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
+msgid "Plugins and Scripts - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4643,7 +4643,7 @@ msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4679,7 +4679,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
+msgid "Edit %s - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4771,7 +4771,7 @@ msgid "Character set:"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
+msgid "Network List - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6136,7 +6136,7 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
+msgid "Preferences - "
 msgstr ""
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6201,7 +6201,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
+msgid "URL Grabber - "
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/am.po
+++ b/po/am.po
@@ -3238,7 +3238,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
+msgid "Ban List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3277,7 +3277,7 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
+msgid "Channel List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3369,7 +3369,7 @@ msgid "Cannot resume the same file from two people."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
+msgid "Uploads and Downloads - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3427,7 +3427,7 @@ msgid "Open Folder..."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
+msgid "DCC Chat List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3624,7 +3624,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
+msgid "Keyboard Shortcuts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3669,7 +3669,7 @@ msgid "Enter mask to ignore:"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
+msgid "Ignore list - %s"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3705,7 +3705,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
+msgid "Connection Complete - %s"
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4032,7 +4032,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
+msgid "User menu - %s"
 msgstr ""
 
 #. sep
@@ -4153,11 +4153,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
+msgid "User Defined Commands - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
+msgid "Userlist Popup menu - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4165,23 +4165,23 @@ msgid "Replace with"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
+msgid "Replace - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
+msgid "URL Handlers - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
+msgid "Userlist buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
+msgid "Dialog buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
+msgid "CTCP Replies - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4489,7 +4489,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
+msgid "Friends List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4528,7 +4528,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
+msgid "Connected to %u networks and %u channels - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4570,42 +4570,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4621,7 +4621,7 @@ msgid "Select a Plugin or Script to load"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
+msgid "Plugins and Scripts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4643,7 +4643,7 @@ msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4679,7 +4679,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
+msgid "Edit %s - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4771,7 +4771,7 @@ msgid "Character set:"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
+msgid "Network List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6136,7 +6136,7 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
+msgid "Preferences - %s"
 msgstr ""
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6201,7 +6201,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
+msgid "URL Grabber - %s"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/ast.po
+++ b/po/ast.po
@@ -3238,7 +3238,7 @@ msgstr "Namái pues abrir la llista de baneaos mentanto hai llingüeta de canal.
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
+msgid "Ban List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3277,7 +3277,7 @@ msgstr "Copiar Testu _Tema"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
+msgid "Channel List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3369,7 +3369,7 @@ msgid "Cannot resume the same file from two people."
 msgstr "Nun puede retomase'l mesmu ficheru de dos persones."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
+msgid "Uploads and Downloads - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3427,7 +3427,7 @@ msgid "Open Folder..."
 msgstr "Abrir carpeta..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
+msgid "DCC Chat List - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3624,7 +3624,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
+msgid "Keyboard Shortcuts - "
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3669,7 +3669,7 @@ msgid "Enter mask to ignore:"
 msgstr "Introduz la mázcara que quies inorar:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
+msgid "Ignore list - "
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3705,7 +3705,7 @@ msgid "Channel name too short, try again."
 msgstr "Nome de canal enforma curtiu, intenta de nuevu."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
+msgid "Connection Complete - "
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4032,7 +4032,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
+msgid "User menu - "
 msgstr ""
 
 #. sep
@@ -4153,11 +4153,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
+msgid "User Defined Commands - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
+msgid "Userlist Popup menu - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4165,23 +4165,23 @@ msgid "Replace with"
 msgstr "Camudar con"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
+msgid "Replace - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
+msgid "URL Handlers - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
+msgid "Userlist buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
+msgid "Dialog buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
+msgid "CTCP Replies - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4489,7 +4489,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Acéutase una coma como separtador na llista de redes."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
+msgid "Friends List - "
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4528,7 +4528,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
+msgid "Connected to %u networks and %u channels - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4570,42 +4570,42 @@ msgstr "_P'atrás"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
+msgid "Private message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
+msgid "File offer from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4621,7 +4621,7 @@ msgid "Select a Plugin or Script to load"
 msgstr "Escueyi una estensión o guión a cargar"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
+msgid "Plugins and Scripts - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4643,7 +4643,7 @@ msgstr "Guardar como..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4679,7 +4679,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
+msgid "Edit %s - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4771,7 +4771,7 @@ msgid "Character set:"
 msgstr "Xuegu de caráuteres:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
+msgid "Network List - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6136,7 +6136,7 @@ msgid ""
 msgstr "*ALVERTENCIA*\nAceutar automáticamente DCC haza'l to direutoriu d'aniciu\npue ser peligroso y ye esplotable. Por exemplu: Dalguien \npue unviate un ficheru .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
+msgid "Preferences - "
 msgstr ""
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6201,7 +6201,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
+msgid "URL Grabber - "
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/ast.po
+++ b/po/ast.po
@@ -3238,7 +3238,7 @@ msgstr "Namái pues abrir la llista de baneaos mentanto hai llingüeta de canal.
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
+msgid "Ban List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3277,7 +3277,7 @@ msgstr "Copiar Testu _Tema"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
+msgid "Channel List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3369,7 +3369,7 @@ msgid "Cannot resume the same file from two people."
 msgstr "Nun puede retomase'l mesmu ficheru de dos persones."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
+msgid "Uploads and Downloads - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3427,7 +3427,7 @@ msgid "Open Folder..."
 msgstr "Abrir carpeta..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
+msgid "DCC Chat List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3624,7 +3624,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
+msgid "Keyboard Shortcuts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3669,7 +3669,7 @@ msgid "Enter mask to ignore:"
 msgstr "Introduz la mázcara que quies inorar:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
+msgid "Ignore list - %s"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3705,7 +3705,7 @@ msgid "Channel name too short, try again."
 msgstr "Nome de canal enforma curtiu, intenta de nuevu."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
+msgid "Connection Complete - %s"
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4032,7 +4032,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
+msgid "User menu - %s"
 msgstr ""
 
 #. sep
@@ -4153,11 +4153,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
+msgid "User Defined Commands - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
+msgid "Userlist Popup menu - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4165,23 +4165,23 @@ msgid "Replace with"
 msgstr "Camudar con"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
+msgid "Replace - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
+msgid "URL Handlers - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
+msgid "Userlist buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
+msgid "Dialog buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
+msgid "CTCP Replies - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4489,7 +4489,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Acéutase una coma como separtador na llista de redes."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
+msgid "Friends List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4528,7 +4528,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
+msgid "Connected to %u networks and %u channels - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4570,42 +4570,42 @@ msgstr "_P'atrás"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4621,7 +4621,7 @@ msgid "Select a Plugin or Script to load"
 msgstr "Escueyi una estensión o guión a cargar"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
+msgid "Plugins and Scripts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4643,7 +4643,7 @@ msgstr "Guardar como..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4679,7 +4679,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
+msgid "Edit %s - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4771,7 +4771,7 @@ msgid "Character set:"
 msgstr "Xuegu de caráuteres:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
+msgid "Network List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6136,7 +6136,7 @@ msgid ""
 msgstr "*ALVERTENCIA*\nAceutar automáticamente DCC haza'l to direutoriu d'aniciu\npue ser peligroso y ye esplotable. Por exemplu: Dalguien \npue unviate un ficheru .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
+msgid "Preferences - %s"
 msgstr ""
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6201,7 +6201,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
+msgid "URL Grabber - %s"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/az.po
+++ b/po/az.po
@@ -3238,7 +3238,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
+msgid "Ban List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3277,7 +3277,7 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
+msgid "Channel List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3369,7 +3369,7 @@ msgid "Cannot resume the same file from two people."
 msgstr "Eyni fayl iki nəfərdən davam etdirilə bilməz."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
+msgid "Uploads and Downloads - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3427,7 +3427,7 @@ msgid "Open Folder..."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
+msgid "DCC Chat List - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3624,7 +3624,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
+msgid "Keyboard Shortcuts - "
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3669,7 +3669,7 @@ msgid "Enter mask to ignore:"
 msgstr "Rədd ediləcək maskanı bildir:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
+msgid "Ignore list - "
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3705,7 +3705,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
+msgid "Connection Complete - "
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4032,7 +4032,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
+msgid "User menu - "
 msgstr ""
 
 #. sep
@@ -4153,11 +4153,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
+msgid "User Defined Commands - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
+msgid "Userlist Popup menu - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4165,23 +4165,23 @@ msgid "Replace with"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
+msgid "Replace - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
+msgid "URL Handlers - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
+msgid "Userlist buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
+msgid "Dialog buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
+msgid "CTCP Replies - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4489,7 +4489,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
+msgid "Friends List - "
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4528,7 +4528,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
+msgid "Connected to %u networks and %u channels - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4570,42 +4570,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
+msgid "Private message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
+msgid "File offer from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4621,7 +4621,7 @@ msgid "Select a Plugin or Script to load"
 msgstr "Yüklənəcək Əlavə ya da Skripti Seç"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
+msgid "Plugins and Scripts - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4643,7 +4643,7 @@ msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4679,7 +4679,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
+msgid "Edit %s - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4771,7 +4771,7 @@ msgid "Character set:"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
+msgid "Network List - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6136,7 +6136,7 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
+msgid "Preferences - "
 msgstr ""
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6201,7 +6201,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
+msgid "URL Grabber - "
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/az.po
+++ b/po/az.po
@@ -3238,7 +3238,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
+msgid "Ban List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3277,7 +3277,7 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
+msgid "Channel List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3369,7 +3369,7 @@ msgid "Cannot resume the same file from two people."
 msgstr "Eyni fayl iki nəfərdən davam etdirilə bilməz."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
+msgid "Uploads and Downloads - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3427,7 +3427,7 @@ msgid "Open Folder..."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
+msgid "DCC Chat List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3624,7 +3624,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
+msgid "Keyboard Shortcuts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3669,7 +3669,7 @@ msgid "Enter mask to ignore:"
 msgstr "Rədd ediləcək maskanı bildir:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
+msgid "Ignore list - %s"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3705,7 +3705,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
+msgid "Connection Complete - %s"
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4032,7 +4032,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
+msgid "User menu - %s"
 msgstr ""
 
 #. sep
@@ -4153,11 +4153,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
+msgid "User Defined Commands - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
+msgid "Userlist Popup menu - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4165,23 +4165,23 @@ msgid "Replace with"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
+msgid "Replace - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
+msgid "URL Handlers - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
+msgid "Userlist buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
+msgid "Dialog buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
+msgid "CTCP Replies - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4489,7 +4489,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
+msgid "Friends List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4528,7 +4528,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
+msgid "Connected to %u networks and %u channels - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4570,42 +4570,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4621,7 +4621,7 @@ msgid "Select a Plugin or Script to load"
 msgstr "Yüklənəcək Əlavə ya da Skripti Seç"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
+msgid "Plugins and Scripts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4643,7 +4643,7 @@ msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4679,7 +4679,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
+msgid "Edit %s - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4771,7 +4771,7 @@ msgid "Character set:"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
+msgid "Network List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6136,7 +6136,7 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
+msgid "Preferences - %s"
 msgstr ""
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6201,7 +6201,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
+msgid "URL Grabber - %s"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/be.po
+++ b/po/be.po
@@ -3237,7 +3237,7 @@ msgstr "Вы можаце адкрыць акно са спісам забаро
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
+msgid "Ban List (%s) - "
 msgstr "XChat: спіс забаронаў (%s)"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3276,8 +3276,8 @@ msgstr "Капіяваць тэкст _тэмы"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr "XChat: Спіс каналаў (%s)"
+msgid "Channel List (%s) - "
+msgstr "Спіс каналаў (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3368,8 +3368,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Немагчыма працягнуць той жа самы файл з двух чалавек."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr "XChat: запампоўкі і спампоўкі"
+msgid "Uploads and Downloads - "
+msgstr "запампоўкі і спампоўкі - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3426,8 +3426,8 @@ msgid "Open Folder..."
 msgstr "Адкрыць тэчку..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr "XChat: Спіс DCC Chat"
+msgid "DCC Chat List - "
+msgstr "Спіс DCC Chat - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3623,8 +3623,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr "XChat: Камбінацыі клавішаў"
+msgid "Keyboard Shortcuts - "
+msgstr "Камбінацыі клавішаў - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3668,8 +3668,8 @@ msgid "Enter mask to ignore:"
 msgstr "Увядзіце маску для ігнаравання:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr "XChat: Спіс ігнараванняў"
+msgid "Ignore list - "
+msgstr "Спіс ігнараванняў - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3704,8 +3704,8 @@ msgid "Channel name too short, try again."
 msgstr "Імя канала занадта кароткае, паспрабуйце зноў."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr "XChat: Злучэнне выканана"
+msgid "Connection Complete - "
+msgstr "Злучэнне выканана - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4031,8 +4031,8 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr "XChat: Меню карыстальніка"
+msgid "User menu - "
+msgstr "Меню карыстальніка - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4152,36 +4152,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr "XChat: Вызначаныя карыстальнікам каманды"
+msgid "User Defined Commands - "
+msgstr "Вызначаныя карыстальнікам каманды - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr "XChat: Кантэкстнае меню спісу карыстальнікаў"
+msgid "Userlist Popup menu - "
+msgstr "Кантэкстнае меню спісу карыстальнікаў - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Замяніць"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr "XChat: Замена"
+msgid "Replace - "
+msgstr "Замена - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr "XChat: Апрацоўчыкі URL"
+msgid "URL Handlers - "
+msgstr "Апрацоўчыкі URL - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr "XChat: Кнопкі спісу карыстальнікаў"
+msgid "Userlist buttons - "
+msgstr "Кнопкі спісу карыстальнікаў - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr "XChat: Кнопкі дыялогу"
+msgid "Dialog buttons - "
+msgstr "Кнопкі дыялогу - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr "XChat: Адказы CTCP"
+msgid "CTCP Replies - "
+msgstr "Адказы CTCP - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4488,7 +4488,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Прымаецца спіс сеціваў, падзеленых коскамі."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
+msgid "Friends List - "
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4527,8 +4527,8 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
-msgstr "XChat: злучана з %u сецівамі і %u каналамі"
+msgid "Connected to %u networks and %u channels - "
+msgstr "злучана з %u сецівамі і %u каналамі - "
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4569,43 +4569,43 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
-msgstr "XChat: %u падсвечаных паведамленняў, апошняе ад: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
+msgstr "%u падсвечаных паведамленняў, апошняе ад: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
-msgstr "XChat: Асабістае паведамленне ад: %s (%s)"
+msgid "Private message from: %s (%s) - "
+msgstr "Асабістае паведамленне ад: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
-msgstr "XChat: %u асабістых паведамленняў, апошняе ад: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
+msgstr "%u асабістых паведамленняў, апошняе ад: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
-msgstr "XChat: прапанова файла ад: %s (%s)"
+msgid "File offer from: %s (%s) - "
+msgstr "прапанова файла ад: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
-msgstr "XChat: %u прапаноў файлаў, апошняя ад: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
+msgstr "%u прапаноў файлаў, апошняя ад: %s (%s) - "
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4620,8 +4620,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Выберыце плагін ці скрыпт для загрузкі"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr "XChat: плагіны і скрыпты"
+msgid "Plugins and Scripts - "
+msgstr "плагіны і скрыпты - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4642,7 +4642,7 @@ msgstr "Захаваць як..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4678,8 +4678,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr "XChat: Рэдагаваць %s"
+msgid "Edit %s - "
+msgstr "Рэдагаваць %s - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4770,8 +4770,8 @@ msgid "Character set:"
 msgstr "Знаказбор:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr "XChat: спіс абвяшчэнняў"
+msgid "Network List - "
+msgstr "спіс абвяшчэнняў - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6135,8 +6135,8 @@ msgid ""
 msgstr "*УВАГА*\nАўтапрыманне DCC у вашу хатнюю тэчку ёсць\nнебяспечным і можа быць выкарыставана, напрыклад,\nнехта можа даслаць вам .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr "XChat: Асаблівасці"
+msgid "Preferences - "
+msgstr "Асаблівасці - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6200,8 +6200,8 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr "XChat: Зборшчык URL"
+msgid "URL Grabber - "
+msgstr "Зборшчык URL - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/be.po
+++ b/po/be.po
@@ -3237,8 +3237,8 @@ msgstr "Вы можаце адкрыць акно са спісам забаро
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "XChat: спіс забаронаў (%s)"
+msgid "Ban List (%s) - %s"
+msgstr "спіс забаронаў (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3276,8 +3276,8 @@ msgstr "Капіяваць тэкст _тэмы"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr "Спіс каналаў (%s) - "
+msgid "Channel List (%s) - %s"
+msgstr "Спіс каналаў (%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3368,8 +3368,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Немагчыма працягнуць той жа самы файл з двух чалавек."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "запампоўкі і спампоўкі - "
+msgid "Uploads and Downloads - %s"
+msgstr "запампоўкі і спампоўкі - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3426,8 +3426,8 @@ msgid "Open Folder..."
 msgstr "Адкрыць тэчку..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "Спіс DCC Chat - "
+msgid "DCC Chat List - %s"
+msgstr "Спіс DCC Chat - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3623,8 +3623,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "Камбінацыі клавішаў - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "Камбінацыі клавішаў - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3668,8 +3668,8 @@ msgid "Enter mask to ignore:"
 msgstr "Увядзіце маску для ігнаравання:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "Спіс ігнараванняў - "
+msgid "Ignore list - %s"
+msgstr "Спіс ігнараванняў - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3704,8 +3704,8 @@ msgid "Channel name too short, try again."
 msgstr "Імя канала занадта кароткае, паспрабуйце зноў."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "Злучэнне выканана - "
+msgid "Connection Complete - %s"
+msgstr "Злучэнне выканана - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4031,8 +4031,8 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "Меню карыстальніка - "
+msgid "User menu - %s"
+msgstr "Меню карыстальніка - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4152,36 +4152,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "Вызначаныя карыстальнікам каманды - "
+msgid "User Defined Commands - %s"
+msgstr "Вызначаныя карыстальнікам каманды - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "Кантэкстнае меню спісу карыстальнікаў - "
+msgid "Userlist Popup menu - %s"
+msgstr "Кантэкстнае меню спісу карыстальнікаў - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Замяніць"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "Замена - "
+msgid "Replace - %s"
+msgstr "Замена - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "Апрацоўчыкі URL - "
+msgid "URL Handlers - %s"
+msgstr "Апрацоўчыкі URL - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "Кнопкі спісу карыстальнікаў - "
+msgid "Userlist buttons - %s"
+msgstr "Кнопкі спісу карыстальнікаў - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "Кнопкі дыялогу - "
+msgid "Dialog buttons - %s"
+msgstr "Кнопкі дыялогу - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "Адказы CTCP - "
+msgid "CTCP Replies - %s"
+msgstr "Адказы CTCP - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4488,7 +4488,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Прымаецца спіс сеціваў, падзеленых коскамі."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
+msgid "Friends List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4527,8 +4527,8 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
-msgstr "злучана з %u сецівамі і %u каналамі - "
+msgid "Connected to %u networks and %u channels - %s"
+msgstr "злучана з %u сецівамі і %u каналамі - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4569,43 +4569,43 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
-msgstr "%u падсвечаных паведамленняў, апошняе ад: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
+msgstr "%u падсвечаных паведамленняў, апошняе ад: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
-msgstr "Асабістае паведамленне ад: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
+msgstr "Асабістае паведамленне ад: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
-msgstr "%u асабістых паведамленняў, апошняе ад: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
+msgstr "%u асабістых паведамленняў, апошняе ад: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
-msgstr "прапанова файла ад: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
+msgstr "прапанова файла ад: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
-msgstr "%u прапаноў файлаў, апошняя ад: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
+msgstr "%u прапаноў файлаў, апошняя ад: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4620,8 +4620,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Выберыце плагін ці скрыпт для загрузкі"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "плагіны і скрыпты - "
+msgid "Plugins and Scripts - %s"
+msgstr "плагіны і скрыпты - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4642,7 +4642,7 @@ msgstr "Захаваць як..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4678,8 +4678,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "Рэдагаваць %s - "
+msgid "Edit %s - %s"
+msgstr "Рэдагаваць %s - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4770,8 +4770,8 @@ msgid "Character set:"
 msgstr "Знаказбор:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "спіс абвяшчэнняў - "
+msgid "Network List - %s"
+msgstr "спіс абвяшчэнняў - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6135,8 +6135,8 @@ msgid ""
 msgstr "*УВАГА*\nАўтапрыманне DCC у вашу хатнюю тэчку ёсць\nнебяспечным і можа быць выкарыставана, напрыклад,\nнехта можа даслаць вам .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "Асаблівасці - "
+msgid "Preferences - %s"
+msgstr "Асаблівасці - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6200,8 +6200,8 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "Зборшчык URL - "
+msgid "URL Grabber - %s"
+msgstr "Зборшчык URL - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/bg.po
+++ b/po/bg.po
@@ -3239,7 +3239,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
+msgid "Ban List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3278,7 +3278,7 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
+msgid "Channel List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3370,7 +3370,7 @@ msgid "Cannot resume the same file from two people."
 msgstr "Не може да се продължава същия файл от различни хора."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
+msgid "Uploads and Downloads - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3428,7 +3428,7 @@ msgid "Open Folder..."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
+msgid "DCC Chat List - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3625,7 +3625,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
+msgid "Keyboard Shortcuts - "
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3670,7 +3670,7 @@ msgid "Enter mask to ignore:"
 msgstr "Въведете маската, която да се игнорира:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
+msgid "Ignore list - "
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3706,7 +3706,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
+msgid "Connection Complete - "
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4033,7 +4033,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
+msgid "User menu - "
 msgstr ""
 
 #. sep
@@ -4154,11 +4154,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
+msgid "User Defined Commands - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
+msgid "Userlist Popup menu - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4166,23 +4166,23 @@ msgid "Replace with"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
+msgid "Replace - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
+msgid "URL Handlers - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
+msgid "Userlist buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
+msgid "Dialog buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
+msgid "CTCP Replies - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4490,7 +4490,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
+msgid "Friends List - "
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4529,7 +4529,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
+msgid "Connected to %u networks and %u channels - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4571,42 +4571,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
+msgid "Private message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
+msgid "File offer from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4622,7 +4622,7 @@ msgid "Select a Plugin or Script to load"
 msgstr "Избор на плъгин или скрипт за зареждане"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
+msgid "Plugins and Scripts - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4644,7 +4644,7 @@ msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4680,7 +4680,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
+msgid "Edit %s - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4772,7 +4772,7 @@ msgid "Character set:"
 msgstr "Кодиране:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
+msgid "Network List - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6137,7 +6137,7 @@ msgid ""
 msgstr "*ВНИМАНИЕ*\nАвтоматично приемане на DCC във вашата домашна папка\nможе да бъде опасно и използваемо от други. Пример:\nНякой може да ви прати .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
+msgid "Preferences - "
 msgstr ""
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6202,7 +6202,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
+msgid "URL Grabber - "
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/bg.po
+++ b/po/bg.po
@@ -3239,7 +3239,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
+msgid "Ban List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3278,7 +3278,7 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
+msgid "Channel List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3370,7 +3370,7 @@ msgid "Cannot resume the same file from two people."
 msgstr "Не може да се продължава същия файл от различни хора."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
+msgid "Uploads and Downloads - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3428,7 +3428,7 @@ msgid "Open Folder..."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
+msgid "DCC Chat List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3625,7 +3625,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
+msgid "Keyboard Shortcuts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3670,7 +3670,7 @@ msgid "Enter mask to ignore:"
 msgstr "Въведете маската, която да се игнорира:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
+msgid "Ignore list - %s"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3706,7 +3706,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
+msgid "Connection Complete - %s"
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4033,7 +4033,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
+msgid "User menu - %s"
 msgstr ""
 
 #. sep
@@ -4154,11 +4154,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
+msgid "User Defined Commands - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
+msgid "Userlist Popup menu - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4166,23 +4166,23 @@ msgid "Replace with"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
+msgid "Replace - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
+msgid "URL Handlers - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
+msgid "Userlist buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
+msgid "Dialog buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
+msgid "CTCP Replies - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4490,7 +4490,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
+msgid "Friends List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4529,7 +4529,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
+msgid "Connected to %u networks and %u channels - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4571,42 +4571,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4622,7 +4622,7 @@ msgid "Select a Plugin or Script to load"
 msgstr "Избор на плъгин или скрипт за зареждане"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
+msgid "Plugins and Scripts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4644,7 +4644,7 @@ msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4680,7 +4680,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
+msgid "Edit %s - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4772,7 +4772,7 @@ msgid "Character set:"
 msgstr "Кодиране:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
+msgid "Network List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6137,7 +6137,7 @@ msgid ""
 msgstr "*ВНИМАНИЕ*\nАвтоматично приемане на DCC във вашата домашна папка\nможе да бъде опасно и използваемо от други. Пример:\nНякой може да ви прати .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
+msgid "Preferences - %s"
 msgstr ""
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6202,7 +6202,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
+msgid "URL Grabber - %s"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/ca.po
+++ b/po/ca.po
@@ -3243,7 +3243,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
+msgid "Ban List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3282,7 +3282,7 @@ msgstr "Copia el text del _tema"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
+msgid "Channel List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3374,7 +3374,7 @@ msgid "Cannot resume the same file from two people."
 msgstr "No es pot reprendre la recepció del mateix fitxer des de dues persones diferents."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
+msgid "Uploads and Downloads - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3432,7 +3432,7 @@ msgid "Open Folder..."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
+msgid "DCC Chat List - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3629,7 +3629,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
+msgid "Keyboard Shortcuts - "
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3674,7 +3674,7 @@ msgid "Enter mask to ignore:"
 msgstr "Introduïu una màscara a ignorar:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
+msgid "Ignore list - "
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3710,7 +3710,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
+msgid "Connection Complete - "
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4037,7 +4037,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
+msgid "User menu - "
 msgstr ""
 
 #. sep
@@ -4158,11 +4158,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
+msgid "User Defined Commands - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
+msgid "Userlist Popup menu - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4170,23 +4170,23 @@ msgid "Replace with"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
+msgid "Replace - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
+msgid "URL Handlers - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
+msgid "Userlist buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
+msgid "Dialog buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
+msgid "CTCP Replies - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4494,7 +4494,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
+msgid "Friends List - "
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4533,7 +4533,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
+msgid "Connected to %u networks and %u channels - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4575,42 +4575,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
+msgid "Private message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
+msgid "File offer from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4626,7 +4626,7 @@ msgid "Select a Plugin or Script to load"
 msgstr "Seleccioneu el connector o script a carregar"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
+msgid "Plugins and Scripts - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4648,7 +4648,7 @@ msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4684,7 +4684,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
+msgid "Edit %s - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4776,7 +4776,7 @@ msgid "Character set:"
 msgstr "Joc de caràcters:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
+msgid "Network List - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6141,7 +6141,7 @@ msgid ""
 msgstr "*ATENCIÓ*\nAcceptar automàticament DCCs al vostre\ndirectori personal pot ser perillós. P.ex:\nAlgú podria enviar-vos un .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
+msgid "Preferences - "
 msgstr ""
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6206,7 +6206,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
+msgid "URL Grabber - "
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/ca.po
+++ b/po/ca.po
@@ -3243,7 +3243,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
+msgid "Ban List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3282,7 +3282,7 @@ msgstr "Copia el text del _tema"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
+msgid "Channel List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3374,7 +3374,7 @@ msgid "Cannot resume the same file from two people."
 msgstr "No es pot reprendre la recepció del mateix fitxer des de dues persones diferents."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
+msgid "Uploads and Downloads - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3432,7 +3432,7 @@ msgid "Open Folder..."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
+msgid "DCC Chat List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3629,7 +3629,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
+msgid "Keyboard Shortcuts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3674,7 +3674,7 @@ msgid "Enter mask to ignore:"
 msgstr "Introduïu una màscara a ignorar:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
+msgid "Ignore list - %s"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3710,7 +3710,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
+msgid "Connection Complete - %s"
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4037,7 +4037,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
+msgid "User menu - %s"
 msgstr ""
 
 #. sep
@@ -4158,11 +4158,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
+msgid "User Defined Commands - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
+msgid "Userlist Popup menu - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4170,23 +4170,23 @@ msgid "Replace with"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
+msgid "Replace - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
+msgid "URL Handlers - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
+msgid "Userlist buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
+msgid "Dialog buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
+msgid "CTCP Replies - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4494,7 +4494,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
+msgid "Friends List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4533,7 +4533,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
+msgid "Connected to %u networks and %u channels - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4575,42 +4575,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4626,7 +4626,7 @@ msgid "Select a Plugin or Script to load"
 msgstr "Seleccioneu el connector o script a carregar"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
+msgid "Plugins and Scripts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4648,7 +4648,7 @@ msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4684,7 +4684,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
+msgid "Edit %s - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4776,7 +4776,7 @@ msgid "Character set:"
 msgstr "Joc de caràcters:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
+msgid "Network List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6141,7 +6141,7 @@ msgid ""
 msgstr "*ATENCIÓ*\nAcceptar automàticament DCCs al vostre\ndirectori personal pot ser perillós. P.ex:\nAlgú podria enviar-vos un .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
+msgid "Preferences - %s"
 msgstr ""
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6206,7 +6206,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
+msgid "URL Grabber - %s"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/cs.po
+++ b/po/cs.po
@@ -3239,8 +3239,8 @@ msgstr "Okno se seznamem banů otevřet pouze pokud se nacházíte na kanálu."
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr "XChat: Seznam Banů (%s)"
+msgid "Ban List (%s) - "
+msgstr "Seznam Banů (%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3278,8 +3278,8 @@ msgstr "Zkopíruje _téma kanálu"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr "XChat: Seznam kanálu (%s)"
+msgid "Channel List (%s) - "
+msgstr "Seznam kanálu (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3370,8 +3370,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Nemohu pokračovat ve stahování souboru od dvou lidí."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr "XChat: Upload a Download"
+msgid "Uploads and Downloads - "
+msgstr "Upload a Download - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3428,8 +3428,8 @@ msgid "Open Folder..."
 msgstr "Otevřít adresář"
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr "XChat: Seznam DCC Chat"
+msgid "DCC Chat List - "
+msgstr "Seznam DCC Chat - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3625,8 +3625,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr "XChat: Klávesové zkratky"
+msgid "Keyboard Shortcuts - "
+msgstr "Klávesové zkratky - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3670,8 +3670,8 @@ msgid "Enter mask to ignore:"
 msgstr "Zadejte masku pro ignorování:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr "XChat: Seznam ignorovaných"
+msgid "Ignore list - "
+msgstr "Seznam ignorovaných - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3706,8 +3706,8 @@ msgid "Channel name too short, try again."
 msgstr "Název kanálu je příliš krátký, zkuste to znovu."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr "XChat: Dokončení připojení"
+msgid "Connection Complete - "
+msgstr "Dokončení připojení - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4033,8 +4033,8 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr "X-Chat: Uživatelské menu"
+msgid "User menu - "
+msgstr "Uživatelské menu - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4154,36 +4154,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr "X-Chat: Uživatelem definované příkazy"
+msgid "User Defined Commands - "
+msgstr "Uživatelem definované příkazy - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr "XChat: Menu se seznamem uživatelů"
+msgid "Userlist Popup menu - "
+msgstr "Menu se seznamem uživatelů - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Nahradit s"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr "X-Chat: Nahrazení"
+msgid "Replace - "
+msgstr "Nahrazení - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr "XChat: Obsluhy URL"
+msgid "URL Handlers - "
+msgstr "Obsluhy URL - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr "XChat: Tlačítka uživatelského seznamu"
+msgid "Userlist buttons - "
+msgstr "Tlačítka uživatelského seznamu - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr "XChat: Dialogová tlačítka"
+msgid "Dialog buttons - "
+msgstr "Dialogová tlačítka - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr "XChat: Odpovědi CTCP"
+msgid "CTCP Replies - "
+msgstr "Odpovědi CTCP - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4490,7 +4490,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Čárkou oddělený seznam zvolených sítí."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
+msgid "Friends List - "
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4529,8 +4529,8 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
-msgstr "XChat: Připojen k %u sítím a %u kanálům"
+msgid "Connected to %u networks and %u channels - "
+msgstr "Připojen k %u sítím a %u kanálům - "
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4571,43 +4571,43 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
-msgstr "XChat: Zvýrazněná zpráva od: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
+msgstr "Zvýrazněná zpráva od: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
-msgstr "XChat: %u zvýrazněných zpráv, poslední od: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
+msgstr "%u zvýrazněných zpráv, poslední od: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
-msgstr "XChat: Soukromá zpráva od: %s (%s)"
+msgid "Private message from: %s (%s) - "
+msgstr "Soukromá zpráva od: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
-msgstr "XChat: %u soukromých zpráv, poslední od: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
+msgstr "%u soukromých zpráv, poslední od: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
-msgstr "XChat: Nabídka souboru od: %s (%s)"
+msgid "File offer from: %s (%s) - "
+msgstr "Nabídka souboru od: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
-msgstr "XChat: %u nabídnutých souborů, poslední od: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
+msgstr "%u nabídnutých souborů, poslední od: %s (%s) - "
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4622,8 +4622,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Zvolit plugin nebo skript pro načtení"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr "XChat: Pluginy a skripty"
+msgid "Plugins and Scripts - "
+msgstr "Pluginy a skripty - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4644,7 +4644,7 @@ msgstr "Uložit jako..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4680,8 +4680,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr "XChat: Upravit %s"
+msgid "Edit %s - "
+msgstr "Upravit %s - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4772,8 +4772,8 @@ msgid "Character set:"
 msgstr "Znaková sada:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr "XChat: Seznam sítí"
+msgid "Network List - "
+msgstr "Seznam sítí - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6137,8 +6137,8 @@ msgid ""
 msgstr "*UPOZORNĚNÍ*\nAutomatické přijmutí DCC do vašeho domovského adresáře\nmůže být nebezpečné a zneužitelné. Např.:\nNěkdo vám může poslat soubor .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr "XChat: Nastavení"
+msgid "Preferences - "
+msgstr "Nastavení - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6202,8 +6202,8 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr "XChat: Grabování URL"
+msgid "URL Grabber - "
+msgstr "Grabování URL - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/cs.po
+++ b/po/cs.po
@@ -3239,8 +3239,8 @@ msgstr "Okno se seznamem banů otevřet pouze pokud se nacházíte na kanálu."
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "Seznam Banů (%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "Seznam Banů (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3278,8 +3278,8 @@ msgstr "Zkopíruje _téma kanálu"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr "Seznam kanálu (%s) - "
+msgid "Channel List (%s) - %s"
+msgstr "Seznam kanálu (%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3370,8 +3370,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Nemohu pokračovat ve stahování souboru od dvou lidí."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "Upload a Download - "
+msgid "Uploads and Downloads - %s"
+msgstr "Upload a Download - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3428,8 +3428,8 @@ msgid "Open Folder..."
 msgstr "Otevřít adresář"
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "Seznam DCC Chat - "
+msgid "DCC Chat List - %s"
+msgstr "Seznam DCC Chat - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3625,8 +3625,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "Klávesové zkratky - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "Klávesové zkratky - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3670,8 +3670,8 @@ msgid "Enter mask to ignore:"
 msgstr "Zadejte masku pro ignorování:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "Seznam ignorovaných - "
+msgid "Ignore list - %s"
+msgstr "Seznam ignorovaných - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3706,8 +3706,8 @@ msgid "Channel name too short, try again."
 msgstr "Název kanálu je příliš krátký, zkuste to znovu."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "Dokončení připojení - "
+msgid "Connection Complete - %s"
+msgstr "Dokončení připojení - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4033,8 +4033,8 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "Uživatelské menu - "
+msgid "User menu - %s"
+msgstr "Uživatelské menu - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4154,36 +4154,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "Uživatelem definované příkazy - "
+msgid "User Defined Commands - %s"
+msgstr "Uživatelem definované příkazy - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "Menu se seznamem uživatelů - "
+msgid "Userlist Popup menu - %s"
+msgstr "Menu se seznamem uživatelů - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Nahradit s"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "Nahrazení - "
+msgid "Replace - %s"
+msgstr "Nahrazení - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "Obsluhy URL - "
+msgid "URL Handlers - %s"
+msgstr "Obsluhy URL - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "Tlačítka uživatelského seznamu - "
+msgid "Userlist buttons - %s"
+msgstr "Tlačítka uživatelského seznamu - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "Dialogová tlačítka - "
+msgid "Dialog buttons - %s"
+msgstr "Dialogová tlačítka - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "Odpovědi CTCP - "
+msgid "CTCP Replies - %s"
+msgstr "Odpovědi CTCP - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4490,7 +4490,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Čárkou oddělený seznam zvolených sítí."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
+msgid "Friends List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4529,8 +4529,8 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
-msgstr "Připojen k %u sítím a %u kanálům - "
+msgid "Connected to %u networks and %u channels - %s"
+msgstr "Připojen k %u sítím a %u kanálům - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4571,43 +4571,43 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
-msgstr "Zvýrazněná zpráva od: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
+msgstr "Zvýrazněná zpráva od: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
-msgstr "%u zvýrazněných zpráv, poslední od: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
+msgstr "%u zvýrazněných zpráv, poslední od: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
-msgstr "Soukromá zpráva od: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
+msgstr "Soukromá zpráva od: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
-msgstr "%u soukromých zpráv, poslední od: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
+msgstr "%u soukromých zpráv, poslední od: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
-msgstr "Nabídka souboru od: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
+msgstr "Nabídka souboru od: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
-msgstr "%u nabídnutých souborů, poslední od: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
+msgstr "%u nabídnutých souborů, poslední od: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4622,8 +4622,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Zvolit plugin nebo skript pro načtení"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "Pluginy a skripty - "
+msgid "Plugins and Scripts - %s"
+msgstr "Pluginy a skripty - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4644,7 +4644,7 @@ msgstr "Uložit jako..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4680,8 +4680,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "Upravit %s - "
+msgid "Edit %s - %s"
+msgstr "Upravit %s - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4772,8 +4772,8 @@ msgid "Character set:"
 msgstr "Znaková sada:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "Seznam sítí - "
+msgid "Network List - %s"
+msgstr "Seznam sítí - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6137,8 +6137,8 @@ msgid ""
 msgstr "*UPOZORNĚNÍ*\nAutomatické přijmutí DCC do vašeho domovského adresáře\nmůže být nebezpečné a zneužitelné. Např.:\nNěkdo vám může poslat soubor .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "Nastavení - "
+msgid "Preferences - %s"
+msgstr "Nastavení - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6202,8 +6202,8 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "Grabování URL - "
+msgid "URL Grabber - %s"
+msgstr "Grabování URL - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/da.po
+++ b/po/da.po
@@ -3249,8 +3249,8 @@ msgstr "Du kan kun åbne udelukkelseslisten inde fra et kanalfaneblad."
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "Udelukkelsesliste (%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "Udelukkelsesliste (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3288,8 +3288,8 @@ msgstr "Kopiér _emnetekst"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr "Kanalliste (%s) - "
+msgid "Channel List (%s) - %s"
+msgstr "Kanalliste (%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3380,8 +3380,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Kan ikke genoptage samme fil fra to personer."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "Uploads og downloads - "
+msgid "Uploads and Downloads - %s"
+msgstr "Uploads og downloads - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3438,8 +3438,8 @@ msgid "Open Folder..."
 msgstr "Åbn mappe..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "DCC-chatliste - "
+msgid "DCC Chat List - %s"
+msgstr "DCC-chatliste - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3635,8 +3635,8 @@ msgid "Select a row to get help information on its Action."
 msgstr "Vælg en række for at få hjælp til dens handling."
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "Tastaturgenveje - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "Tastaturgenveje - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3680,8 +3680,8 @@ msgid "Enter mask to ignore:"
 msgstr "Angiv maske at ignorere:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "Ignoreringsliste - "
+msgid "Ignore list - %s"
+msgstr "Ignoreringsliste - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3716,8 +3716,8 @@ msgid "Channel name too short, try again."
 msgstr "Kanalnavn er for kort, prøv igen."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "Forbindelse færdig - "
+msgid "Connection Complete - %s"
+msgstr "Forbindelse færdig - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4043,8 +4043,8 @@ msgid "_Auto-Connect"
 msgstr "_Auto-opret forbindelse"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "Brugermenu - "
+msgid "User menu - %s"
+msgstr "Brugermenu - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4164,36 +4164,36 @@ msgid ""
 msgstr "URL-behandlere - specielle koder:\n\n%s  =  URL-strengen\n\nEt ! foran kommandoen\nindikerer at den skal sendes\ntil en skal i stedet for HexChat"
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "Brugerdefinerede kommandoer - "
+msgid "User Defined Commands - %s"
+msgstr "Brugerdefinerede kommandoer - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "Brugerliste pop op-menu - "
+msgid "Userlist Popup menu - %s"
+msgstr "Brugerliste pop op-menu - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Erstat med"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "Erstat - "
+msgid "Replace - %s"
+msgstr "Erstat - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "URL-behandlere - "
+msgid "URL Handlers - %s"
+msgstr "URL-behandlere - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "Brugerlisteknapper - "
+msgid "Userlist buttons - %s"
+msgstr "Brugerlisteknapper - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "Dialogknapper - "
+msgid "Dialog buttons - %s"
+msgstr "Dialogknapper - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "CTCP-svar - "
+msgid "CTCP Replies - %s"
+msgstr "CTCP-svar - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4500,8 +4500,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Kommasepareret liste over netværk accepteres."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
-msgstr "Venneliste - "
+msgid "Friends List - %s"
+msgstr "Venneliste - %s"
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4539,8 +4539,8 @@ msgstr "Privat meddelelse fra: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
-msgstr "Forbundet til %u netværk og %u kanaler - "
+msgid "Connected to %u networks and %u channels - %s"
+msgstr "Forbundet til %u netværk og %u kanaler - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4581,43 +4581,43 @@ msgstr "_Tilbage"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
-msgstr "Fremhævet meddelelse fra: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
+msgstr "Fremhævet meddelelse fra: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
-msgstr "%u fremhævede meddelelser, seneste fra: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
+msgstr "%u fremhævede meddelelser, seneste fra: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
-msgstr "Kanalmeddelelse fra: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
+msgstr "Kanalmeddelelse fra: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
-msgstr "%u kanalmeddelelser. - "
+msgid "%u channel messages. - %s"
+msgstr "%u kanalmeddelelser. - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
-msgstr "Privat meddelelse fra: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
+msgstr "Privat meddelelse fra: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
-msgstr "%u private meddelelser, seneste fra: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
+msgstr "%u private meddelelser, seneste fra: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
-msgstr "Fil-tilbud fra: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
+msgstr "Fil-tilbud fra: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
-msgstr "%u fil-tilbud, seneste fra: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
+msgstr "%u fil-tilbud, seneste fra: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4632,8 +4632,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Vælg et plugin eller script som skal indlæses"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "Plugins og scripts - "
+msgid "Plugins and Scripts - %s"
+msgstr "Plugins og scripts - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4654,8 +4654,8 @@ msgstr "Gem som..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
-msgstr "Rå log (%s) - "
+msgid "Raw Log (%s) - %s"
+msgstr "Rå log (%s) - %s"
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4690,8 +4690,8 @@ msgstr "Måden hvorpå du identificerer dig overfor serveren. Brug connect-komma
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "Rediger %s - "
+msgid "Edit %s - %s"
+msgstr "Rediger %s - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4782,8 +4782,8 @@ msgid "Character set:"
 msgstr "Tegnsæt:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "Netværksliste - "
+msgid "Network List - %s"
+msgstr "Netværksliste - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6147,8 +6147,8 @@ msgid ""
 msgstr "*ADVARSEL*\nAt auto-acceptering af DCC til din hjemmemappe\nkan være farligt og kan udnyttes. Eksempelvis:\nNogen kunne sende dig en .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "Præferencer - "
+msgid "Preferences - %s"
+msgstr "Præferencer - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6212,8 +6212,8 @@ msgid "OK"
 msgstr "OK"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "URL-opfanger - "
+msgid "URL Grabber - %s"
+msgstr "URL-opfanger - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/da.po
+++ b/po/da.po
@@ -3249,8 +3249,8 @@ msgstr "Du kan kun åbne udelukkelseslisten inde fra et kanalfaneblad."
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr ": Udelukkelsesliste (%s)"
+msgid "Ban List (%s) - "
+msgstr "Udelukkelsesliste (%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3288,8 +3288,8 @@ msgstr "Kopiér _emnetekst"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr ": Kanalliste (%s)"
+msgid "Channel List (%s) - "
+msgstr "Kanalliste (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3380,8 +3380,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Kan ikke genoptage samme fil fra to personer."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr ": Uploads og downloads"
+msgid "Uploads and Downloads - "
+msgstr "Uploads og downloads - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3438,8 +3438,8 @@ msgid "Open Folder..."
 msgstr "Åbn mappe..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr ": DCC-chatliste"
+msgid "DCC Chat List - "
+msgstr "DCC-chatliste - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3635,8 +3635,8 @@ msgid "Select a row to get help information on its Action."
 msgstr "Vælg en række for at få hjælp til dens handling."
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr ": Tastaturgenveje"
+msgid "Keyboard Shortcuts - "
+msgstr "Tastaturgenveje - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3680,8 +3680,8 @@ msgid "Enter mask to ignore:"
 msgstr "Angiv maske at ignorere:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr ": Ignoreringsliste"
+msgid "Ignore list - "
+msgstr "Ignoreringsliste - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3716,8 +3716,8 @@ msgid "Channel name too short, try again."
 msgstr "Kanalnavn er for kort, prøv igen."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr ": Forbindelse færdig"
+msgid "Connection Complete - "
+msgstr "Forbindelse færdig - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4043,8 +4043,8 @@ msgid "_Auto-Connect"
 msgstr "_Auto-opret forbindelse"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr ": Brugermenu"
+msgid "User menu - "
+msgstr "Brugermenu - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4164,36 +4164,36 @@ msgid ""
 msgstr "URL-behandlere - specielle koder:\n\n%s  =  URL-strengen\n\nEt ! foran kommandoen\nindikerer at den skal sendes\ntil en skal i stedet for HexChat"
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr ": Brugerdefinerede kommandoer"
+msgid "User Defined Commands - "
+msgstr "Brugerdefinerede kommandoer - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr ": Brugerliste pop op-menu"
+msgid "Userlist Popup menu - "
+msgstr "Brugerliste pop op-menu - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Erstat med"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr ": Erstat"
+msgid "Replace - "
+msgstr "Erstat - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr ": URL-behandlere"
+msgid "URL Handlers - "
+msgstr "URL-behandlere - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr ": Brugerlisteknapper"
+msgid "Userlist buttons - "
+msgstr "Brugerlisteknapper - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr ": Dialogknapper"
+msgid "Dialog buttons - "
+msgstr "Dialogknapper - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr ": CTCP-svar"
+msgid "CTCP Replies - "
+msgstr "CTCP-svar - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4500,8 +4500,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Kommasepareret liste over netværk accepteres."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
-msgstr ": Venneliste"
+msgid "Friends List - "
+msgstr "Venneliste - "
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4539,8 +4539,8 @@ msgstr "Privat meddelelse fra: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
-msgstr ": Forbundet til %u netværk og %u kanaler"
+msgid "Connected to %u networks and %u channels - "
+msgstr "Forbundet til %u netværk og %u kanaler - "
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4581,43 +4581,43 @@ msgstr "_Tilbage"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
-msgstr ": Fremhævet meddelelse fra: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
+msgstr "Fremhævet meddelelse fra: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
-msgstr ": %u fremhævede meddelelser, seneste fra: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
+msgstr "%u fremhævede meddelelser, seneste fra: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
-msgstr ": Kanalmeddelelse fra: %s (%s)"
+msgid "Channel message from: %s (%s) - "
+msgstr "Kanalmeddelelse fra: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
-msgstr ": %u kanalmeddelelser."
+msgid "%u channel messages. - "
+msgstr "%u kanalmeddelelser. - "
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
-msgstr ": Privat meddelelse fra: %s (%s)"
+msgid "Private message from: %s (%s) - "
+msgstr "Privat meddelelse fra: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
-msgstr ": %u private meddelelser, seneste fra: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
+msgstr "%u private meddelelser, seneste fra: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
-msgstr ": Fil-tilbud fra: %s (%s)"
+msgid "File offer from: %s (%s) - "
+msgstr "Fil-tilbud fra: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
-msgstr ": %u fil-tilbud, seneste fra: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
+msgstr "%u fil-tilbud, seneste fra: %s (%s) - "
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4632,8 +4632,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Vælg et plugin eller script som skal indlæses"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr ": Plugins og scripts"
+msgid "Plugins and Scripts - "
+msgstr "Plugins og scripts - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4654,8 +4654,8 @@ msgstr "Gem som..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
-msgstr ": Rå log (%s)"
+msgid "Raw Log (%s) - "
+msgstr "Rå log (%s) - "
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4690,8 +4690,8 @@ msgstr "Måden hvorpå du identificerer dig overfor serveren. Brug connect-komma
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr ": Rediger %s"
+msgid "Edit %s - "
+msgstr "Rediger %s - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4782,8 +4782,8 @@ msgid "Character set:"
 msgstr "Tegnsæt:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr ": Netværksliste"
+msgid "Network List - "
+msgstr "Netværksliste - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6147,8 +6147,8 @@ msgid ""
 msgstr "*ADVARSEL*\nAt auto-acceptering af DCC til din hjemmemappe\nkan være farligt og kan udnyttes. Eksempelvis:\nNogen kunne sende dig en .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr ": Præferencer"
+msgid "Preferences - "
+msgstr "Præferencer - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6212,8 +6212,8 @@ msgid "OK"
 msgstr "OK"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr ": URL-opfanger"
+msgid "URL Grabber - "
+msgstr "URL-opfanger - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/de.po
+++ b/po/de.po
@@ -3258,8 +3258,8 @@ msgstr "Sie können die Bannliste nur öffnen, während Sie sich in einem Channe
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "Bannliste (%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "Bannliste (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3297,8 +3297,8 @@ msgstr "_Thementext kopieren"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr "Channel-Liste (%s) - "
+msgid "Channel List (%s) - %s"
+msgstr "Channel-Liste (%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3389,8 +3389,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Kann dieselbe Datei nicht von zwei Leuten fortsetzen."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "Up- und Downloads - "
+msgid "Uploads and Downloads - %s"
+msgstr "Up- und Downloads - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3447,8 +3447,8 @@ msgid "Open Folder..."
 msgstr "Verzeichnis öffnen …"
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "DCC-Chat-Liste - "
+msgid "DCC Chat List - %s"
+msgstr "DCC-Chat-Liste - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3644,8 +3644,8 @@ msgid "Select a row to get help information on its Action."
 msgstr "Markiere eine Zeile, für Hilfestellung über die jeweilige Aktion."
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "Tastenkürzel - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "Tastenkürzel - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3689,8 +3689,8 @@ msgid "Enter mask to ignore:"
 msgstr "Maske zum Ignorieren eingeben:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "Ignorierliste - "
+msgid "Ignore list - %s"
+msgstr "Ignorierliste - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3725,8 +3725,8 @@ msgid "Channel name too short, try again."
 msgstr "Channelname zu kurz, bitte erneut versuchen."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "Verbindung hergestellt - "
+msgid "Connection Complete - %s"
+msgstr "Verbindung hergestellt - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4052,8 +4052,8 @@ msgid "_Auto-Connect"
 msgstr "_Automatisches Verbinden"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "Benutzermenü - "
+msgid "User menu - %s"
+msgstr "Benutzermenü - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4173,36 +4173,36 @@ msgid ""
 msgstr "Befehle für URLs - Spezielle Codes:\n\n%s  =  die URL\n\nEin »!« am Anfang des Befehls sagt\naus, dass der Befehl in der Shell\nstatt in HexChat ausgeführt wird"
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "Benutzerdefinierte Befehle - "
+msgid "User Defined Commands - %s"
+msgstr "Benutzerdefinierte Befehle - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "Benutzerlisten-Menü - "
+msgid "Userlist Popup menu - %s"
+msgstr "Benutzerlisten-Menü - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Ersetzen durch"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "Ersetzen - "
+msgid "Replace - %s"
+msgstr "Ersetzen - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "Befehle für URLs - "
+msgid "URL Handlers - %s"
+msgstr "Befehle für URLs - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "Benutzerlistenknöpfe - "
+msgid "Userlist buttons - %s"
+msgstr "Benutzerlistenknöpfe - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "Dialogknöpfe - "
+msgid "Dialog buttons - %s"
+msgstr "Dialogknöpfe - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "CTCP-Antworten - "
+msgid "CTCP Replies - %s"
+msgstr "CTCP-Antworten - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4509,8 +4509,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Eine kommagetrennte Liste von Netzen wird akzeptiert"
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
-msgstr "Freundesliste - "
+msgid "Friends List - %s"
+msgstr "Freundesliste - %s"
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4548,8 +4548,8 @@ msgstr ": Private Nachricht von: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
-msgstr "Mit %u Netzwerken und %u Channels verbunden - "
+msgid "Connected to %u networks and %u channels - %s"
+msgstr "Mit %u Netzwerken und %u Channels verbunden - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4590,43 +4590,43 @@ msgstr "_Zurück"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
-msgstr "Hervorgehobene Nachricht von: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
+msgstr "Hervorgehobene Nachricht von: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
-msgstr "%u hervorgehobene Nachrichten, letzte von: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
+msgstr "%u hervorgehobene Nachrichten, letzte von: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr "Kanal-Nachricht von: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
-msgstr "%u Kanal-Nachrichten. - "
+msgid "%u channel messages. - %s"
+msgstr "%u Kanal-Nachrichten. - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
-msgstr "Private Nachricht von: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
+msgstr "Private Nachricht von: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
-msgstr "%u private Nachrichten, letzte von: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
+msgstr "%u private Nachrichten, letzte von: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
-msgstr "Dateiangebot von: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
+msgstr "Dateiangebot von: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
-msgstr "%u Dateiangebote, letztes von: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
+msgstr "%u Dateiangebote, letztes von: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4641,8 +4641,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Wählen Sie ein Plugin oder Skript zum Laden"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "Plugins und Skripte - "
+msgid "Plugins and Scripts - %s"
+msgstr "Plugins und Skripte - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4663,8 +4663,8 @@ msgstr "Speichern als …"
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
-msgstr "Rohdatenlogbuch (%s) - "
+msgid "Raw Log (%s) - %s"
+msgstr "Rohdatenlogbuch (%s) - %s"
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4699,8 +4699,8 @@ msgstr "Die Art, wie Sie sich auf dem Server identifizieren. Für spezielle Logi
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "%s ändern - "
+msgid "Edit %s - %s"
+msgstr "%s ändern - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4791,8 +4791,8 @@ msgid "Character set:"
 msgstr "Zeichensatz:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "Netzwerkliste - "
+msgid "Network List - %s"
+msgstr "Netzwerkliste - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6156,8 +6156,8 @@ msgid ""
 msgstr "*WARNUNG*\nAutomatisches Annehmen von DCCs in Ihr Home-\nVerzeichnis kann gefährlich sein und ist\nausnutzbar. Zum Beispiel könnte Ihnen jemand\nein .bash_profile schicken."
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "Optionen - "
+msgid "Preferences - %s"
+msgstr "Optionen - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6221,8 +6221,8 @@ msgid "OK"
 msgstr "OK"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "Gesammelte URLs - "
+msgid "URL Grabber - %s"
+msgstr "Gesammelte URLs - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/de.po
+++ b/po/de.po
@@ -3258,8 +3258,8 @@ msgstr "Sie können die Bannliste nur öffnen, während Sie sich in einem Channe
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr ": Bannliste (%s)"
+msgid "Ban List (%s) - "
+msgstr "Bannliste (%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3297,8 +3297,8 @@ msgstr "_Thementext kopieren"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr ": Channel-Liste (%s)"
+msgid "Channel List (%s) - "
+msgstr "Channel-Liste (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3389,8 +3389,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Kann dieselbe Datei nicht von zwei Leuten fortsetzen."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr ": Up- und Downloads"
+msgid "Uploads and Downloads - "
+msgstr "Up- und Downloads - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3447,8 +3447,8 @@ msgid "Open Folder..."
 msgstr "Verzeichnis öffnen …"
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr ": DCC-Chat-Liste"
+msgid "DCC Chat List - "
+msgstr "DCC-Chat-Liste - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3644,8 +3644,8 @@ msgid "Select a row to get help information on its Action."
 msgstr "Markiere eine Zeile, für Hilfestellung über die jeweilige Aktion."
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr ": Tastenkürzel"
+msgid "Keyboard Shortcuts - "
+msgstr "Tastenkürzel - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3689,8 +3689,8 @@ msgid "Enter mask to ignore:"
 msgstr "Maske zum Ignorieren eingeben:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr ": Ignorierliste"
+msgid "Ignore list - "
+msgstr "Ignorierliste - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3725,8 +3725,8 @@ msgid "Channel name too short, try again."
 msgstr "Channelname zu kurz, bitte erneut versuchen."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr ": Verbindung hergestellt"
+msgid "Connection Complete - "
+msgstr "Verbindung hergestellt - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4052,8 +4052,8 @@ msgid "_Auto-Connect"
 msgstr "_Automatisches Verbinden"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr ": Benutzermenü"
+msgid "User menu - "
+msgstr "Benutzermenü - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4173,36 +4173,36 @@ msgid ""
 msgstr "Befehle für URLs - Spezielle Codes:\n\n%s  =  die URL\n\nEin »!« am Anfang des Befehls sagt\naus, dass der Befehl in der Shell\nstatt in HexChat ausgeführt wird"
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr ": Benutzerdefinierte Befehle"
+msgid "User Defined Commands - "
+msgstr "Benutzerdefinierte Befehle - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr ": Benutzerlisten-Menü"
+msgid "Userlist Popup menu - "
+msgstr "Benutzerlisten-Menü - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Ersetzen durch"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr ": Ersetzen"
+msgid "Replace - "
+msgstr "Ersetzen - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr ": Befehle für URLs"
+msgid "URL Handlers - "
+msgstr "Befehle für URLs - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr ": Benutzerlistenknöpfe"
+msgid "Userlist buttons - "
+msgstr "Benutzerlistenknöpfe - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr ": Dialogknöpfe"
+msgid "Dialog buttons - "
+msgstr "Dialogknöpfe - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr ": CTCP-Antworten"
+msgid "CTCP Replies - "
+msgstr "CTCP-Antworten - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4509,8 +4509,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Eine kommagetrennte Liste von Netzen wird akzeptiert"
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
-msgstr ": Freundesliste"
+msgid "Friends List - "
+msgstr "Freundesliste - "
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4548,8 +4548,8 @@ msgstr ": Private Nachricht von: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
-msgstr ": Mit %u Netzwerken und %u Channels verbunden"
+msgid "Connected to %u networks and %u channels - "
+msgstr "Mit %u Netzwerken und %u Channels verbunden - "
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4590,43 +4590,43 @@ msgstr "_Zurück"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
-msgstr ": Hervorgehobene Nachricht von: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
+msgstr "Hervorgehobene Nachricht von: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
-msgstr ": %u hervorgehobene Nachrichten, letzte von: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
+msgstr "%u hervorgehobene Nachrichten, letzte von: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr "Kanal-Nachricht von: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
-msgstr ": %u Kanal-Nachrichten."
+msgid "%u channel messages. - "
+msgstr "%u Kanal-Nachrichten. - "
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
-msgstr ": Private Nachricht von: %s (%s)"
+msgid "Private message from: %s (%s) - "
+msgstr "Private Nachricht von: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
-msgstr ": %u private Nachrichten, letzte von: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
+msgstr "%u private Nachrichten, letzte von: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
-msgstr ": Dateiangebot von: %s (%s)"
+msgid "File offer from: %s (%s) - "
+msgstr "Dateiangebot von: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
-msgstr ": %u Dateiangebote, letztes von: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
+msgstr "%u Dateiangebote, letztes von: %s (%s) - "
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4641,8 +4641,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Wählen Sie ein Plugin oder Skript zum Laden"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr ": Plugins und Skripte"
+msgid "Plugins and Scripts - "
+msgstr "Plugins und Skripte - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4663,8 +4663,8 @@ msgstr "Speichern als …"
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
-msgstr ": Rohdatenlogbuch (%s)"
+msgid "Raw Log (%s) - "
+msgstr "Rohdatenlogbuch (%s) - "
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4699,8 +4699,8 @@ msgstr "Die Art, wie Sie sich auf dem Server identifizieren. Für spezielle Logi
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr ": %s ändern"
+msgid "Edit %s - "
+msgstr "%s ändern - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4791,8 +4791,8 @@ msgid "Character set:"
 msgstr "Zeichensatz:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr ": Netzwerkliste"
+msgid "Network List - "
+msgstr "Netzwerkliste - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6156,8 +6156,8 @@ msgid ""
 msgstr "*WARNUNG*\nAutomatisches Annehmen von DCCs in Ihr Home-\nVerzeichnis kann gefährlich sein und ist\nausnutzbar. Zum Beispiel könnte Ihnen jemand\nein .bash_profile schicken."
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr ": Optionen"
+msgid "Preferences - "
+msgstr "Optionen - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6221,8 +6221,8 @@ msgid "OK"
 msgstr "OK"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr ": Gesammelte URLs"
+msgid "URL Grabber - "
+msgstr "Gesammelte URLs - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/el.po
+++ b/po/el.po
@@ -3244,8 +3244,8 @@ msgstr "Μπορείτε να ανοίξετε τη λίστα ban μόνο μέ
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr "XChat: Λίστα Ban (%s)"
+msgid "Ban List (%s) - "
+msgstr "Λίστα Ban (%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3283,8 +3283,8 @@ msgstr "Αν_τιγραφή κειμένου θέματος"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr "XChat: Λίστα καναλιών (%s)"
+msgid "Channel List (%s) - "
+msgstr "Λίστα καναλιών (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3375,8 +3375,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Η συνέχιση λήψης του ίδιου αρχείου από δυο ανθρώπους είναι αδύνατη."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr "XChat: Λήψεις και αποστολές αρχείων"
+msgid "Uploads and Downloads - "
+msgstr "Λήψεις και αποστολές αρχείων - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3433,8 +3433,8 @@ msgid "Open Folder..."
 msgstr "Άνοιγμα Φακέλου..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr "XChat: Λίστα συνομιλίας DCC"
+msgid "DCC Chat List - "
+msgstr "Λίστα συνομιλίας DCC - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3630,8 +3630,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr "XChat: Συντομεύσεις πληκτρολογίου"
+msgid "Keyboard Shortcuts - "
+msgstr "Συντομεύσεις πληκτρολογίου - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3675,8 +3675,8 @@ msgid "Enter mask to ignore:"
 msgstr "Εισάγετε μάσκα προς αγνόηση:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr "XChat: Λίστα αγνοημένων"
+msgid "Ignore list - "
+msgstr "Λίστα αγνοημένων - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3711,8 +3711,8 @@ msgid "Channel name too short, try again."
 msgstr "Το όνομα του καναλιού είναι πολύ μικρό, προσπαθήσετε ξανά."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr "XChat: Η σύνδεση ολοκληρώθηκε"
+msgid "Connection Complete - "
+msgstr "Η σύνδεση ολοκληρώθηκε - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4038,8 +4038,8 @@ msgid "_Auto-Connect"
 msgstr "_Αυτόματη σύνδεση"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr "XChat: Μενού χρήστη"
+msgid "User menu - "
+msgstr "Μενού χρήστη - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4159,36 +4159,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr "XChat: Εντολές καθορισμένες από το χρήστη"
+msgid "User Defined Commands - "
+msgstr "Εντολές καθορισμένες από το χρήστη - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr "XChat: Αναδυόμενο μενού λίστας χρηστών"
+msgid "Userlist Popup menu - "
+msgstr "Αναδυόμενο μενού λίστας χρηστών - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Αντικατάσταση με"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr "XChat: Αντικατάσταση"
+msgid "Replace - "
+msgstr "Αντικατάσταση - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr "XChat: Χειριστές διευθύνσεων"
+msgid "URL Handlers - "
+msgstr "Χειριστές διευθύνσεων - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr "XChat: Κουμπιά λίστας χρηστών"
+msgid "Userlist buttons - "
+msgstr "Κουμπιά λίστας χρηστών - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr "XChat: Κουμπιά διαλόγου"
+msgid "Dialog buttons - "
+msgstr "Κουμπιά διαλόγου - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr "XChat: Απαντήσεις CTCP"
+msgid "CTCP Replies - "
+msgstr "Απαντήσεις CTCP - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4495,8 +4495,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Είναι αποδεκτή μια λίστα δικτύων χωρισμένη με κόμματα."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
-msgstr ": Λίστα φίλων"
+msgid "Friends List - "
+msgstr "Λίστα φίλων - "
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4534,8 +4534,8 @@ msgstr "Προσωπικό μήνυμα από: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
-msgstr "XChat: Συνδεδεμένο σε %u δίκτυα και %u κανάλια"
+msgid "Connected to %u networks and %u channels - "
+msgstr "Συνδεδεμένο σε %u δίκτυα και %u κανάλια - "
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4576,42 +4576,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
-msgstr "XChat: %u επισημασμένα μηνύματα, τελευταίο από: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
+msgstr "%u επισημασμένα μηνύματα, τελευταίο από: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
-msgstr "XChat: Προσωπικό  μήνυμα από: %s (%s)"
+msgid "Private message from: %s (%s) - "
+msgstr "Προσωπικό  μήνυμα από: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
-msgstr "XChat: %u προσωπικά μηνύματα, το τελευταίο από: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
+msgstr "%u προσωπικά μηνύματα, το τελευταίο από: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
-msgstr "XChat: Προσφορά αρχείου από: %s (%s)"
+msgid "File offer from: %s (%s) - "
+msgstr "Προσφορά αρχείου από: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
 msgstr "XChat:%u προσφορές αρχείων, τελευταία από: %s (%s)"
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4627,8 +4627,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Επιλογή ενός πρόσθετου ή δέσμης ενεργειών για φόρτωμα"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr "XChat: Πρόσθετα και δέσμες ενεργειών"
+msgid "Plugins and Scripts - "
+msgstr "Πρόσθετα και δέσμες ενεργειών - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4649,7 +4649,7 @@ msgstr "Αποθήκευση ως..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4685,8 +4685,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr "XChat: Επεξεργασία %s"
+msgid "Edit %s - "
+msgstr "Επεξεργασία %s - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4777,8 +4777,8 @@ msgid "Character set:"
 msgstr "Σετ χαρακτήρων:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr "XChat: Λίστα δικτύων"
+msgid "Network List - "
+msgstr "Λίστα δικτύων - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6142,8 +6142,8 @@ msgid ""
 msgstr "*ΠΡΟΕΙΔΟΠΟΙΗΣΗ*\nΗ αυτόματη αποδοχή DCC στο αρχικό κατάλογό σας\nείναι επικίνδυνη και εκμεταλλεύσιμη. Πχ:\nΚάποιος μπορεί να σας στείλει ένα .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr "XChat: Προτιμήσεις"
+msgid "Preferences - "
+msgstr "Προτιμήσεις - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6207,8 +6207,8 @@ msgid "OK"
 msgstr "Εντάξει"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr "XChat: Καταγραφέας διευθύνσεων"
+msgid "URL Grabber - "
+msgstr "Καταγραφέας διευθύνσεων - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/el.po
+++ b/po/el.po
@@ -3244,8 +3244,8 @@ msgstr "Μπορείτε να ανοίξετε τη λίστα ban μόνο μέ
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "Λίστα Ban (%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "Λίστα Ban (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3283,8 +3283,8 @@ msgstr "Αν_τιγραφή κειμένου θέματος"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr "Λίστα καναλιών (%s) - "
+msgid "Channel List (%s) - %s"
+msgstr "Λίστα καναλιών (%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3375,8 +3375,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Η συνέχιση λήψης του ίδιου αρχείου από δυο ανθρώπους είναι αδύνατη."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "Λήψεις και αποστολές αρχείων - "
+msgid "Uploads and Downloads - %s"
+msgstr "Λήψεις και αποστολές αρχείων - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3433,8 +3433,8 @@ msgid "Open Folder..."
 msgstr "Άνοιγμα Φακέλου..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "Λίστα συνομιλίας DCC - "
+msgid "DCC Chat List - %s"
+msgstr "Λίστα συνομιλίας DCC - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3630,8 +3630,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "Συντομεύσεις πληκτρολογίου - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "Συντομεύσεις πληκτρολογίου - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3675,8 +3675,8 @@ msgid "Enter mask to ignore:"
 msgstr "Εισάγετε μάσκα προς αγνόηση:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "Λίστα αγνοημένων - "
+msgid "Ignore list - %s"
+msgstr "Λίστα αγνοημένων - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3711,8 +3711,8 @@ msgid "Channel name too short, try again."
 msgstr "Το όνομα του καναλιού είναι πολύ μικρό, προσπαθήσετε ξανά."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "Η σύνδεση ολοκληρώθηκε - "
+msgid "Connection Complete - %s"
+msgstr "Η σύνδεση ολοκληρώθηκε - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4038,8 +4038,8 @@ msgid "_Auto-Connect"
 msgstr "_Αυτόματη σύνδεση"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "Μενού χρήστη - "
+msgid "User menu - %s"
+msgstr "Μενού χρήστη - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4159,36 +4159,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "Εντολές καθορισμένες από το χρήστη - "
+msgid "User Defined Commands - %s"
+msgstr "Εντολές καθορισμένες από το χρήστη - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "Αναδυόμενο μενού λίστας χρηστών - "
+msgid "Userlist Popup menu - %s"
+msgstr "Αναδυόμενο μενού λίστας χρηστών - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Αντικατάσταση με"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "Αντικατάσταση - "
+msgid "Replace - %s"
+msgstr "Αντικατάσταση - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "Χειριστές διευθύνσεων - "
+msgid "URL Handlers - %s"
+msgstr "Χειριστές διευθύνσεων - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "Κουμπιά λίστας χρηστών - "
+msgid "Userlist buttons - %s"
+msgstr "Κουμπιά λίστας χρηστών - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "Κουμπιά διαλόγου - "
+msgid "Dialog buttons - %s"
+msgstr "Κουμπιά διαλόγου - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "Απαντήσεις CTCP - "
+msgid "CTCP Replies - %s"
+msgstr "Απαντήσεις CTCP - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4495,8 +4495,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Είναι αποδεκτή μια λίστα δικτύων χωρισμένη με κόμματα."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
-msgstr "Λίστα φίλων - "
+msgid "Friends List - %s"
+msgstr "Λίστα φίλων - %s"
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4534,8 +4534,8 @@ msgstr "Προσωπικό μήνυμα από: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
-msgstr "Συνδεδεμένο σε %u δίκτυα και %u κανάλια - "
+msgid "Connected to %u networks and %u channels - %s"
+msgstr "Συνδεδεμένο σε %u δίκτυα και %u κανάλια - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4576,43 +4576,43 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
-msgstr "%u επισημασμένα μηνύματα, τελευταίο από: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
+msgstr "%u επισημασμένα μηνύματα, τελευταίο από: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
-msgstr "Προσωπικό  μήνυμα από: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
+msgstr "Προσωπικό  μήνυμα από: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
-msgstr "%u προσωπικά μηνύματα, το τελευταίο από: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
+msgstr "%u προσωπικά μηνύματα, το τελευταίο από: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
-msgstr "Προσφορά αρχείου από: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
+msgstr "Προσφορά αρχείου από: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
-msgstr "XChat:%u προσφορές αρχείων, τελευταία από: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - %s"
+msgstr "%u προσφορές αρχείων, τελευταία από: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4627,8 +4627,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Επιλογή ενός πρόσθετου ή δέσμης ενεργειών για φόρτωμα"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "Πρόσθετα και δέσμες ενεργειών - "
+msgid "Plugins and Scripts - %s"
+msgstr "Πρόσθετα και δέσμες ενεργειών - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4649,7 +4649,7 @@ msgstr "Αποθήκευση ως..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4685,8 +4685,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "Επεξεργασία %s - "
+msgid "Edit %s - %s"
+msgstr "Επεξεργασία %s - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4777,8 +4777,8 @@ msgid "Character set:"
 msgstr "Σετ χαρακτήρων:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "Λίστα δικτύων - "
+msgid "Network List - %s"
+msgstr "Λίστα δικτύων - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6142,8 +6142,8 @@ msgid ""
 msgstr "*ΠΡΟΕΙΔΟΠΟΙΗΣΗ*\nΗ αυτόματη αποδοχή DCC στο αρχικό κατάλογό σας\nείναι επικίνδυνη και εκμεταλλεύσιμη. Πχ:\nΚάποιος μπορεί να σας στείλει ένα .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "Προτιμήσεις - "
+msgid "Preferences - %s"
+msgstr "Προτιμήσεις - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6207,8 +6207,8 @@ msgid "OK"
 msgstr "Εντάξει"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "Καταγραφέας διευθύνσεων - "
+msgid "URL Grabber - %s"
+msgstr "Καταγραφέας διευθύνσεων - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -3244,8 +3244,8 @@ msgstr "You can only open the Ban List window while in a channel tab."
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "Ban List (%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "Ban List (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3283,8 +3283,8 @@ msgstr "Copy _Topic Text"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr "Channel List (%s) - "
+msgid "Channel List (%s) - %s"
+msgstr "Channel List (%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3375,8 +3375,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Cannot resume the same file from two people."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "Uploads and Downloads - "
+msgid "Uploads and Downloads - %s"
+msgstr "Uploads and Downloads - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3433,8 +3433,8 @@ msgid "Open Folder..."
 msgstr "Open Folder..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "DCC Chat List - "
+msgid "DCC Chat List - %s"
+msgstr "DCC Chat List - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3630,8 +3630,8 @@ msgid "Select a row to get help information on its Action."
 msgstr "Select a row to get help information on its Action."
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "Keyboard Shortcuts - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "Keyboard Shortcuts - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3675,8 +3675,8 @@ msgid "Enter mask to ignore:"
 msgstr "Enter mask to ignore:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "Ignore list - "
+msgid "Ignore list - %s"
+msgstr "Ignore list - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3711,8 +3711,8 @@ msgid "Channel name too short, try again."
 msgstr "Channel name too short, try again."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "Connection Complete - "
+msgid "Connection Complete - %s"
+msgstr "Connection Complete - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4038,8 +4038,8 @@ msgid "_Auto-Connect"
 msgstr "_Auto-Connect"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "User menu - "
+msgid "User menu - %s"
+msgstr "User menu - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4159,36 +4159,36 @@ msgid ""
 msgstr "URL Handlers - Special codes:\n\n%s  =  the URL string\n\nPutting a ! in front of the command\nindicates it should be sent to a\nshell instead of HexChat"
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "User Defined Commands - "
+msgid "User Defined Commands - %s"
+msgstr "User Defined Commands - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "Userlist Popup menu - "
+msgid "Userlist Popup menu - %s"
+msgstr "Userlist Popup menu - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Replace with"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "Replace - "
+msgid "Replace - %s"
+msgstr "Replace - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "URL Handlers - "
+msgid "URL Handlers - %s"
+msgstr "URL Handlers - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "Userlist buttons - "
+msgid "Userlist buttons - %s"
+msgstr "Userlist buttons - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "Dialogue buttons - "
+msgid "Dialog buttons - %s"
+msgstr "Dialogue buttons - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "CTCP Replies - "
+msgid "CTCP Replies - %s"
+msgstr "CTCP Replies - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4495,8 +4495,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Comma separated list of networks is accepted."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
-msgstr "Friends List - "
+msgid "Friends List - %s"
+msgstr "Friends List - %s"
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4534,8 +4534,8 @@ msgstr "Private message from: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
-msgstr "Connected to %u networks and %u channels - "
+msgid "Connected to %u networks and %u channels - %s"
+msgstr "Connected to %u networks and %u channels - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4576,43 +4576,43 @@ msgstr "_Back"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
-msgstr "%s (%s) -  - "
+msgid "Highlighted message from: %s (%s) - %s"
+msgstr "%s (%s) -  - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
-msgstr "%s (%s) -  - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
+msgstr "%s (%s) -  - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
-msgstr "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
+msgstr "Channel message from: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
-msgstr "%u channel messages. - "
+msgid "%u channel messages. - %s"
+msgstr "%u channel messages. - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
-msgstr "%s (%s) -  - "
+msgid "Private message from: %s (%s) - %s"
+msgstr "%s (%s) -  - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
-msgstr "%s (%s) -  - "
+msgid "%u private messages, latest from: %s (%s) - %s"
+msgstr "%s (%s) -  - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
-msgstr "%s (%s) -  - "
+msgid "File offer from: %s (%s) - %s"
+msgstr "%s (%s) -  - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
-msgstr "%s (%s) -  - "
+msgid "%u file offers, latest from: %s (%s) - %s"
+msgstr "%s (%s) -  - %s"
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4627,8 +4627,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Select a Plugin or Script to load"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "Plugins and Scripts - "
+msgid "Plugins and Scripts - %s"
+msgstr "Plugins and Scripts - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4649,8 +4649,8 @@ msgstr "Save As..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
-msgstr "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
+msgstr "Raw Log (%s) - %s"
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4685,8 +4685,8 @@ msgstr "The way you identify yourself to the server. For custom login methods us
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "Edit %s - "
+msgid "Edit %s - %s"
+msgstr "Edit %s - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4777,8 +4777,8 @@ msgid "Character set:"
 msgstr "Character set:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "Network List - "
+msgid "Network List - %s"
+msgstr "Network List - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6142,8 +6142,8 @@ msgid ""
 msgstr "*WARNING*\nAuto accepting DCC to your home directory\ncan be dangerous and is exploitable. Eg:\nSomeone could send you a .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "Preferences - "
+msgid "Preferences - %s"
+msgstr "Preferences - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6207,8 +6207,8 @@ msgid "OK"
 msgstr "OK"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "URL Grabber - "
+msgid "URL Grabber - %s"
+msgstr "URL Grabber - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -3244,8 +3244,8 @@ msgstr "You can only open the Ban List window while in a channel tab."
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr ": Ban List (%s)"
+msgid "Ban List (%s) - "
+msgstr "Ban List (%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3283,8 +3283,8 @@ msgstr "Copy _Topic Text"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr ": Channel List (%s)"
+msgid "Channel List (%s) - "
+msgstr "Channel List (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3375,8 +3375,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Cannot resume the same file from two people."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr ": Uploads and Downloads"
+msgid "Uploads and Downloads - "
+msgstr "Uploads and Downloads - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3433,8 +3433,8 @@ msgid "Open Folder..."
 msgstr "Open Folder..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr ": DCC Chat List"
+msgid "DCC Chat List - "
+msgstr "DCC Chat List - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3630,8 +3630,8 @@ msgid "Select a row to get help information on its Action."
 msgstr "Select a row to get help information on its Action."
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr ": Keyboard Shortcuts"
+msgid "Keyboard Shortcuts - "
+msgstr "Keyboard Shortcuts - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3675,8 +3675,8 @@ msgid "Enter mask to ignore:"
 msgstr "Enter mask to ignore:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr ": Ignore list"
+msgid "Ignore list - "
+msgstr "Ignore list - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3711,8 +3711,8 @@ msgid "Channel name too short, try again."
 msgstr "Channel name too short, try again."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr ": Connection Complete"
+msgid "Connection Complete - "
+msgstr "Connection Complete - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4038,8 +4038,8 @@ msgid "_Auto-Connect"
 msgstr "_Auto-Connect"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr ": User menu"
+msgid "User menu - "
+msgstr "User menu - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4159,36 +4159,36 @@ msgid ""
 msgstr "URL Handlers - Special codes:\n\n%s  =  the URL string\n\nPutting a ! in front of the command\nindicates it should be sent to a\nshell instead of HexChat"
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr ": User Defined Commands"
+msgid "User Defined Commands - "
+msgstr "User Defined Commands - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr ": Userlist Popup menu"
+msgid "Userlist Popup menu - "
+msgstr "Userlist Popup menu - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Replace with"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr ": Replace"
+msgid "Replace - "
+msgstr "Replace - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr ": URL Handlers"
+msgid "URL Handlers - "
+msgstr "URL Handlers - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr ": Userlist buttons"
+msgid "Userlist buttons - "
+msgstr "Userlist buttons - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr ": Dialogue buttons"
+msgid "Dialog buttons - "
+msgstr "Dialogue buttons - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr ": CTCP Replies"
+msgid "CTCP Replies - "
+msgstr "CTCP Replies - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4495,8 +4495,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Comma separated list of networks is accepted."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
-msgstr ": Friends List"
+msgid "Friends List - "
+msgstr "Friends List - "
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4534,8 +4534,8 @@ msgstr "Private message from: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
-msgstr ": Connected to %u networks and %u channels"
+msgid "Connected to %u networks and %u channels - "
+msgstr "Connected to %u networks and %u channels - "
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4576,43 +4576,43 @@ msgstr "_Back"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
-msgstr ": Highlighted message from: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
+msgstr "%s (%s) -  - "
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
-msgstr ": %u highlighted messages, latest from: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
+msgstr "%s (%s) -  - "
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
-msgstr ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
+msgstr "Channel message from: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
-msgstr ": %u channel messages."
+msgid "%u channel messages. - "
+msgstr "%u channel messages. - "
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
-msgstr ": Private message from: %s (%s)"
+msgid "Private message from: %s (%s) - "
+msgstr "%s (%s) -  - "
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
-msgstr ": %u private messages, latest from: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
+msgstr "%s (%s) -  - "
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
-msgstr ": File offer from: %s (%s)"
+msgid "File offer from: %s (%s) - "
+msgstr "%s (%s) -  - "
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
-msgstr ": %u file offers, latest from: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
+msgstr "%s (%s) -  - "
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4627,8 +4627,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Select a Plugin or Script to load"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr ": Plugins and Scripts"
+msgid "Plugins and Scripts - "
+msgstr "Plugins and Scripts - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4649,8 +4649,8 @@ msgstr "Save As..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
-msgstr ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
+msgstr "Raw Log (%s) - "
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4685,8 +4685,8 @@ msgstr "The way you identify yourself to the server. For custom login methods us
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr ": Edit %s"
+msgid "Edit %s - "
+msgstr "Edit %s - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4777,8 +4777,8 @@ msgid "Character set:"
 msgstr "Character set:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr ": Network List"
+msgid "Network List - "
+msgstr "Network List - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6142,8 +6142,8 @@ msgid ""
 msgstr "*WARNING*\nAuto accepting DCC to your home directory\ncan be dangerous and is exploitable. Eg:\nSomeone could send you a .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr ": Preferences"
+msgid "Preferences - "
+msgstr "Preferences - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6207,8 +6207,8 @@ msgid "OK"
 msgstr "OK"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr ": URL Grabber"
+msgid "URL Grabber - "
+msgstr "URL Grabber - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/es.po
+++ b/po/es.po
@@ -3247,8 +3247,8 @@ msgstr "Sólo puedes abrir la lista de bans mientras hay pestaña de canal."
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "Lista de baneos (%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "Lista de baneos (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3286,8 +3286,8 @@ msgstr "Copiar el texto del _tema"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr "Lista de canales (%s) - "
+msgid "Channel List (%s) - %s"
+msgstr "Lista de canales (%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3378,8 +3378,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "No se puede retomar el mismo archivo de dos personas."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "Subidas y descargas - "
+msgid "Uploads and Downloads - %s"
+msgstr "Subidas y descargas - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3436,8 +3436,8 @@ msgid "Open Folder..."
 msgstr "Abrir carpeta..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "Lista de conversación DCC - "
+msgid "DCC Chat List - %s"
+msgstr "Lista de conversación DCC - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3633,8 +3633,8 @@ msgid "Select a row to get help information on its Action."
 msgstr "Selecciona una fila para obtener ayuda en su acción."
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "atajos de teclado - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "atajos de teclado - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3678,8 +3678,8 @@ msgid "Enter mask to ignore:"
 msgstr "Introduzca la máscara que quiere ignorar:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "Lista de ignorados - "
+msgid "Ignore list - %s"
+msgstr "Lista de ignorados - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3714,8 +3714,8 @@ msgid "Channel name too short, try again."
 msgstr "Nombre de canal muy corto, intente de nuevo."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "Conexión completa - "
+msgid "Connection Complete - %s"
+msgstr "Conexión completa - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4041,8 +4041,8 @@ msgid "_Auto-Connect"
 msgstr "_Autoconectar"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "Menú de usuario - "
+msgid "User menu - %s"
+msgstr "Menú de usuario - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4162,36 +4162,36 @@ msgid ""
 msgstr "Manejadores de URL - Códigos especiales:\n\n%s  =  la cadena de URL\n\nPoniendo un ! en frente del comando\nindica que debe de ser enviado a una\nshell en lugar de HexChat"
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "Órdenes definidas por el usuario - "
+msgid "User Defined Commands - %s"
+msgstr "Órdenes definidas por el usuario - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "Menú emergente de la lista de usuarios - "
+msgid "Userlist Popup menu - %s"
+msgstr "Menú emergente de la lista de usuarios - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Reemplazar con"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "Reemplazar - "
+msgid "Replace - %s"
+msgstr "Reemplazar - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "Manejadores de URL - "
+msgid "URL Handlers - %s"
+msgstr "Manejadores de URL - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "Botones de la lista de usuarios - "
+msgid "Userlist buttons - %s"
+msgstr "Botones de la lista de usuarios - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "Botones de diálogo - "
+msgid "Dialog buttons - %s"
+msgstr "Botones de diálogo - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "Respuestas CTCP - "
+msgid "CTCP Replies - %s"
+msgstr "Respuestas CTCP - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4498,8 +4498,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Lista de redes separada por comas es aceptada."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
-msgstr "Lista de amigos - "
+msgid "Friends List - %s"
+msgstr "Lista de amigos - %s"
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4537,8 +4537,8 @@ msgstr "Mensaje privado de: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
-msgstr "Conectado a %u redes y %u canales - "
+msgid "Connected to %u networks and %u channels - %s"
+msgstr "Conectado a %u redes y %u canales - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4579,43 +4579,43 @@ msgstr "_Conectado"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
-msgstr "Mensaje resaltado desde: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
+msgstr "Mensaje resaltado desde: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
-msgstr "%u mensajes resaltados, el último desde: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
+msgstr "%u mensajes resaltados, el último desde: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
-msgstr "Mensaje de canal de: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
+msgstr "Mensaje de canal de: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
-msgstr "%u mensajes de canal. - "
+msgid "%u channel messages. - %s"
+msgstr "%u mensajes de canal. - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
-msgstr "Mensaje privado desde: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
+msgstr "Mensaje privado desde: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
-msgstr "%u mensajes privados, el último desde: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
+msgstr "%u mensajes privados, el último desde: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
-msgstr "Archivo desde: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
+msgstr "Archivo desde: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
-msgstr "%u archivos, el último desde: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
+msgstr "%u archivos, el último desde: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4630,8 +4630,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Seleccione una extensión o guión a cargar"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "complementos y guiones - "
+msgid "Plugins and Scripts - %s"
+msgstr "complementos y guiones - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4652,8 +4652,8 @@ msgstr "Guardar como..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
-msgstr "Registro plano (%s) - "
+msgid "Raw Log (%s) - %s"
+msgstr "Registro plano (%s) - %s"
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4688,8 +4688,8 @@ msgstr "La manera en que te identificas al servidor. Para usar un método distin
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "Editar %s - "
+msgid "Edit %s - %s"
+msgstr "Editar %s - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4780,8 +4780,8 @@ msgid "Character set:"
 msgstr "Juego de caracteres:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "Lista de redes - "
+msgid "Network List - %s"
+msgstr "Lista de redes - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6145,8 +6145,8 @@ msgid ""
 msgstr "*ADVERTENCIA*\nAceptar automáticamente DCC hacia su directorio de inicio\npuede ser peligroso y es explotable. Por ejemplo: Alguien \npuede enviarle un archivo .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "Preferencias - "
+msgid "Preferences - %s"
+msgstr "Preferencias - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6210,8 +6210,8 @@ msgid "OK"
 msgstr "Ok"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "Capturador de URL - "
+msgid "URL Grabber - %s"
+msgstr "Capturador de URL - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/es.po
+++ b/po/es.po
@@ -3247,8 +3247,8 @@ msgstr "Sólo puedes abrir la lista de bans mientras hay pestaña de canal."
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr "XChat: Lista de baneos (%s)"
+msgid "Ban List (%s) - "
+msgstr "Lista de baneos (%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3286,8 +3286,8 @@ msgstr "Copiar el texto del _tema"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr "XChat: Lista de canales (%s)"
+msgid "Channel List (%s) - "
+msgstr "Lista de canales (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3378,8 +3378,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "No se puede retomar el mismo archivo de dos personas."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr ": Subidas y descargas"
+msgid "Uploads and Downloads - "
+msgstr "Subidas y descargas - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3436,8 +3436,8 @@ msgid "Open Folder..."
 msgstr "Abrir carpeta..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr "XChat: Lista de conversación DCC"
+msgid "DCC Chat List - "
+msgstr "Lista de conversación DCC - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3633,8 +3633,8 @@ msgid "Select a row to get help information on its Action."
 msgstr "Selecciona una fila para obtener ayuda en su acción."
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr "XChat: atajos de teclado"
+msgid "Keyboard Shortcuts - "
+msgstr "atajos de teclado - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3678,8 +3678,8 @@ msgid "Enter mask to ignore:"
 msgstr "Introduzca la máscara que quiere ignorar:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr "XChat: Lista de ignorados"
+msgid "Ignore list - "
+msgstr "Lista de ignorados - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3714,8 +3714,8 @@ msgid "Channel name too short, try again."
 msgstr "Nombre de canal muy corto, intente de nuevo."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr "XChat: Conexión completa"
+msgid "Connection Complete - "
+msgstr "Conexión completa - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4041,8 +4041,8 @@ msgid "_Auto-Connect"
 msgstr "_Autoconectar"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr "XChat: Menú de usuario"
+msgid "User menu - "
+msgstr "Menú de usuario - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4162,36 +4162,36 @@ msgid ""
 msgstr "Manejadores de URL - Códigos especiales:\n\n%s  =  la cadena de URL\n\nPoniendo un ! en frente del comando\nindica que debe de ser enviado a una\nshell en lugar de HexChat"
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr "XChat: Órdenes definidas por el usuario"
+msgid "User Defined Commands - "
+msgstr "Órdenes definidas por el usuario - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr "XChat: Menú emergente de la lista de usuarios"
+msgid "Userlist Popup menu - "
+msgstr "Menú emergente de la lista de usuarios - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Reemplazar con"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr "XChat: Reemplazar"
+msgid "Replace - "
+msgstr "Reemplazar - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr "XChat: Manejadores de URL"
+msgid "URL Handlers - "
+msgstr "Manejadores de URL - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr "XChat: Botones de la lista de usuarios"
+msgid "Userlist buttons - "
+msgstr "Botones de la lista de usuarios - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr "XChat: Botones de diálogo"
+msgid "Dialog buttons - "
+msgstr "Botones de diálogo - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr "XChat: Respuestas CTCP"
+msgid "CTCP Replies - "
+msgstr "Respuestas CTCP - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4498,8 +4498,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Lista de redes separada por comas es aceptada."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
-msgstr ": Lista de amigos"
+msgid "Friends List - "
+msgstr "Lista de amigos - "
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4537,8 +4537,8 @@ msgstr "Mensaje privado de: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
-msgstr ": Conectado a %u redes y %u canales"
+msgid "Connected to %u networks and %u channels - "
+msgstr "Conectado a %u redes y %u canales - "
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4579,43 +4579,43 @@ msgstr "_Conectado"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
-msgstr ": Mensaje resaltado desde: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
+msgstr "Mensaje resaltado desde: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
-msgstr ": %u mensajes resaltados, el último desde: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
+msgstr "%u mensajes resaltados, el último desde: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
-msgstr ": Mensaje de canal de: %s (%s)"
+msgid "Channel message from: %s (%s) - "
+msgstr "Mensaje de canal de: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
-msgstr ": %u mensajes de canal."
+msgid "%u channel messages. - "
+msgstr "%u mensajes de canal. - "
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
-msgstr ": Mensaje privado desde: %s (%s)"
+msgid "Private message from: %s (%s) - "
+msgstr "Mensaje privado desde: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
-msgstr ": %u mensajes privados, el último desde: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
+msgstr "%u mensajes privados, el último desde: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
-msgstr ": Archivo desde: %s (%s)"
+msgid "File offer from: %s (%s) - "
+msgstr "Archivo desde: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
-msgstr ": %u archivos, el último desde: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
+msgstr "%u archivos, el último desde: %s (%s) - "
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4630,8 +4630,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Seleccione una extensión o guión a cargar"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr "XChat: complementos y guiones"
+msgid "Plugins and Scripts - "
+msgstr "complementos y guiones - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4652,8 +4652,8 @@ msgstr "Guardar como..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
-msgstr ": Registro plano (%s)"
+msgid "Raw Log (%s) - "
+msgstr "Registro plano (%s) - "
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4688,8 +4688,8 @@ msgstr "La manera en que te identificas al servidor. Para usar un método distin
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr "XChat: Editar %s"
+msgid "Edit %s - "
+msgstr "Editar %s - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4780,8 +4780,8 @@ msgid "Character set:"
 msgstr "Juego de caracteres:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr ": Lista de redes"
+msgid "Network List - "
+msgstr "Lista de redes - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6145,8 +6145,8 @@ msgid ""
 msgstr "*ADVERTENCIA*\nAceptar automáticamente DCC hacia su directorio de inicio\npuede ser peligroso y es explotable. Por ejemplo: Alguien \npuede enviarle un archivo .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr "XChat: Preferencias"
+msgid "Preferences - "
+msgstr "Preferencias - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6210,8 +6210,8 @@ msgid "OK"
 msgstr "Ok"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr "XChat: Capturador de URL"
+msgid "URL Grabber - "
+msgstr "Capturador de URL - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/et.po
+++ b/po/et.po
@@ -3240,8 +3240,8 @@ msgstr "Bännitute nimekirja saab vaadata ainult siis, kui mõni kanal aktiivne 
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr "XChat: bännitute nimekiri (%s)"
+msgid "Ban List (%s) - "
+msgstr "bännitute nimekiri (%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3279,8 +3279,8 @@ msgstr "Kopeeri _teemaväli"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr "XChat: kanalid (%s)"
+msgid "Channel List (%s) - "
+msgstr "kanalid (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3371,8 +3371,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Ei saa jätkata sama faili tõmbamist kahelt inimeselt."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr "XChat: Üles- ja allalaadimised"
+msgid "Uploads and Downloads - "
+msgstr "Üles- ja allalaadimised - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3429,8 +3429,8 @@ msgid "Open Folder..."
 msgstr "Ava kataloog..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr "XChat: DCC vestluste nimekiri"
+msgid "DCC Chat List - "
+msgstr "DCC vestluste nimekiri - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3626,8 +3626,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr "XChat: klaviatuuriotseteed"
+msgid "Keyboard Shortcuts - "
+msgstr "klaviatuuriotseteed - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3671,8 +3671,8 @@ msgid "Enter mask to ignore:"
 msgstr "Ignoreeritav hostimask:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr "XChat: ignoreeritavate nimekiri"
+msgid "Ignore list - "
+msgstr "ignoreeritavate nimekiri - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3707,8 +3707,8 @@ msgid "Channel name too short, try again."
 msgstr "Kanali nimi on liiga lühike, proovi uuesti."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr "XChat: Ühendatud"
+msgid "Connection Complete - "
+msgstr "Ühendatud - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4034,8 +4034,8 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr "XChat: Kasutja menüü"
+msgid "User menu - "
+msgstr "Kasutja menüü - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4155,36 +4155,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr "XChat: kasutaja määratud käsud"
+msgid "User Defined Commands - "
+msgstr "kasutaja määratud käsud - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr "X-Chat: kasutajate nimekirja popup"
+msgid "Userlist Popup menu - "
+msgstr "kasutajate nimekirja popup - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr "XChat: asenda"
+msgid "Replace - "
+msgstr "asenda - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr "XChat: URLi käsitlejad"
+msgid "URL Handlers - "
+msgstr "URLi käsitlejad - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr "XChat: kasutajate nimekirja nupud"
+msgid "Userlist buttons - "
+msgstr "kasutajate nimekirja nupud - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr "XChat: dialooginupud"
+msgid "Dialog buttons - "
+msgstr "dialooginupud - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr "XChat: CTCP vastused"
+msgid "CTCP Replies - "
+msgstr "CTCP vastused - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4491,7 +4491,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Mitu võrgunime eralda komadega."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
+msgid "Friends List - "
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4530,8 +4530,8 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
-msgstr "XChat: Ühendatud %u võrgu ja %u kanaliga"
+msgid "Connected to %u networks and %u channels - "
+msgstr "Ühendatud %u võrgu ja %u kanaliga - "
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4572,43 +4572,43 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
-msgstr "XChat: Esiletõstetud sõnum: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
+msgstr "Esiletõstetud sõnum: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
-msgstr "XChat: %u esiletõstetud sõnumit, viimane: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
+msgstr "%u esiletõstetud sõnumit, viimane: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
-msgstr "XChat: Privaatsõnum: %s (%s)"
+msgid "Private message from: %s (%s) - "
+msgstr "Privaatsõnum: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
-msgstr "XChat: %u privaatsõnumit. Viimane kasutajalt: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
+msgstr "%u privaatsõnumit. Viimane kasutajalt: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
-msgstr "XChat: Faili pakkumine kasutajalt: %s (%s)"
+msgid "File offer from: %s (%s) - "
+msgstr "Faili pakkumine kasutajalt: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
-msgstr "XChat: %u faili pakkumist. Viimane kasutajalt: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
+msgstr "%u faili pakkumist. Viimane kasutajalt: %s (%s) - "
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4623,8 +4623,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Vali laetav plugin või skript"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr "XChat: pluginad ja skriptid"
+msgid "Plugins and Scripts - "
+msgstr "pluginad ja skriptid - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4645,7 +4645,7 @@ msgstr "Salvesta kui..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4681,8 +4681,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr "XChat: Muuda %s"
+msgid "Edit %s - "
+msgstr "Muuda %s - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4773,8 +4773,8 @@ msgid "Character set:"
 msgstr "Märgistik:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr "XChat: serverite nimekiri"
+msgid "Network List - "
+msgstr "serverite nimekiri - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6138,8 +6138,8 @@ msgid ""
 msgstr "*HOIATUS*\nDCC failide automaatne kodukataloogi salvestamine\non ohtlik ja ära kasutatav. Näiteks võin keegi\nsaata sulle faili .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr "X-Chat: häälestus"
+msgid "Preferences - "
+msgstr "häälestus - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6203,8 +6203,8 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr "X-Chat: URLipüüdja"
+msgid "URL Grabber - "
+msgstr "URLipüüdja - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/et.po
+++ b/po/et.po
@@ -3240,8 +3240,8 @@ msgstr "Bännitute nimekirja saab vaadata ainult siis, kui mõni kanal aktiivne 
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "bännitute nimekiri (%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "bännitute nimekiri (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3279,8 +3279,8 @@ msgstr "Kopeeri _teemaväli"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr "kanalid (%s) - "
+msgid "Channel List (%s) - %s"
+msgstr "kanalid (%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3371,8 +3371,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Ei saa jätkata sama faili tõmbamist kahelt inimeselt."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "Üles- ja allalaadimised - "
+msgid "Uploads and Downloads - %s"
+msgstr "Üles- ja allalaadimised - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3429,8 +3429,8 @@ msgid "Open Folder..."
 msgstr "Ava kataloog..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "DCC vestluste nimekiri - "
+msgid "DCC Chat List - %s"
+msgstr "DCC vestluste nimekiri - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3626,8 +3626,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "klaviatuuriotseteed - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "klaviatuuriotseteed - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3671,8 +3671,8 @@ msgid "Enter mask to ignore:"
 msgstr "Ignoreeritav hostimask:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "ignoreeritavate nimekiri - "
+msgid "Ignore list - %s"
+msgstr "ignoreeritavate nimekiri - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3707,8 +3707,8 @@ msgid "Channel name too short, try again."
 msgstr "Kanali nimi on liiga lühike, proovi uuesti."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "Ühendatud - "
+msgid "Connection Complete - %s"
+msgstr "Ühendatud - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4034,8 +4034,8 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "Kasutja menüü - "
+msgid "User menu - %s"
+msgstr "Kasutja menüü - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4155,36 +4155,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "kasutaja määratud käsud - "
+msgid "User Defined Commands - %s"
+msgstr "kasutaja määratud käsud - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "kasutajate nimekirja popup - "
+msgid "Userlist Popup menu - %s"
+msgstr "kasutajate nimekirja popup - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "asenda - "
+msgid "Replace - %s"
+msgstr "asenda - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "URLi käsitlejad - "
+msgid "URL Handlers - %s"
+msgstr "URLi käsitlejad - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "kasutajate nimekirja nupud - "
+msgid "Userlist buttons - %s"
+msgstr "kasutajate nimekirja nupud - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "dialooginupud - "
+msgid "Dialog buttons - %s"
+msgstr "dialooginupud - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "CTCP vastused - "
+msgid "CTCP Replies - %s"
+msgstr "CTCP vastused - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4491,7 +4491,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Mitu võrgunime eralda komadega."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
+msgid "Friends List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4530,8 +4530,8 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
-msgstr "Ühendatud %u võrgu ja %u kanaliga - "
+msgid "Connected to %u networks and %u channels - %s"
+msgstr "Ühendatud %u võrgu ja %u kanaliga - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4572,43 +4572,43 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
-msgstr "Esiletõstetud sõnum: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
+msgstr "Esiletõstetud sõnum: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
-msgstr "%u esiletõstetud sõnumit, viimane: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
+msgstr "%u esiletõstetud sõnumit, viimane: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
-msgstr "Privaatsõnum: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
+msgstr "Privaatsõnum: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
-msgstr "%u privaatsõnumit. Viimane kasutajalt: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
+msgstr "%u privaatsõnumit. Viimane kasutajalt: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
-msgstr "Faili pakkumine kasutajalt: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
+msgstr "Faili pakkumine kasutajalt: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
-msgstr "%u faili pakkumist. Viimane kasutajalt: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
+msgstr "%u faili pakkumist. Viimane kasutajalt: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4623,8 +4623,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Vali laetav plugin või skript"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "pluginad ja skriptid - "
+msgid "Plugins and Scripts - %s"
+msgstr "pluginad ja skriptid - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4645,7 +4645,7 @@ msgstr "Salvesta kui..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4681,8 +4681,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "Muuda %s - "
+msgid "Edit %s - %s"
+msgstr "Muuda %s - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4773,8 +4773,8 @@ msgid "Character set:"
 msgstr "Märgistik:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "serverite nimekiri - "
+msgid "Network List - %s"
+msgstr "serverite nimekiri - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6138,8 +6138,8 @@ msgid ""
 msgstr "*HOIATUS*\nDCC failide automaatne kodukataloogi salvestamine\non ohtlik ja ära kasutatav. Näiteks võin keegi\nsaata sulle faili .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "häälestus - "
+msgid "Preferences - %s"
+msgstr "häälestus - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6203,8 +6203,8 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "URLipüüdja - "
+msgid "URL Grabber - %s"
+msgstr "URLipüüdja - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/eu.po
+++ b/po/eu.po
@@ -3240,7 +3240,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
+msgid "Ban List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3279,7 +3279,7 @@ msgstr "Kopiatu g_aiaren testua"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
+msgid "Channel List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3371,7 +3371,7 @@ msgid "Cannot resume the same file from two people."
 msgstr "Ezin da bi pertsonen fitxategi berdinarekin jarraitu"
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
+msgid "Uploads and Downloads - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3429,7 +3429,7 @@ msgid "Open Folder..."
 msgstr "Ireki karpeta..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
+msgid "DCC Chat List - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3626,7 +3626,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
+msgid "Keyboard Shortcuts - "
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3671,7 +3671,7 @@ msgid "Enter mask to ignore:"
 msgstr "Sartu ignoratu nahi duzun maskara:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
+msgid "Ignore list - "
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3707,7 +3707,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
+msgid "Connection Complete - "
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4034,7 +4034,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
+msgid "User menu - "
 msgstr ""
 
 #. sep
@@ -4155,11 +4155,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
+msgid "User Defined Commands - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
+msgid "Userlist Popup menu - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4167,23 +4167,23 @@ msgid "Replace with"
 msgstr "Ordeztu honekin"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr ": Ordeztu"
+msgid "Replace - "
+msgstr "Ordeztu - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
+msgid "URL Handlers - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
+msgid "Userlist buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
+msgid "Dialog buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
+msgid "CTCP Replies - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4491,7 +4491,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
+msgid "Friends List - "
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4530,7 +4530,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
+msgid "Connected to %u networks and %u channels - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4572,42 +4572,42 @@ msgstr "_Itzuli"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
+msgid "Private message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
+msgid "File offer from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4623,7 +4623,7 @@ msgid "Select a Plugin or Script to load"
 msgstr "Aukeratu kargatzeko plugin edo skript bat"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
+msgid "Plugins and Scripts - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4645,7 +4645,7 @@ msgstr "Gorde honela..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4681,7 +4681,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
+msgid "Edit %s - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4773,7 +4773,7 @@ msgid "Character set:"
 msgstr "Karaktere-jokoa:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
+msgid "Network List - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6138,8 +6138,8 @@ msgid ""
 msgstr "*OHARRA*\nDCCak automatikoki onartzea zure etxe karpetara\nkaltegarria izan daiteke. Adibidez norbaitek\n.bash_profile fitxategia bidali dezake"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr ": Hobespenak"
+msgid "Preferences - "
+msgstr "Hobespenak - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6203,7 +6203,7 @@ msgid "OK"
 msgstr "Ados"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
+msgid "URL Grabber - "
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/eu.po
+++ b/po/eu.po
@@ -3240,7 +3240,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
+msgid "Ban List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3279,7 +3279,7 @@ msgstr "Kopiatu g_aiaren testua"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
+msgid "Channel List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3371,7 +3371,7 @@ msgid "Cannot resume the same file from two people."
 msgstr "Ezin da bi pertsonen fitxategi berdinarekin jarraitu"
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
+msgid "Uploads and Downloads - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3429,7 +3429,7 @@ msgid "Open Folder..."
 msgstr "Ireki karpeta..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
+msgid "DCC Chat List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3626,7 +3626,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
+msgid "Keyboard Shortcuts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3671,7 +3671,7 @@ msgid "Enter mask to ignore:"
 msgstr "Sartu ignoratu nahi duzun maskara:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
+msgid "Ignore list - %s"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3707,7 +3707,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
+msgid "Connection Complete - %s"
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4034,7 +4034,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
+msgid "User menu - %s"
 msgstr ""
 
 #. sep
@@ -4155,11 +4155,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
+msgid "User Defined Commands - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
+msgid "Userlist Popup menu - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4167,23 +4167,23 @@ msgid "Replace with"
 msgstr "Ordeztu honekin"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "Ordeztu - "
+msgid "Replace - %s"
+msgstr "Ordeztu - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
+msgid "URL Handlers - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
+msgid "Userlist buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
+msgid "Dialog buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
+msgid "CTCP Replies - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4491,7 +4491,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
+msgid "Friends List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4530,7 +4530,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
+msgid "Connected to %u networks and %u channels - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4572,42 +4572,42 @@ msgstr "_Itzuli"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4623,7 +4623,7 @@ msgid "Select a Plugin or Script to load"
 msgstr "Aukeratu kargatzeko plugin edo skript bat"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
+msgid "Plugins and Scripts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4645,7 +4645,7 @@ msgstr "Gorde honela..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4681,7 +4681,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
+msgid "Edit %s - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4773,7 +4773,7 @@ msgid "Character set:"
 msgstr "Karaktere-jokoa:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
+msgid "Network List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6138,8 +6138,8 @@ msgid ""
 msgstr "*OHARRA*\nDCCak automatikoki onartzea zure etxe karpetara\nkaltegarria izan daiteke. Adibidez norbaitek\n.bash_profile fitxategia bidali dezake"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "Hobespenak - "
+msgid "Preferences - %s"
+msgstr "Hobespenak - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6203,7 +6203,7 @@ msgid "OK"
 msgstr "Ados"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
+msgid "URL Grabber - %s"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/fi.po
+++ b/po/fi.po
@@ -3239,8 +3239,8 @@ msgstr "Banniluettelon voi avata vain, kun jokin kanavaikkuna on valittuna."
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr "XChat: Banniluettelo (%s)"
+msgid "Ban List (%s) - "
+msgstr "Banniluettelo (%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3278,8 +3278,8 @@ msgstr "Kopioi kanavan aihepiiriteksti"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr "XChat: Kanavaluettelo (%s)"
+msgid "Channel List (%s) - "
+msgstr "Kanavaluettelo (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3370,8 +3370,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Saman tiedoston siirtoa ei voi jatkaa kahdelta käyttäjältä."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr "XChat: Tiedostonsiirrot"
+msgid "Uploads and Downloads - "
+msgstr "Tiedostonsiirrot - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3428,8 +3428,8 @@ msgid "Open Folder..."
 msgstr "Avaa kansio..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr "XChat: DCC-keskusteluluettelo"
+msgid "DCC Chat List - "
+msgstr "DCC-keskusteluluettelo - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3625,8 +3625,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr "XChat: Pikanäppäimet"
+msgid "Keyboard Shortcuts - "
+msgstr "Pikanäppäimet - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3670,8 +3670,8 @@ msgid "Enter mask to ignore:"
 msgstr "Anna peite huomiotta jätettäville:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr "XChat: Huomioimattomuusluettelo"
+msgid "Ignore list - "
+msgstr "Huomioimattomuusluettelo - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3706,8 +3706,8 @@ msgid "Channel name too short, try again."
 msgstr "Kanavan nimi on liian lyhyt. Yritä uudestaan."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr "XChat: Yhteys muodostettu"
+msgid "Connection Complete - "
+msgstr "Yhteys muodostettu - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4033,8 +4033,8 @@ msgid "_Auto-Connect"
 msgstr "_Yhdistä automaattisesti"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr "XChat: Käyttäjän valikko"
+msgid "User menu - "
+msgstr "Käyttäjän valikko - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4154,36 +4154,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr "XChat: Käyttäjän määrittelemät komennot"
+msgid "User Defined Commands - "
+msgstr "Käyttäjän määrittelemät komennot - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr "XChat: Käyttäjäluettelon ponnahdusvalikko"
+msgid "Userlist Popup menu - "
+msgstr "Käyttäjäluettelon ponnahdusvalikko - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Korvaava teksti"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr "XChat: Korvaaminen"
+msgid "Replace - "
+msgstr "Korvaaminen - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr "XChat: URL-käsittelimet"
+msgid "URL Handlers - "
+msgstr "URL-käsittelimet - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr "XChat: Käyttäjäluettelon painikkeet"
+msgid "Userlist buttons - "
+msgstr "Käyttäjäluettelon painikkeet - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr "XChat: Keskusteluikkunan painikkeet"
+msgid "Dialog buttons - "
+msgstr "Keskusteluikkunan painikkeet - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr "XChat: CTCP-vastaukset"
+msgid "CTCP Replies - "
+msgstr "CTCP-vastaukset - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4490,8 +4490,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Pilkuilla eroteltu luettelo IRC-verkkoja."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
-msgstr ": Kaverilista"
+msgid "Friends List - "
+msgstr "Kaverilista - "
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4529,8 +4529,8 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
-msgstr "XChat: Yhteydessä %u verkkoon ja %u kanavaan"
+msgid "Connected to %u networks and %u channels - "
+msgstr "Yhteydessä %u verkkoon ja %u kanavaan - "
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4571,43 +4571,43 @@ msgstr "Palaa _takaisin"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
-msgstr "XChat: Korostettu viesti käyttäjältä %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
+msgstr "Korostettu viesti käyttäjältä %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
-msgstr "XChat: %u korostettua viestiä, viimeksi käyttäjältä %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
+msgstr "%u korostettua viestiä, viimeksi käyttäjältä %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
-msgstr "XChat: Yksityisviesti käyttäjältä %s (%s)"
+msgid "Private message from: %s (%s) - "
+msgstr "Yksityisviesti käyttäjältä %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
-msgstr "XChat: %u yksityisviestiä, viimeksi käyttäjältä %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
+msgstr "%u yksityisviestiä, viimeksi käyttäjältä %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
-msgstr "XChat: Käyttäjä %s tarjoaa tiedostoa (%s)"
+msgid "File offer from: %s (%s) - "
+msgstr "Käyttäjä %s tarjoaa tiedostoa (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
-msgstr "XChat: %u tiedostoa tarjottu, vimeksi käyttäjältä %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
+msgstr "%u tiedostoa tarjottu, vimeksi käyttäjältä %s (%s) - "
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4622,8 +4622,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Valitse ladattava skripti tai liitännäinen"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr "XChat: Skriptit ja liitännäiset"
+msgid "Plugins and Scripts - "
+msgstr "Skriptit ja liitännäiset - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4644,7 +4644,7 @@ msgstr "Tallenna..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4680,8 +4680,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr "XChat: Muokkaa %s-verkkoa"
+msgid "Edit %s - "
+msgstr "Muokkaa %s-verkkoa - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4772,8 +4772,8 @@ msgid "Character set:"
 msgstr "Merkistö:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr " : Verkkoluettelo"
+msgid "Network List - "
+msgstr "Verkkoluettelo - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6137,8 +6137,8 @@ msgid ""
 msgstr "*VAROITUS*\nDCC-siirtojen automaattinen hyväksyminen\nkotihakemistoon voi olla vaarallista. Esim:\nJoku voi lähettää tiedoston .bash_profile."
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr "XChat: Ominaisuudet"
+msgid "Preferences - "
+msgstr "Ominaisuudet - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6202,8 +6202,8 @@ msgid "OK"
 msgstr "OK"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr "XChat: URL-kaappaaja"
+msgid "URL Grabber - "
+msgstr "URL-kaappaaja - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/fi.po
+++ b/po/fi.po
@@ -3239,8 +3239,8 @@ msgstr "Banniluettelon voi avata vain, kun jokin kanavaikkuna on valittuna."
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "Banniluettelo (%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "Banniluettelo (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3278,8 +3278,8 @@ msgstr "Kopioi kanavan aihepiiriteksti"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr "Kanavaluettelo (%s) - "
+msgid "Channel List (%s) - %s"
+msgstr "Kanavaluettelo (%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3370,8 +3370,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Saman tiedoston siirtoa ei voi jatkaa kahdelta käyttäjältä."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "Tiedostonsiirrot - "
+msgid "Uploads and Downloads - %s"
+msgstr "Tiedostonsiirrot - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3428,8 +3428,8 @@ msgid "Open Folder..."
 msgstr "Avaa kansio..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "DCC-keskusteluluettelo - "
+msgid "DCC Chat List - %s"
+msgstr "DCC-keskusteluluettelo - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3625,8 +3625,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "Pikanäppäimet - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "Pikanäppäimet - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3670,8 +3670,8 @@ msgid "Enter mask to ignore:"
 msgstr "Anna peite huomiotta jätettäville:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "Huomioimattomuusluettelo - "
+msgid "Ignore list - %s"
+msgstr "Huomioimattomuusluettelo - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3706,8 +3706,8 @@ msgid "Channel name too short, try again."
 msgstr "Kanavan nimi on liian lyhyt. Yritä uudestaan."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "Yhteys muodostettu - "
+msgid "Connection Complete - %s"
+msgstr "Yhteys muodostettu - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4033,8 +4033,8 @@ msgid "_Auto-Connect"
 msgstr "_Yhdistä automaattisesti"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "Käyttäjän valikko - "
+msgid "User menu - %s"
+msgstr "Käyttäjän valikko - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4154,36 +4154,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "Käyttäjän määrittelemät komennot - "
+msgid "User Defined Commands - %s"
+msgstr "Käyttäjän määrittelemät komennot - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "Käyttäjäluettelon ponnahdusvalikko - "
+msgid "Userlist Popup menu - %s"
+msgstr "Käyttäjäluettelon ponnahdusvalikko - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Korvaava teksti"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "Korvaaminen - "
+msgid "Replace - %s"
+msgstr "Korvaaminen - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "URL-käsittelimet - "
+msgid "URL Handlers - %s"
+msgstr "URL-käsittelimet - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "Käyttäjäluettelon painikkeet - "
+msgid "Userlist buttons - %s"
+msgstr "Käyttäjäluettelon painikkeet - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "Keskusteluikkunan painikkeet - "
+msgid "Dialog buttons - %s"
+msgstr "Keskusteluikkunan painikkeet - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "CTCP-vastaukset - "
+msgid "CTCP Replies - %s"
+msgstr "CTCP-vastaukset - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4490,8 +4490,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Pilkuilla eroteltu luettelo IRC-verkkoja."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
-msgstr "Kaverilista - "
+msgid "Friends List - %s"
+msgstr "Kaverilista - %s"
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4529,8 +4529,8 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
-msgstr "Yhteydessä %u verkkoon ja %u kanavaan - "
+msgid "Connected to %u networks and %u channels - %s"
+msgstr "Yhteydessä %u verkkoon ja %u kanavaan - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4571,43 +4571,43 @@ msgstr "Palaa _takaisin"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
-msgstr "Korostettu viesti käyttäjältä %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
+msgstr "Korostettu viesti käyttäjältä %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
-msgstr "%u korostettua viestiä, viimeksi käyttäjältä %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
+msgstr "%u korostettua viestiä, viimeksi käyttäjältä %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
-msgstr "Yksityisviesti käyttäjältä %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
+msgstr "Yksityisviesti käyttäjältä %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
-msgstr "%u yksityisviestiä, viimeksi käyttäjältä %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
+msgstr "%u yksityisviestiä, viimeksi käyttäjältä %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
-msgstr "Käyttäjä %s tarjoaa tiedostoa (%s) - "
+msgid "File offer from: %s (%s) - %s"
+msgstr "Käyttäjä %s tarjoaa tiedostoa (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
-msgstr "%u tiedostoa tarjottu, vimeksi käyttäjältä %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
+msgstr "%u tiedostoa tarjottu, vimeksi käyttäjältä %s (%s) - %s"
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4622,8 +4622,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Valitse ladattava skripti tai liitännäinen"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "Skriptit ja liitännäiset - "
+msgid "Plugins and Scripts - %s"
+msgstr "Skriptit ja liitännäiset - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4644,7 +4644,7 @@ msgstr "Tallenna..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4680,8 +4680,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "Muokkaa %s-verkkoa - "
+msgid "Edit %s - %s"
+msgstr "Muokkaa %s-verkkoa - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4772,8 +4772,8 @@ msgid "Character set:"
 msgstr "Merkistö:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "Verkkoluettelo - "
+msgid "Network List - %s"
+msgstr "Verkkoluettelo - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6137,8 +6137,8 @@ msgid ""
 msgstr "*VAROITUS*\nDCC-siirtojen automaattinen hyväksyminen\nkotihakemistoon voi olla vaarallista. Esim:\nJoku voi lähettää tiedoston .bash_profile."
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "Ominaisuudet - "
+msgid "Preferences - %s"
+msgstr "Ominaisuudet - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6202,8 +6202,8 @@ msgid "OK"
 msgstr "OK"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "URL-kaappaaja - "
+msgid "URL Grabber - %s"
+msgstr "URL-kaappaaja - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/fr.po
+++ b/po/fr.po
@@ -3246,8 +3246,8 @@ msgstr "Vous pouvez ouvrir la fenêtre de la liste des bannissements uniquement 
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr ": liste des bannissements (%s)"
+msgid "Ban List (%s) - "
+msgstr "liste des bannissements (%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3285,8 +3285,8 @@ msgstr "Copie le suje_t du canal"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr ": liste des canaux (%s)"
+msgid "Channel List (%s) - "
+msgstr "liste des canaux (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3377,8 +3377,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Impossible de reprendre le même fichier en provenance de deux personnes différentes."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr ": envois et réceptions"
+msgid "Uploads and Downloads - "
+msgstr "envois et réceptions - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3435,8 +3435,8 @@ msgid "Open Folder..."
 msgstr "Ouvrir le dossier…"
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr ": liste de Chat DCC"
+msgid "DCC Chat List - "
+msgstr "liste de Chat DCC - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3632,8 +3632,8 @@ msgid "Select a row to get help information on its Action."
 msgstr "Sélectionner une ligne pour obtenir des informations sur son action."
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr ": raccourcis clavier"
+msgid "Keyboard Shortcuts - "
+msgstr "raccourcis clavier - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3677,8 +3677,8 @@ msgid "Enter mask to ignore:"
 msgstr "Entrer le masque d'exclusion :"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr ": liste d'ignorance"
+msgid "Ignore list - "
+msgstr "liste d'ignorance - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3713,8 +3713,8 @@ msgid "Channel name too short, try again."
 msgstr "Le nom de canal est trop court, veuillez réessayer."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr ": fin de la procédure de connexion"
+msgid "Connection Complete - "
+msgstr "fin de la procédure de connexion - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4040,8 +4040,8 @@ msgid "_Auto-Connect"
 msgstr "Connexion _automatique"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr ": menu utilisateur"
+msgid "User menu - "
+msgstr "menu utilisateur - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4161,36 +4161,36 @@ msgid ""
 msgstr "Gestionnaire d'URL - Codes d'échappement :\n\n%s  =  la chaîne URL\n\nSi vous mettez un ! devant la commande\ncela signifie qu'elle sera envoyée\nau terminal plutôt qu'à HexChat."
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr ": commandes définies par l'utilisateur"
+msgid "User Defined Commands - "
+msgstr "commandes définies par l'utilisateur - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr ": menu de la liste des utilisateurs"
+msgid "Userlist Popup menu - "
+msgstr "menu de la liste des utilisateurs - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Remplacer par"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr ": remplacer"
+msgid "Replace - "
+msgstr "remplacer - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr ": gestionnaires d'URL"
+msgid "URL Handlers - "
+msgstr "gestionnaires d'URL - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr ": boutons de la liste des utilisateurs"
+msgid "Userlist buttons - "
+msgstr "boutons de la liste des utilisateurs - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr ": boutons de dialogue"
+msgid "Dialog buttons - "
+msgstr "boutons de dialogue - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr ": réponses CTCP"
+msgid "CTCP Replies - "
+msgstr "réponses CTCP - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4497,8 +4497,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Une liste de réseaux séparés par une virgule est acceptée."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
-msgstr ": liste d'amis"
+msgid "Friends List - "
+msgstr "liste d'amis - "
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4536,8 +4536,8 @@ msgstr "Message privé de : %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
-msgstr ": Vous êtes connecté à %u réseaux et %u canaux"
+msgid "Connected to %u networks and %u channels - "
+msgstr "Vous êtes connecté à %u réseaux et %u canaux - "
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4578,43 +4578,43 @@ msgstr "_Retour"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
-msgstr ": Message en surbrillance de %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
+msgstr "Message en surbrillance de %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
-msgstr ": %u messages en surbrillance. Le dernier est de %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
+msgstr "%u messages en surbrillance. Le dernier est de %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
-msgstr ": Message de canal de : %s (%s)"
+msgid "Channel message from: %s (%s) - "
+msgstr "Message de canal de : %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
-msgstr ": %u messages de canal."
+msgid "%u channel messages. - "
+msgstr "%u messages de canal. - "
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
-msgstr ": Message privé de %s (%s)"
+msgid "Private message from: %s (%s) - "
+msgstr "Message privé de %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
-msgstr ": %u messages privés. Le dernier est de %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
+msgstr "%u messages privés. Le dernier est de %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
-msgstr ": Demande de transfert de fichier de %s (%s)"
+msgid "File offer from: %s (%s) - "
+msgstr "Demande de transfert de fichier de %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
-msgstr ": %u demandes de transferts de fichier. Le dernier est de %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
+msgstr "%u demandes de transferts de fichier. Le dernier est de %s (%s) - "
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4629,8 +4629,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Sélectionner un greffon ou un script à charger"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr ": greffons et scripts"
+msgid "Plugins and Scripts - "
+msgstr "greffons et scripts - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4651,8 +4651,8 @@ msgstr "Enregistrer sous…"
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
-msgstr ": journal brut (%s)"
+msgid "Raw Log (%s) - "
+msgstr "journal brut (%s) - "
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4687,8 +4687,8 @@ msgstr "La façon qui permet de vous identifier sur le serveur. Pour des méthod
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr ": éditer %s"
+msgid "Edit %s - "
+msgstr "éditer %s - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4779,8 +4779,8 @@ msgid "Character set:"
 msgstr "Jeu de caractères :"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr ": liste des réseaux"
+msgid "Network List - "
+msgstr "liste des réseaux - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6144,8 +6144,8 @@ msgid ""
 msgstr "*ATTENTION*\nAccepter automatiquement les DCC dans votre répertoire personnel\npeut être dangereux et peut être exploité. Par exemple :\nquelqu'un pourrait vous envoyer un .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr ": préférences"
+msgid "Preferences - "
+msgstr "préférences - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6209,8 +6209,8 @@ msgid "OK"
 msgstr "OK"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr ": récupération d'URL"
+msgid "URL Grabber - "
+msgstr "récupération d'URL - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/fr.po
+++ b/po/fr.po
@@ -3246,8 +3246,8 @@ msgstr "Vous pouvez ouvrir la fenêtre de la liste des bannissements uniquement 
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "liste des bannissements (%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "liste des bannissements (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3285,8 +3285,8 @@ msgstr "Copie le suje_t du canal"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr "liste des canaux (%s) - "
+msgid "Channel List (%s) - %s"
+msgstr "liste des canaux (%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3377,8 +3377,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Impossible de reprendre le même fichier en provenance de deux personnes différentes."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "envois et réceptions - "
+msgid "Uploads and Downloads - %s"
+msgstr "envois et réceptions - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3435,8 +3435,8 @@ msgid "Open Folder..."
 msgstr "Ouvrir le dossier…"
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "liste de Chat DCC - "
+msgid "DCC Chat List - %s"
+msgstr "liste de Chat DCC - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3632,8 +3632,8 @@ msgid "Select a row to get help information on its Action."
 msgstr "Sélectionner une ligne pour obtenir des informations sur son action."
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "raccourcis clavier - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "raccourcis clavier - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3677,8 +3677,8 @@ msgid "Enter mask to ignore:"
 msgstr "Entrer le masque d'exclusion :"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "liste d'ignorance - "
+msgid "Ignore list - %s"
+msgstr "liste d'ignorance - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3713,8 +3713,8 @@ msgid "Channel name too short, try again."
 msgstr "Le nom de canal est trop court, veuillez réessayer."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "fin de la procédure de connexion - "
+msgid "Connection Complete - %s"
+msgstr "fin de la procédure de connexion - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4040,8 +4040,8 @@ msgid "_Auto-Connect"
 msgstr "Connexion _automatique"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "menu utilisateur - "
+msgid "User menu - %s"
+msgstr "menu utilisateur - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4161,36 +4161,36 @@ msgid ""
 msgstr "Gestionnaire d'URL - Codes d'échappement :\n\n%s  =  la chaîne URL\n\nSi vous mettez un ! devant la commande\ncela signifie qu'elle sera envoyée\nau terminal plutôt qu'à HexChat."
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "commandes définies par l'utilisateur - "
+msgid "User Defined Commands - %s"
+msgstr "commandes définies par l'utilisateur - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "menu de la liste des utilisateurs - "
+msgid "Userlist Popup menu - %s"
+msgstr "menu de la liste des utilisateurs - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Remplacer par"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "remplacer - "
+msgid "Replace - %s"
+msgstr "remplacer - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "gestionnaires d'URL - "
+msgid "URL Handlers - %s"
+msgstr "gestionnaires d'URL - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "boutons de la liste des utilisateurs - "
+msgid "Userlist buttons - %s"
+msgstr "boutons de la liste des utilisateurs - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "boutons de dialogue - "
+msgid "Dialog buttons - %s"
+msgstr "boutons de dialogue - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "réponses CTCP - "
+msgid "CTCP Replies - %s"
+msgstr "réponses CTCP - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4497,8 +4497,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Une liste de réseaux séparés par une virgule est acceptée."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
-msgstr "liste d'amis - "
+msgid "Friends List - %s"
+msgstr "liste d'amis - %s"
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4536,8 +4536,8 @@ msgstr "Message privé de : %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
-msgstr "Vous êtes connecté à %u réseaux et %u canaux - "
+msgid "Connected to %u networks and %u channels - %s"
+msgstr "Vous êtes connecté à %u réseaux et %u canaux - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4578,43 +4578,43 @@ msgstr "_Retour"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
-msgstr "Message en surbrillance de %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
+msgstr "Message en surbrillance de %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
-msgstr "%u messages en surbrillance. Le dernier est de %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
+msgstr "%u messages en surbrillance. Le dernier est de %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
-msgstr "Message de canal de : %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
+msgstr "Message de canal de : %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
-msgstr "%u messages de canal. - "
+msgid "%u channel messages. - %s"
+msgstr "%u messages de canal. - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
-msgstr "Message privé de %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
+msgstr "Message privé de %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
-msgstr "%u messages privés. Le dernier est de %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
+msgstr "%u messages privés. Le dernier est de %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
-msgstr "Demande de transfert de fichier de %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
+msgstr "Demande de transfert de fichier de %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
-msgstr "%u demandes de transferts de fichier. Le dernier est de %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
+msgstr "%u demandes de transferts de fichier. Le dernier est de %s (%s) - %s"
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4629,8 +4629,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Sélectionner un greffon ou un script à charger"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "greffons et scripts - "
+msgid "Plugins and Scripts - %s"
+msgstr "greffons et scripts - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4651,8 +4651,8 @@ msgstr "Enregistrer sous…"
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
-msgstr "journal brut (%s) - "
+msgid "Raw Log (%s) - %s"
+msgstr "journal brut (%s) - %s"
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4687,8 +4687,8 @@ msgstr "La façon qui permet de vous identifier sur le serveur. Pour des méthod
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "éditer %s - "
+msgid "Edit %s - %s"
+msgstr "éditer %s - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4779,8 +4779,8 @@ msgid "Character set:"
 msgstr "Jeu de caractères :"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "liste des réseaux - "
+msgid "Network List - %s"
+msgstr "liste des réseaux - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6144,8 +6144,8 @@ msgid ""
 msgstr "*ATTENTION*\nAccepter automatiquement les DCC dans votre répertoire personnel\npeut être dangereux et peut être exploité. Par exemple :\nquelqu'un pourrait vous envoyer un .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "préférences - "
+msgid "Preferences - %s"
+msgstr "préférences - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6209,8 +6209,8 @@ msgid "OK"
 msgstr "OK"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "récupération d'URL - "
+msgid "URL Grabber - %s"
+msgstr "récupération d'URL - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/gl.po
+++ b/po/gl.po
@@ -3238,8 +3238,8 @@ msgstr "Só podes abrir a ventá da lista de vetados nunha solapa da canle."
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr "XChat: Lista de vetados (%s)"
+msgid "Ban List (%s) - "
+msgstr "Lista de vetados (%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3277,8 +3277,8 @@ msgstr "Copiar texto do _tema"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr "XChat: Lista de Canles (%s)"
+msgid "Channel List (%s) - "
+msgstr "Lista de Canles (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3369,8 +3369,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Non se pode reanudar o mesmo ficheiro de dúas persoas."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr "XChat: Cargas e descargas"
+msgid "Uploads and Downloads - "
+msgstr "Cargas e descargas - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3427,8 +3427,8 @@ msgid "Open Folder..."
 msgstr "Abrir cartafol..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr "XChat: Lista de Chat DCC"
+msgid "DCC Chat List - "
+msgstr "Lista de Chat DCC - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3624,8 +3624,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr ": Atallos de teclado"
+msgid "Keyboard Shortcuts - "
+msgstr "Atallos de teclado - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3669,8 +3669,8 @@ msgid "Enter mask to ignore:"
 msgstr "Introduza a máscara que quere ignorar:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr "XChat: Lista de ignorados"
+msgid "Ignore list - "
+msgstr "Lista de ignorados - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3705,8 +3705,8 @@ msgid "Channel name too short, try again."
 msgstr "O nome da canle é demasiado corto, ténteo de novo."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr "XChat: Conexión completada"
+msgid "Connection Complete - "
+msgstr "Conexión completada - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4032,8 +4032,8 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr ": Menú de usuario"
+msgid "User menu - "
+msgstr "Menú de usuario - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4153,36 +4153,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr "XChat: Comandos definidos polo usuario"
+msgid "User Defined Commands - "
+msgstr "Comandos definidos polo usuario - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr "XChat: Menú emerxente da lista de usuarios"
+msgid "Userlist Popup menu - "
+msgstr "Menú emerxente da lista de usuarios - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Reemprazar con"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr "XChat: Reemprazar"
+msgid "Replace - "
+msgstr "Reemprazar - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr "XChat: Manexadores de URL"
+msgid "URL Handlers - "
+msgstr "Manexadores de URL - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr "XChat: Botóns da lista de usuarios"
+msgid "Userlist buttons - "
+msgstr "Botóns da lista de usuarios - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr "XChat: Botóns de diálogo"
+msgid "Dialog buttons - "
+msgstr "Botóns de diálogo - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr "XChat: Respostas CTCP"
+msgid "CTCP Replies - "
+msgstr "Respostas CTCP - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4489,7 +4489,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
+msgid "Friends List - "
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4528,8 +4528,8 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
-msgstr ": Conectado a %u redes e %u canles"
+msgid "Connected to %u networks and %u channels - "
+msgstr "Conectado a %u redes e %u canles - "
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4570,43 +4570,43 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
-msgstr "XChat: Resaltar mensaxe de %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
+msgstr "Resaltar mensaxe de %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
-msgstr "XChat: %u mensaxes resaltadas, a última de: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
+msgstr "%u mensaxes resaltadas, a última de: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
-msgstr "XChat: Mensaxe privada desde %s (%s)"
+msgid "Private message from: %s (%s) - "
+msgstr "Mensaxe privada desde %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
-msgstr "XChat: %u mensaxes privadas, a última de: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
+msgstr "%u mensaxes privadas, a última de: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
-msgstr "XChat: Ofrécese ficheiro desde: %s (%s)"
+msgid "File offer from: %s (%s) - "
+msgstr "Ofrécese ficheiro desde: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
-msgstr "XChat: %u ficheiro ofrecidos, o último de: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
+msgstr "%u ficheiro ofrecidos, o último de: %s (%s) - "
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4621,8 +4621,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Seleccione un Complemento ou Script a cargar"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr "XChat: Complementos e Scripts"
+msgid "Plugins and Scripts - "
+msgstr "Complementos e Scripts - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4643,7 +4643,7 @@ msgstr "Gardar como..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4679,8 +4679,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr ": Editar %s"
+msgid "Edit %s - "
+msgstr "Editar %s - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4771,8 +4771,8 @@ msgid "Character set:"
 msgstr "Conxunto de caracteres:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr "XChat: Lista de redes"
+msgid "Network List - "
+msgstr "Lista de redes - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6136,8 +6136,8 @@ msgid ""
 msgstr "*AVISO*\nAceptar automaticamente DCC ao seu directorio de inicio\npode ser peligroso e é explotable. Por exemplo:\nAlguén pode enviarlle un ficheiro .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr "XChat: Preferencias"
+msgid "Preferences - "
+msgstr "Preferencias - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6201,8 +6201,8 @@ msgid "OK"
 msgstr "Aceptar"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr "XChat: Capturador de URL"
+msgid "URL Grabber - "
+msgstr "Capturador de URL - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/gl.po
+++ b/po/gl.po
@@ -3238,8 +3238,8 @@ msgstr "Só podes abrir a ventá da lista de vetados nunha solapa da canle."
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "Lista de vetados (%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "Lista de vetados (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3277,8 +3277,8 @@ msgstr "Copiar texto do _tema"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr "Lista de Canles (%s) - "
+msgid "Channel List (%s) - %s"
+msgstr "Lista de Canles (%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3369,8 +3369,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Non se pode reanudar o mesmo ficheiro de dúas persoas."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "Cargas e descargas - "
+msgid "Uploads and Downloads - %s"
+msgstr "Cargas e descargas - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3427,8 +3427,8 @@ msgid "Open Folder..."
 msgstr "Abrir cartafol..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "Lista de Chat DCC - "
+msgid "DCC Chat List - %s"
+msgstr "Lista de Chat DCC - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3624,8 +3624,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "Atallos de teclado - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "Atallos de teclado - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3669,8 +3669,8 @@ msgid "Enter mask to ignore:"
 msgstr "Introduza a máscara que quere ignorar:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "Lista de ignorados - "
+msgid "Ignore list - %s"
+msgstr "Lista de ignorados - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3705,8 +3705,8 @@ msgid "Channel name too short, try again."
 msgstr "O nome da canle é demasiado corto, ténteo de novo."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "Conexión completada - "
+msgid "Connection Complete - %s"
+msgstr "Conexión completada - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4032,8 +4032,8 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "Menú de usuario - "
+msgid "User menu - %s"
+msgstr "Menú de usuario - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4153,36 +4153,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "Comandos definidos polo usuario - "
+msgid "User Defined Commands - %s"
+msgstr "Comandos definidos polo usuario - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "Menú emerxente da lista de usuarios - "
+msgid "Userlist Popup menu - %s"
+msgstr "Menú emerxente da lista de usuarios - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Reemprazar con"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "Reemprazar - "
+msgid "Replace - %s"
+msgstr "Reemprazar - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "Manexadores de URL - "
+msgid "URL Handlers - %s"
+msgstr "Manexadores de URL - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "Botóns da lista de usuarios - "
+msgid "Userlist buttons - %s"
+msgstr "Botóns da lista de usuarios - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "Botóns de diálogo - "
+msgid "Dialog buttons - %s"
+msgstr "Botóns de diálogo - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "Respostas CTCP - "
+msgid "CTCP Replies - %s"
+msgstr "Respostas CTCP - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4489,7 +4489,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
+msgid "Friends List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4528,8 +4528,8 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
-msgstr "Conectado a %u redes e %u canles - "
+msgid "Connected to %u networks and %u channels - %s"
+msgstr "Conectado a %u redes e %u canles - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4570,43 +4570,43 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
-msgstr "Resaltar mensaxe de %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
+msgstr "Resaltar mensaxe de %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
-msgstr "%u mensaxes resaltadas, a última de: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
+msgstr "%u mensaxes resaltadas, a última de: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
-msgstr "Mensaxe privada desde %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
+msgstr "Mensaxe privada desde %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
-msgstr "%u mensaxes privadas, a última de: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
+msgstr "%u mensaxes privadas, a última de: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
-msgstr "Ofrécese ficheiro desde: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
+msgstr "Ofrécese ficheiro desde: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
-msgstr "%u ficheiro ofrecidos, o último de: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
+msgstr "%u ficheiro ofrecidos, o último de: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4621,8 +4621,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Seleccione un Complemento ou Script a cargar"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "Complementos e Scripts - "
+msgid "Plugins and Scripts - %s"
+msgstr "Complementos e Scripts - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4643,7 +4643,7 @@ msgstr "Gardar como..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4679,8 +4679,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "Editar %s - "
+msgid "Edit %s - %s"
+msgstr "Editar %s - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4771,8 +4771,8 @@ msgid "Character set:"
 msgstr "Conxunto de caracteres:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "Lista de redes - "
+msgid "Network List - %s"
+msgstr "Lista de redes - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6136,8 +6136,8 @@ msgid ""
 msgstr "*AVISO*\nAceptar automaticamente DCC ao seu directorio de inicio\npode ser peligroso e é explotable. Por exemplo:\nAlguén pode enviarlle un ficheiro .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "Preferencias - "
+msgid "Preferences - %s"
+msgstr "Preferencias - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6201,8 +6201,8 @@ msgid "OK"
 msgstr "Aceptar"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "Capturador de URL - "
+msgid "URL Grabber - %s"
+msgstr "Capturador de URL - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/gu.po
+++ b/po/gu.po
@@ -3237,7 +3237,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
+msgid "Ban List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3276,7 +3276,7 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
+msgid "Channel List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3368,7 +3368,7 @@ msgid "Cannot resume the same file from two people."
 msgstr "એ જ ફાઈલ બે વ્યક્તિમાંથી અટકાવી શકાતી નથી."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
+msgid "Uploads and Downloads - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3426,7 +3426,7 @@ msgid "Open Folder..."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
+msgid "DCC Chat List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3623,7 +3623,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
+msgid "Keyboard Shortcuts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3668,7 +3668,7 @@ msgid "Enter mask to ignore:"
 msgstr "અવગણવા માટે માસ્ક દાખલ કરો:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
+msgid "Ignore list - %s"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3704,7 +3704,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
+msgid "Connection Complete - %s"
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4031,7 +4031,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
+msgid "User menu - %s"
 msgstr ""
 
 #. sep
@@ -4152,11 +4152,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
+msgid "User Defined Commands - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
+msgid "Userlist Popup menu - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4164,23 +4164,23 @@ msgid "Replace with"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
+msgid "Replace - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
+msgid "URL Handlers - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
+msgid "Userlist buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
+msgid "Dialog buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
+msgid "CTCP Replies - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4488,7 +4488,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
+msgid "Friends List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4527,7 +4527,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
+msgid "Connected to %u networks and %u channels - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4569,42 +4569,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4620,7 +4620,7 @@ msgid "Select a Plugin or Script to load"
 msgstr "લાવવા માટે પ્લગઈન અથવા સ્ક્રિપ્ટ પસંદ કરો"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
+msgid "Plugins and Scripts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4642,7 +4642,7 @@ msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4678,7 +4678,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
+msgid "Edit %s - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4770,7 +4770,7 @@ msgid "Character set:"
 msgstr "અક્ષર સમૂહ:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
+msgid "Network List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6135,7 +6135,7 @@ msgid ""
 msgstr "*WARNING*\nતમારી ઘર ડિરેક્ટરીમાં DCC ને આપોઆપ સ્વીકારવાનું\nએ ભયજનક અને વિનાશકારી હોઈ શકે. દાત:\nકોઈક તમને .bash_profile મોકલી શક્યું હોય"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
+msgid "Preferences - %s"
 msgstr ""
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6200,7 +6200,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
+msgid "URL Grabber - %s"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/gu.po
+++ b/po/gu.po
@@ -3237,7 +3237,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
+msgid "Ban List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3276,7 +3276,7 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
+msgid "Channel List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3368,7 +3368,7 @@ msgid "Cannot resume the same file from two people."
 msgstr "એ જ ફાઈલ બે વ્યક્તિમાંથી અટકાવી શકાતી નથી."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
+msgid "Uploads and Downloads - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3426,7 +3426,7 @@ msgid "Open Folder..."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
+msgid "DCC Chat List - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3623,7 +3623,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
+msgid "Keyboard Shortcuts - "
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3668,7 +3668,7 @@ msgid "Enter mask to ignore:"
 msgstr "અવગણવા માટે માસ્ક દાખલ કરો:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
+msgid "Ignore list - "
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3704,7 +3704,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
+msgid "Connection Complete - "
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4031,7 +4031,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
+msgid "User menu - "
 msgstr ""
 
 #. sep
@@ -4152,11 +4152,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
+msgid "User Defined Commands - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
+msgid "Userlist Popup menu - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4164,23 +4164,23 @@ msgid "Replace with"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
+msgid "Replace - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
+msgid "URL Handlers - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
+msgid "Userlist buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
+msgid "Dialog buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
+msgid "CTCP Replies - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4488,7 +4488,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
+msgid "Friends List - "
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4527,7 +4527,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
+msgid "Connected to %u networks and %u channels - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4569,42 +4569,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
+msgid "Private message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
+msgid "File offer from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4620,7 +4620,7 @@ msgid "Select a Plugin or Script to load"
 msgstr "લાવવા માટે પ્લગઈન અથવા સ્ક્રિપ્ટ પસંદ કરો"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
+msgid "Plugins and Scripts - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4642,7 +4642,7 @@ msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4678,7 +4678,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
+msgid "Edit %s - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4770,7 +4770,7 @@ msgid "Character set:"
 msgstr "અક્ષર સમૂહ:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
+msgid "Network List - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6135,7 +6135,7 @@ msgid ""
 msgstr "*WARNING*\nતમારી ઘર ડિરેક્ટરીમાં DCC ને આપોઆપ સ્વીકારવાનું\nએ ભયજનક અને વિનાશકારી હોઈ શકે. દાત:\nકોઈક તમને .bash_profile મોકલી શક્યું હોય"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
+msgid "Preferences - "
 msgstr ""
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6200,7 +6200,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
+msgid "URL Grabber - "
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/hi.po
+++ b/po/hi.po
@@ -3238,7 +3238,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
+msgid "Ban List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3277,7 +3277,7 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
+msgid "Channel List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3369,7 +3369,7 @@ msgid "Cannot resume the same file from two people."
 msgstr "दो व्यक्ति से समान फाइल नहीं ले सकता."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
+msgid "Uploads and Downloads - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3427,7 +3427,7 @@ msgid "Open Folder..."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
+msgid "DCC Chat List - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3624,7 +3624,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
+msgid "Keyboard Shortcuts - "
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3669,7 +3669,7 @@ msgid "Enter mask to ignore:"
 msgstr "अनदेखा करने के लिये मास्क दें: "
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
+msgid "Ignore list - "
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3705,7 +3705,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
+msgid "Connection Complete - "
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4032,7 +4032,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
+msgid "User menu - "
 msgstr ""
 
 #. sep
@@ -4153,11 +4153,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
+msgid "User Defined Commands - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
+msgid "Userlist Popup menu - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4165,23 +4165,23 @@ msgid "Replace with"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
+msgid "Replace - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
+msgid "URL Handlers - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
+msgid "Userlist buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
+msgid "Dialog buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
+msgid "CTCP Replies - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4489,7 +4489,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
+msgid "Friends List - "
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4528,7 +4528,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
+msgid "Connected to %u networks and %u channels - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4570,42 +4570,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
+msgid "Private message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
+msgid "File offer from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4621,7 +4621,7 @@ msgid "Select a Plugin or Script to load"
 msgstr "भारित करने के लिये प्लगिन या स्क्रिप्ट चुनें"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
+msgid "Plugins and Scripts - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4643,7 +4643,7 @@ msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4679,7 +4679,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
+msgid "Edit %s - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4771,7 +4771,7 @@ msgid "Character set:"
 msgstr "संप्रतीक सेट:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
+msgid "Network List - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6136,7 +6136,7 @@ msgid ""
 msgstr "*WARNING*\nAuto accepting DCC to your home directory\ncan be dangerous and is exploitable. Eg:\nSomeone could send you a .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
+msgid "Preferences - "
 msgstr ""
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6201,7 +6201,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
+msgid "URL Grabber - "
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/hi.po
+++ b/po/hi.po
@@ -3238,7 +3238,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
+msgid "Ban List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3277,7 +3277,7 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
+msgid "Channel List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3369,7 +3369,7 @@ msgid "Cannot resume the same file from two people."
 msgstr "दो व्यक्ति से समान फाइल नहीं ले सकता."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
+msgid "Uploads and Downloads - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3427,7 +3427,7 @@ msgid "Open Folder..."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
+msgid "DCC Chat List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3624,7 +3624,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
+msgid "Keyboard Shortcuts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3669,7 +3669,7 @@ msgid "Enter mask to ignore:"
 msgstr "अनदेखा करने के लिये मास्क दें: "
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
+msgid "Ignore list - %s"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3705,7 +3705,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
+msgid "Connection Complete - %s"
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4032,7 +4032,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
+msgid "User menu - %s"
 msgstr ""
 
 #. sep
@@ -4153,11 +4153,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
+msgid "User Defined Commands - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
+msgid "Userlist Popup menu - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4165,23 +4165,23 @@ msgid "Replace with"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
+msgid "Replace - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
+msgid "URL Handlers - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
+msgid "Userlist buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
+msgid "Dialog buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
+msgid "CTCP Replies - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4489,7 +4489,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
+msgid "Friends List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4528,7 +4528,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
+msgid "Connected to %u networks and %u channels - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4570,42 +4570,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4621,7 +4621,7 @@ msgid "Select a Plugin or Script to load"
 msgstr "भारित करने के लिये प्लगिन या स्क्रिप्ट चुनें"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
+msgid "Plugins and Scripts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4643,7 +4643,7 @@ msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4679,7 +4679,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
+msgid "Edit %s - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4771,7 +4771,7 @@ msgid "Character set:"
 msgstr "संप्रतीक सेट:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
+msgid "Network List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6136,7 +6136,7 @@ msgid ""
 msgstr "*WARNING*\nAuto accepting DCC to your home directory\ncan be dangerous and is exploitable. Eg:\nSomeone could send you a .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
+msgid "Preferences - %s"
 msgstr ""
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6201,7 +6201,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
+msgid "URL Grabber - %s"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/hu.po
+++ b/po/hu.po
@@ -3243,8 +3243,8 @@ msgstr "Csak a csatornafülön nyithatja meg a kitiltáslistát."
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr "XChat: Kitiltáslista (%s)"
+msgid "Ban List (%s) - "
+msgstr "Kitiltáslista (%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3282,8 +3282,8 @@ msgstr "Té_ma szövegének másolása"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr "XChat: Csatornalista (%s)"
+msgid "Channel List (%s) - "
+msgstr "Csatornalista (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3374,8 +3374,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Nem lehet ugyanazt a fájlt két embertől folytatni."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr "XChat: Feltöltések és letöltések"
+msgid "Uploads and Downloads - "
+msgstr "Feltöltések és letöltések - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3432,8 +3432,8 @@ msgid "Open Folder..."
 msgstr "Mappa megnyitása..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr "XChat: DCC csevegés lista"
+msgid "DCC Chat List - "
+msgstr "DCC csevegés lista - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3629,8 +3629,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr "XChat: Gyorsbillentyűk"
+msgid "Keyboard Shortcuts - "
+msgstr "Gyorsbillentyűk - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3674,8 +3674,8 @@ msgid "Enter mask to ignore:"
 msgstr "Írja be a mellőzendő maszkot:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr "XChat: Mellőzési lista"
+msgid "Ignore list - "
+msgstr "Mellőzési lista - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3710,8 +3710,8 @@ msgid "Channel name too short, try again."
 msgstr "A csatornanév túl rövid, próbálja újra."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr "XChat: A kapcsolat kész"
+msgid "Connection Complete - "
+msgstr "A kapcsolat kész - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4037,8 +4037,8 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr "XChat: Felhasználói menü"
+msgid "User menu - "
+msgstr "Felhasználói menü - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4158,36 +4158,36 @@ msgid ""
 msgstr "URL kezelők - Speciális kódok:\n\n%s = az URL szöveg\n\nA parancs elé !-t téve a HexChat\nhelyett egy shell kapja meg"
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr "XChat: Felhasználó által megadott parancsok"
+msgid "User Defined Commands - "
+msgstr "Felhasználó által megadott parancsok - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr "XChat: Felhasználólista helyi menü"
+msgid "Userlist Popup menu - "
+msgstr "Felhasználólista helyi menü - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Csere"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr "XChat: Csere"
+msgid "Replace - "
+msgstr "Csere - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr "XChat: URL-ek kezelése"
+msgid "URL Handlers - "
+msgstr "URL-ek kezelése - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr "XChat: Felhasználólista gombok"
+msgid "Userlist buttons - "
+msgstr "Felhasználólista gombok - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr "XChat: Párbeszédgombok"
+msgid "Dialog buttons - "
+msgstr "Párbeszédgombok - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr "XChat: CTCP  válaszok"
+msgid "CTCP Replies - "
+msgstr "CTCP  válaszok - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4494,8 +4494,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Hálózatok vesszőkkel elválasztott listája adható meg."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
-msgstr "XChat: Barátok listája"
+msgid "Friends List - "
+msgstr "Barátok listája - "
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4533,8 +4533,8 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
-msgstr "XChat: Kapcsolódva %u hálózathoz és %u csatornához"
+msgid "Connected to %u networks and %u channels - "
+msgstr "Kapcsolódva %u hálózathoz és %u csatornához - "
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4575,43 +4575,43 @@ msgstr "_Vissza"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
-msgstr "XChat: Kiemelt üzenet a következőtől: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
+msgstr "Kiemelt üzenet a következőtől: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
-msgstr "XChat: %u kiemelt üzenet, a legutolsó a következőtől: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
+msgstr "%u kiemelt üzenet, a legutolsó a következőtől: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
-msgstr "XChat: Privát üzenet a következőtől: %s (%s)"
+msgid "Private message from: %s (%s) - "
+msgstr "Privát üzenet a következőtől: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
-msgstr "XChat: %u privát üzenet, a legutolsó a következőtől: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
+msgstr "%u privát üzenet, a legutolsó a következőtől: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
-msgstr "XChat: Fájlajánlat a következőtől: %s (%s)"
+msgid "File offer from: %s (%s) - "
+msgstr "Fájlajánlat a következőtől: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
-msgstr "XChat: %u fájlajánlat, a legutolsó a következőtől: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
+msgstr "%u fájlajánlat, a legutolsó a következőtől: %s (%s) - "
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4626,8 +4626,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Válassza ki a betöltendő bővítményt vagy parancsfájlt"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr "XChat: Bővítmények és parancsfájlok"
+msgid "Plugins and Scripts - "
+msgstr "Bővítmények és parancsfájlok - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4648,8 +4648,8 @@ msgstr "Mentés másként..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
-msgstr ": Nyers napló (%s)"
+msgid "Raw Log (%s) - "
+msgstr "Nyers napló (%s) - "
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4684,8 +4684,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr "XChat: %s szerkesztése"
+msgid "Edit %s - "
+msgstr "%s szerkesztése - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4776,8 +4776,8 @@ msgid "Character set:"
 msgstr "Karakterkészlet:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr "XChat: Hálózatlista"
+msgid "Network List - "
+msgstr "Hálózatlista - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6141,8 +6141,8 @@ msgid ""
 msgstr "*FIGYELMEZTETÉS*\nDCC automatikus elfogadása a home könyvtárába\nveszélyes és kihasználható lehet. Például:\nValaki küldhet Önnek egy .bash_profile-t"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr "XChat: Beállítások"
+msgid "Preferences - "
+msgstr "Beállítások - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6206,8 +6206,8 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr "XChat: URL elfogó"
+msgid "URL Grabber - "
+msgstr "URL elfogó - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/hu.po
+++ b/po/hu.po
@@ -3243,8 +3243,8 @@ msgstr "Csak a csatornafülön nyithatja meg a kitiltáslistát."
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "Kitiltáslista (%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "Kitiltáslista (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3282,8 +3282,8 @@ msgstr "Té_ma szövegének másolása"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr "Csatornalista (%s) - "
+msgid "Channel List (%s) - %s"
+msgstr "Csatornalista (%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3374,8 +3374,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Nem lehet ugyanazt a fájlt két embertől folytatni."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "Feltöltések és letöltések - "
+msgid "Uploads and Downloads - %s"
+msgstr "Feltöltések és letöltések - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3432,8 +3432,8 @@ msgid "Open Folder..."
 msgstr "Mappa megnyitása..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "DCC csevegés lista - "
+msgid "DCC Chat List - %s"
+msgstr "DCC csevegés lista - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3629,8 +3629,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "Gyorsbillentyűk - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "Gyorsbillentyűk - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3674,8 +3674,8 @@ msgid "Enter mask to ignore:"
 msgstr "Írja be a mellőzendő maszkot:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "Mellőzési lista - "
+msgid "Ignore list - %s"
+msgstr "Mellőzési lista - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3710,8 +3710,8 @@ msgid "Channel name too short, try again."
 msgstr "A csatornanév túl rövid, próbálja újra."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "A kapcsolat kész - "
+msgid "Connection Complete - %s"
+msgstr "A kapcsolat kész - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4037,8 +4037,8 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "Felhasználói menü - "
+msgid "User menu - %s"
+msgstr "Felhasználói menü - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4158,36 +4158,36 @@ msgid ""
 msgstr "URL kezelők - Speciális kódok:\n\n%s = az URL szöveg\n\nA parancs elé !-t téve a HexChat\nhelyett egy shell kapja meg"
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "Felhasználó által megadott parancsok - "
+msgid "User Defined Commands - %s"
+msgstr "Felhasználó által megadott parancsok - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "Felhasználólista helyi menü - "
+msgid "Userlist Popup menu - %s"
+msgstr "Felhasználólista helyi menü - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Csere"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "Csere - "
+msgid "Replace - %s"
+msgstr "Csere - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "URL-ek kezelése - "
+msgid "URL Handlers - %s"
+msgstr "URL-ek kezelése - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "Felhasználólista gombok - "
+msgid "Userlist buttons - %s"
+msgstr "Felhasználólista gombok - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "Párbeszédgombok - "
+msgid "Dialog buttons - %s"
+msgstr "Párbeszédgombok - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "CTCP  válaszok - "
+msgid "CTCP Replies - %s"
+msgstr "CTCP  válaszok - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4494,8 +4494,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Hálózatok vesszőkkel elválasztott listája adható meg."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
-msgstr "Barátok listája - "
+msgid "Friends List - %s"
+msgstr "Barátok listája - %s"
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4533,8 +4533,8 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
-msgstr "Kapcsolódva %u hálózathoz és %u csatornához - "
+msgid "Connected to %u networks and %u channels - %s"
+msgstr "Kapcsolódva %u hálózathoz és %u csatornához - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4575,43 +4575,43 @@ msgstr "_Vissza"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
-msgstr "Kiemelt üzenet a következőtől: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
+msgstr "Kiemelt üzenet a következőtől: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
-msgstr "%u kiemelt üzenet, a legutolsó a következőtől: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
+msgstr "%u kiemelt üzenet, a legutolsó a következőtől: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
-msgstr "Privát üzenet a következőtől: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
+msgstr "Privát üzenet a következőtől: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
-msgstr "%u privát üzenet, a legutolsó a következőtől: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
+msgstr "%u privát üzenet, a legutolsó a következőtől: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
-msgstr "Fájlajánlat a következőtől: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
+msgstr "Fájlajánlat a következőtől: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
-msgstr "%u fájlajánlat, a legutolsó a következőtől: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
+msgstr "%u fájlajánlat, a legutolsó a következőtől: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4626,8 +4626,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Válassza ki a betöltendő bővítményt vagy parancsfájlt"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "Bővítmények és parancsfájlok - "
+msgid "Plugins and Scripts - %s"
+msgstr "Bővítmények és parancsfájlok - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4648,8 +4648,8 @@ msgstr "Mentés másként..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
-msgstr "Nyers napló (%s) - "
+msgid "Raw Log (%s) - %s"
+msgstr "Nyers napló (%s) - %s"
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4684,8 +4684,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "%s szerkesztése - "
+msgid "Edit %s - %s"
+msgstr "%s szerkesztése - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4776,8 +4776,8 @@ msgid "Character set:"
 msgstr "Karakterkészlet:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "Hálózatlista - "
+msgid "Network List - %s"
+msgstr "Hálózatlista - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6141,8 +6141,8 @@ msgid ""
 msgstr "*FIGYELMEZTETÉS*\nDCC automatikus elfogadása a home könyvtárába\nveszélyes és kihasználható lehet. Például:\nValaki küldhet Önnek egy .bash_profile-t"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "Beállítások - "
+msgid "Preferences - %s"
+msgstr "Beállítások - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6206,8 +6206,8 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "URL elfogó - "
+msgid "URL Grabber - %s"
+msgstr "URL elfogó - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/id.po
+++ b/po/id.po
@@ -3241,8 +3241,8 @@ msgstr "Anda hanya dapat membuka jendela Daftar Hukuman ketika di tab kanal."
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "Daftar Hukuman (%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "Daftar Hukuman (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3280,8 +3280,8 @@ msgstr "Salin _Teks Topik"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr "Daftar Kanal (%s) - "
+msgid "Channel List (%s) - %s"
+msgstr "Daftar Kanal (%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3372,8 +3372,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Tak dapat melanjutkan berkas yang sama dari dua orang."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "Unggah dan Unduh - "
+msgid "Uploads and Downloads - %s"
+msgstr "Unggah dan Unduh - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3430,8 +3430,8 @@ msgid "Open Folder..."
 msgstr "Buka Foler..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "Daftar Chat DCC - "
+msgid "DCC Chat List - %s"
+msgstr "Daftar Chat DCC - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3627,8 +3627,8 @@ msgid "Select a row to get help information on its Action."
 msgstr "Pilih sebuah baris untuk mendapatkan informasi tentang tindakannya."
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "Tombol Cepat Keyboard - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "Tombol Cepat Keyboard - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3672,8 +3672,8 @@ msgid "Enter mask to ignore:"
 msgstr "Masukkan mask yang akan diabaikan:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "Daftar Pengabaian - "
+msgid "Ignore list - %s"
+msgstr "Daftar Pengabaian - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3708,8 +3708,8 @@ msgid "Channel name too short, try again."
 msgstr "Nama kanal terlalu pendek, coba lagi."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "Koneksi Selesai - "
+msgid "Connection Complete - %s"
+msgstr "Koneksi Selesai - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4035,8 +4035,8 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "Menu pengguna - "
+msgid "User menu - %s"
+msgstr "Menu pengguna - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4156,36 +4156,36 @@ msgid ""
 msgstr "Pengendali Tautan - Kode Spesial:\n\n%s  =  Tautan\n\nMenaruh ! di depan perintah\nmenunjukkan hal tersebut harus dikirim ke \nshell bukan HexChat"
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "Kustom Perintah  - "
+msgid "User Defined Commands - %s"
+msgstr "Kustom Perintah  - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "Daftar Menu Popup - "
+msgid "Userlist Popup menu - %s"
+msgstr "Daftar Menu Popup - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Ganti dengan "
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "Ganti - "
+msgid "Replace - %s"
+msgstr "Ganti - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "Pengendali Tautan - "
+msgid "URL Handlers - %s"
+msgstr "Pengendali Tautan - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "Daftar Tombol Kustom - "
+msgid "Userlist buttons - %s"
+msgstr "Daftar Tombol Kustom - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "Tombol Dialog - "
+msgid "Dialog buttons - %s"
+msgstr "Tombol Dialog - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "Balasan CTCP - "
+msgid "CTCP Replies - %s"
+msgstr "Balasan CTCP - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4492,8 +4492,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Koma yang memisahkan daftar jaringan dapat diterima."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
-msgstr "Daftar Teman - "
+msgid "Friends List - %s"
+msgstr "Daftar Teman - %s"
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4531,8 +4531,8 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
-msgstr "Terhubung ke %u jaaringan dan %u kanal - "
+msgid "Connected to %u networks and %u channels - %s"
+msgstr "Terhubung ke %u jaaringan dan %u kanal - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4573,43 +4573,43 @@ msgstr "_Kembali"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
-msgstr "Soroti pesan dari: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
+msgstr "Soroti pesan dari: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
-msgstr "%u pesan disoroti, terakhir dari: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
+msgstr "%u pesan disoroti, terakhir dari: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
-msgstr "Pesan rahasia dari: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
+msgstr "Pesan rahasia dari: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
-msgstr "%u pesan rahasia, terakhir dari: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
+msgstr "%u pesan rahasia, terakhir dari: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
-msgstr "Berkas dikirim dari: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
+msgstr "Berkas dikirim dari: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
-msgstr "%u berkas kiriman, terakhir dari: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
+msgstr "%u berkas kiriman, terakhir dari: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4624,8 +4624,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Pilih Plugin atau Skrip yang akan dibuka"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "Skrip dan Plugin - "
+msgid "Plugins and Scripts - %s"
+msgstr "Skrip dan Plugin - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4646,8 +4646,8 @@ msgstr "Simpan Sebagai..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
-msgstr "Log Asli (%s) - "
+msgid "Raw Log (%s) - %s"
+msgstr "Log Asli (%s) - %s"
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4682,8 +4682,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "Sunting %s - "
+msgid "Edit %s - %s"
+msgstr "Sunting %s - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4774,8 +4774,8 @@ msgid "Character set:"
 msgstr "Set karakter:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "Daftar Jaringan - "
+msgid "Network List - %s"
+msgstr "Daftar Jaringan - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6139,7 +6139,7 @@ msgid ""
 msgstr "*PERINGATAN*\nOtomatis menerima DCC ke direktori home\nanda dapat berbahaya dan mudah dieksploitasi. Misalnya: \nSeseorang dapat mengirimi anda .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
+msgid "Preferences - %s"
 msgstr "Preferensi"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6204,8 +6204,8 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "Perekam Tautan"
+msgid "URL Grabber - %s"
+msgstr "Perekam Tautan - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/id.po
+++ b/po/id.po
@@ -3241,8 +3241,8 @@ msgstr "Anda hanya dapat membuka jendela Daftar Hukuman ketika di tab kanal."
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr ": Daftar Hukuman (%s)"
+msgid "Ban List (%s) - "
+msgstr "Daftar Hukuman (%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3280,8 +3280,8 @@ msgstr "Salin _Teks Topik"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr ": Daftar Kanal (%s)"
+msgid "Channel List (%s) - "
+msgstr "Daftar Kanal (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3372,8 +3372,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Tak dapat melanjutkan berkas yang sama dari dua orang."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr ": Unggah dan Unduh"
+msgid "Uploads and Downloads - "
+msgstr "Unggah dan Unduh - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3430,8 +3430,8 @@ msgid "Open Folder..."
 msgstr "Buka Foler..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr ": Daftar Chat DCC"
+msgid "DCC Chat List - "
+msgstr "Daftar Chat DCC - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3627,8 +3627,8 @@ msgid "Select a row to get help information on its Action."
 msgstr "Pilih sebuah baris untuk mendapatkan informasi tentang tindakannya."
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr ": Tombol Cepat Keyboard"
+msgid "Keyboard Shortcuts - "
+msgstr "Tombol Cepat Keyboard - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3672,8 +3672,8 @@ msgid "Enter mask to ignore:"
 msgstr "Masukkan mask yang akan diabaikan:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr ": Daftar Pengabaian"
+msgid "Ignore list - "
+msgstr "Daftar Pengabaian - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3708,8 +3708,8 @@ msgid "Channel name too short, try again."
 msgstr "Nama kanal terlalu pendek, coba lagi."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr ": Koneksi Selesai"
+msgid "Connection Complete - "
+msgstr "Koneksi Selesai - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4035,8 +4035,8 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr ": Menu pengguna"
+msgid "User menu - "
+msgstr "Menu pengguna - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4156,36 +4156,36 @@ msgid ""
 msgstr "Pengendali Tautan - Kode Spesial:\n\n%s  =  Tautan\n\nMenaruh ! di depan perintah\nmenunjukkan hal tersebut harus dikirim ke \nshell bukan HexChat"
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr ": Kustom Perintah "
+msgid "User Defined Commands - "
+msgstr "Kustom Perintah  - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr ": Daftar Menu Popup"
+msgid "Userlist Popup menu - "
+msgstr "Daftar Menu Popup - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Ganti dengan "
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr ": Ganti"
+msgid "Replace - "
+msgstr "Ganti - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr ": Pengendali Tautan"
+msgid "URL Handlers - "
+msgstr "Pengendali Tautan - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr ": Daftar Tombol Kustom"
+msgid "Userlist buttons - "
+msgstr "Daftar Tombol Kustom - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr ": Tombol Dialog"
+msgid "Dialog buttons - "
+msgstr "Tombol Dialog - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr ": Balasan CTCP"
+msgid "CTCP Replies - "
+msgstr "Balasan CTCP - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4492,8 +4492,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Koma yang memisahkan daftar jaringan dapat diterima."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
-msgstr ": Daftar Teman"
+msgid "Friends List - "
+msgstr "Daftar Teman - "
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4531,8 +4531,8 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
-msgstr ": Terhubung ke %u jaaringan dan %u kanal"
+msgid "Connected to %u networks and %u channels - "
+msgstr "Terhubung ke %u jaaringan dan %u kanal - "
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4573,43 +4573,43 @@ msgstr "_Kembali"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
-msgstr ": Soroti pesan dari: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
+msgstr "Soroti pesan dari: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
-msgstr ": %u pesan disoroti, terakhir dari: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
+msgstr "%u pesan disoroti, terakhir dari: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
-msgstr ": Pesan rahasia dari: %s (%s)"
+msgid "Private message from: %s (%s) - "
+msgstr "Pesan rahasia dari: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
-msgstr ": %u pesan rahasia, terakhir dari: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
+msgstr "%u pesan rahasia, terakhir dari: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
-msgstr ": Berkas dikirim dari: %s (%s)"
+msgid "File offer from: %s (%s) - "
+msgstr "Berkas dikirim dari: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
-msgstr ": %u berkas kiriman, terakhir dari: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
+msgstr "%u berkas kiriman, terakhir dari: %s (%s) - "
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4624,8 +4624,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Pilih Plugin atau Skrip yang akan dibuka"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr ": Skrip dan Plugin"
+msgid "Plugins and Scripts - "
+msgstr "Skrip dan Plugin - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4646,8 +4646,8 @@ msgstr "Simpan Sebagai..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
-msgstr ": Log Asli (%s)"
+msgid "Raw Log (%s) - "
+msgstr "Log Asli (%s) - "
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4682,8 +4682,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr ": Sunting %s"
+msgid "Edit %s - "
+msgstr "Sunting %s - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4774,8 +4774,8 @@ msgid "Character set:"
 msgstr "Set karakter:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr ": Daftar Jaringan"
+msgid "Network List - "
+msgstr "Daftar Jaringan - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6139,7 +6139,7 @@ msgid ""
 msgstr "*PERINGATAN*\nOtomatis menerima DCC ke direktori home\nanda dapat berbahaya dan mudah dieksploitasi. Misalnya: \nSeseorang dapat mengirimi anda .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
+msgid "Preferences - "
 msgstr "Preferensi"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6204,7 +6204,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
+msgid "URL Grabber - "
 msgstr "Perekam Tautan"
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/it.po
+++ b/po/it.po
@@ -3242,8 +3242,8 @@ msgstr "È possibile aprire la finestra con l'elenco dei ban solo mentre si è n
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr ": elenco dei ban (%s)"
+msgid "Ban List (%s) - "
+msgstr "elenco dei ban (%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3281,8 +3281,8 @@ msgstr "Copia l'argomen_to del canale"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr ": elenco canali (%s)"
+msgid "Channel List (%s) - "
+msgstr "elenco canali (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3373,8 +3373,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Impossibile ripristinare lo stesso file da due persone."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr ": trasferimenti file"
+msgid "Uploads and Downloads - "
+msgstr "trasferimenti file - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3431,8 +3431,8 @@ msgid "Open Folder..."
 msgstr "Apri cartella..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr ": elenco chat DCC"
+msgid "DCC Chat List - "
+msgstr "elenco chat DCC - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3628,8 +3628,8 @@ msgid "Select a row to get help information on its Action."
 msgstr "Selezionare una riga per ottenere infromazioni sull'azione"
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr ": scorciatoie da tastiera"
+msgid "Keyboard Shortcuts - "
+msgstr "scorciatoie da tastiera - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3673,8 +3673,8 @@ msgid "Enter mask to ignore:"
 msgstr "Inserire maschera da ignorare:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr ": elenco utenti ignorati"
+msgid "Ignore list - "
+msgstr "elenco utenti ignorati - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3709,8 +3709,8 @@ msgid "Channel name too short, try again."
 msgstr "Nome del canale troppo corto, riprovare."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr ": connessione completata"
+msgid "Connection Complete - "
+msgstr "connessione completata - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4036,8 +4036,8 @@ msgid "_Auto-Connect"
 msgstr "Connetti _automaticamente"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr ": menù utente"
+msgid "User menu - "
+msgstr "menù utente - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4157,36 +4157,36 @@ msgid ""
 msgstr "Gestori URL - Codici speciali:\n\n%s  =  stringa dell'URL\n\nInserire un «!» davanti al comando\nindica che deve essere inviato\nad un terminale invece che ad HexChat"
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr ": comandi definiti dall'utente"
+msgid "User Defined Commands - "
+msgstr "comandi definiti dall'utente - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr ": menù pop-up elenco utenti"
+msgid "Userlist Popup menu - "
+msgstr "menù pop-up elenco utenti - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Sostituisci con"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr ": sostituisci"
+msgid "Replace - "
+msgstr "sostituisci - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr ": gestori URL"
+msgid "URL Handlers - "
+msgstr "gestori URL - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr ": pulsanti elenco utenti"
+msgid "Userlist buttons - "
+msgstr "pulsanti elenco utenti - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr ": pulsanti dialogo"
+msgid "Dialog buttons - "
+msgstr "pulsanti dialogo - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr ": risposte CTCP"
+msgid "CTCP Replies - "
+msgstr "risposte CTCP - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4493,8 +4493,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Elenco di reti, separate da virgole."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
-msgstr ": elenco amici"
+msgid "Friends List - "
+msgstr "elenco amici - "
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4532,8 +4532,8 @@ msgstr "Messaggio privato da: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
-msgstr ": reti connesse %u, canali %u"
+msgid "Connected to %u networks and %u channels - "
+msgstr "reti connesse %u, canali %u - "
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4574,43 +4574,43 @@ msgstr "_Presente"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
-msgstr ": messaggio evidenziato da: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
+msgstr "messaggio evidenziato da: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
-msgstr ": %u messaggi evidenziati, l'ultimo da: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
+msgstr "%u messaggi evidenziati, l'ultimo da: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
-msgstr ": messaggio del canale da: %s (%s)"
+msgid "Channel message from: %s (%s) - "
+msgstr "messaggio del canale da: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
-msgstr ": %u messaggi dal canale."
+msgid "%u channel messages. - "
+msgstr "%u messaggi dal canale. - "
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
-msgstr ": messaggio privato da: %s (%s)"
+msgid "Private message from: %s (%s) - "
+msgstr "messaggio privato da: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
-msgstr ": %u messaggi privati, l'ultimo da: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
+msgstr "%u messaggi privati, l'ultimo da: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
-msgstr ": file offerto da: %s (%s)"
+msgid "File offer from: %s (%s) - "
+msgstr "file offerto da: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
-msgstr ": %u file offerti, l'ultimo da: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
+msgstr "%u file offerti, l'ultimo da: %s (%s) - "
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4625,8 +4625,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Seleziona il plugin o lo script da caricare"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr ": plugin e script"
+msgid "Plugins and Scripts - "
+msgstr "plugin e script - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4647,8 +4647,8 @@ msgstr "Salva come..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
-msgstr ": registro in forma grezza (%s)"
+msgid "Raw Log (%s) - "
+msgstr "registro in forma grezza (%s) - "
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4683,8 +4683,8 @@ msgstr "Il metodo usato per autenticarsi sul server. Per metodi di accesso perso
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr ": modifica %s"
+msgid "Edit %s - "
+msgstr "modifica %s - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4775,8 +4775,8 @@ msgid "Character set:"
 msgstr "Set di caratteri:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr ": elenco reti"
+msgid "Network List - "
+msgstr "elenco reti - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6140,8 +6140,8 @@ msgid ""
 msgstr "*ATTENZIONE*\nAccettare automaticamente DCC nella propria home\npotrebbe essere pericoloso. Esempio:\nQualcuno potrebbe inserire un file .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr ": preferenze"
+msgid "Preferences - "
+msgstr "preferenze - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6205,8 +6205,8 @@ msgid "OK"
 msgstr "OK"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr ": URL collezionati"
+msgid "URL Grabber - "
+msgstr "URL collezionati - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/it.po
+++ b/po/it.po
@@ -3242,8 +3242,8 @@ msgstr "È possibile aprire la finestra con l'elenco dei ban solo mentre si è n
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "elenco dei ban (%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "elenco dei ban (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3281,8 +3281,8 @@ msgstr "Copia l'argomen_to del canale"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr "elenco canali (%s) - "
+msgid "Channel List (%s) - %s"
+msgstr "elenco canali (%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3373,8 +3373,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Impossibile ripristinare lo stesso file da due persone."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "trasferimenti file - "
+msgid "Uploads and Downloads - %s"
+msgstr "trasferimenti file - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3431,8 +3431,8 @@ msgid "Open Folder..."
 msgstr "Apri cartella..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "elenco chat DCC - "
+msgid "DCC Chat List - %s"
+msgstr "elenco chat DCC - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3628,8 +3628,8 @@ msgid "Select a row to get help information on its Action."
 msgstr "Selezionare una riga per ottenere infromazioni sull'azione"
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "scorciatoie da tastiera - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "scorciatoie da tastiera - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3673,8 +3673,8 @@ msgid "Enter mask to ignore:"
 msgstr "Inserire maschera da ignorare:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "elenco utenti ignorati - "
+msgid "Ignore list - %s"
+msgstr "elenco utenti ignorati - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3709,8 +3709,8 @@ msgid "Channel name too short, try again."
 msgstr "Nome del canale troppo corto, riprovare."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "connessione completata - "
+msgid "Connection Complete - %s"
+msgstr "connessione completata - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4036,8 +4036,8 @@ msgid "_Auto-Connect"
 msgstr "Connetti _automaticamente"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "menù utente - "
+msgid "User menu - %s"
+msgstr "menù utente - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4157,36 +4157,36 @@ msgid ""
 msgstr "Gestori URL - Codici speciali:\n\n%s  =  stringa dell'URL\n\nInserire un «!» davanti al comando\nindica che deve essere inviato\nad un terminale invece che ad HexChat"
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "comandi definiti dall'utente - "
+msgid "User Defined Commands - %s"
+msgstr "comandi definiti dall'utente - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "menù pop-up elenco utenti - "
+msgid "Userlist Popup menu - %s"
+msgstr "menù pop-up elenco utenti - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Sostituisci con"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "sostituisci - "
+msgid "Replace - %s"
+msgstr "sostituisci - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "gestori URL - "
+msgid "URL Handlers - %s"
+msgstr "gestori URL - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "pulsanti elenco utenti - "
+msgid "Userlist buttons - %s"
+msgstr "pulsanti elenco utenti - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "pulsanti dialogo - "
+msgid "Dialog buttons - %s"
+msgstr "pulsanti dialogo - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "risposte CTCP - "
+msgid "CTCP Replies - %s"
+msgstr "risposte CTCP - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4493,8 +4493,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Elenco di reti, separate da virgole."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
-msgstr "elenco amici - "
+msgid "Friends List - %s"
+msgstr "elenco amici - %s"
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4532,8 +4532,8 @@ msgstr "Messaggio privato da: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
-msgstr "reti connesse %u, canali %u - "
+msgid "Connected to %u networks and %u channels - %s"
+msgstr "reti connesse %u, canali %u - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4574,43 +4574,43 @@ msgstr "_Presente"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
-msgstr "messaggio evidenziato da: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
+msgstr "messaggio evidenziato da: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
-msgstr "%u messaggi evidenziati, l'ultimo da: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
+msgstr "%u messaggi evidenziati, l'ultimo da: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
-msgstr "messaggio del canale da: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
+msgstr "messaggio del canale da: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
-msgstr "%u messaggi dal canale. - "
+msgid "%u channel messages. - %s"
+msgstr "%u messaggi dal canale. - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
-msgstr "messaggio privato da: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
+msgstr "messaggio privato da: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
-msgstr "%u messaggi privati, l'ultimo da: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
+msgstr "%u messaggi privati, l'ultimo da: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
-msgstr "file offerto da: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
+msgstr "file offerto da: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
-msgstr "%u file offerti, l'ultimo da: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
+msgstr "%u file offerti, l'ultimo da: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4625,8 +4625,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Seleziona il plugin o lo script da caricare"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "plugin e script - "
+msgid "Plugins and Scripts - %s"
+msgstr "plugin e script - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4647,8 +4647,8 @@ msgstr "Salva come..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
-msgstr "registro in forma grezza (%s) - "
+msgid "Raw Log (%s) - %s"
+msgstr "registro in forma grezza (%s) - %s"
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4683,8 +4683,8 @@ msgstr "Il metodo usato per autenticarsi sul server. Per metodi di accesso perso
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "modifica %s - "
+msgid "Edit %s - %s"
+msgstr "modifica %s - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4775,8 +4775,8 @@ msgid "Character set:"
 msgstr "Set di caratteri:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "elenco reti - "
+msgid "Network List - %s"
+msgstr "elenco reti - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6140,8 +6140,8 @@ msgid ""
 msgstr "*ATTENZIONE*\nAccettare automaticamente DCC nella propria home\npotrebbe essere pericoloso. Esempio:\nQualcuno potrebbe inserire un file .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "preferenze - "
+msgid "Preferences - %s"
+msgstr "preferenze - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6205,8 +6205,8 @@ msgid "OK"
 msgstr "OK"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "URL collezionati - "
+msgid "URL Grabber - %s"
+msgstr "URL collezionati - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/ja_JP.po
+++ b/po/ja_JP.po
@@ -3243,8 +3243,8 @@ msgstr "チャンネルタブの間だけバン一覧ウィンドウを開くこ
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "バン一覧 (%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "バン一覧 (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3282,8 +3282,8 @@ msgstr "トピックテキストをコピー(_T)"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr "チャンネル一覧 (%s) - "
+msgid "Channel List (%s) - %s"
+msgstr "チャンネル一覧 (%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3374,8 +3374,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "2 人から同じファイルを再開できません。"
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "アップロードとダウンロード - "
+msgid "Uploads and Downloads - %s"
+msgstr "アップロードとダウンロード - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3432,8 +3432,8 @@ msgid "Open Folder..."
 msgstr "フォルダーを開く..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "DCC チャット一覧 - "
+msgid "DCC Chat List - %s"
+msgstr "DCC チャット一覧 - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3629,8 +3629,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "キーボードショートカット - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "キーボードショートカット - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3674,8 +3674,8 @@ msgid "Enter mask to ignore:"
 msgstr "無視するマスクを入力:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "無視一覧 - "
+msgid "Ignore list - %s"
+msgstr "無視一覧 - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3710,8 +3710,8 @@ msgid "Channel name too short, try again."
 msgstr "チャンネル名が短すぎます。もう一度試してください。"
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "接続完了 - "
+msgid "Connection Complete - %s"
+msgstr "接続完了 - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4037,8 +4037,8 @@ msgid "_Auto-Connect"
 msgstr "自動接続(_A)"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "ユーザーメニュー - "
+msgid "User menu - %s"
+msgstr "ユーザーメニュー - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4158,36 +4158,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "ユーザー定義コマンドの - "
+msgid "User Defined Commands - %s"
+msgstr "ユーザー定義コマンドの - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "ユーザー一覧のポップアップメニュー - "
+msgid "Userlist Popup menu - %s"
+msgstr "ユーザー一覧のポップアップメニュー - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "置換"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "置換 - "
+msgid "Replace - %s"
+msgstr "置換 - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "URL ハンドラー - "
+msgid "URL Handlers - %s"
+msgstr "URL ハンドラー - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "ユーザーリストのボタン - "
+msgid "Userlist buttons - %s"
+msgstr "ユーザーリストのボタン - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "ダイアログボタン - "
+msgid "Dialog buttons - %s"
+msgstr "ダイアログボタン - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "CTCP 応答 - "
+msgid "CTCP Replies - %s"
+msgstr "CTCP 応答 - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4494,8 +4494,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
-msgstr "フレンドリスト - "
+msgid "Friends List - %s"
+msgstr "フレンドリスト - %s"
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4533,7 +4533,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
+msgid "Connected to %u networks and %u channels - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4575,42 +4575,42 @@ msgstr "着席(_B)"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4626,7 +4626,7 @@ msgid "Select a Plugin or Script to load"
 msgstr "読み込むプラグインかスクリプトを選択する"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
+msgid "Plugins and Scripts - %s"
 msgstr "XChat プラグインとスクリプト"
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4648,8 +4648,8 @@ msgstr "別名で保存..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
-msgstr "生ログ (%s) - "
+msgid "Raw Log (%s) - %s"
+msgstr "生ログ (%s) - %s"
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4684,8 +4684,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "%s 編集 - "
+msgid "Edit %s - %s"
+msgstr "%s 編集 - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4776,8 +4776,8 @@ msgid "Character set:"
 msgstr "文字集合:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "ネットワーク一覧 - "
+msgid "Network List - %s"
+msgstr "ネットワーク一覧 - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6141,8 +6141,8 @@ msgid ""
 msgstr "*警告*\nホーム・ディレクトリへ自動DCC受け取りを有効にする\nことは悪戯される危険があり, 勧められません. 例えば,\n誰からがあなたへ『.bash_profile』ファイルを転送す\nると, 勝手にシェルの設定が上書きされてしまいます。"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "設定 - "
+msgid "Preferences - %s"
+msgstr "設定 - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6206,8 +6206,8 @@ msgid "OK"
 msgstr "OK"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "URL 取り込み - "
+msgid "URL Grabber - %s"
+msgstr "URL 取り込み - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/ja_JP.po
+++ b/po/ja_JP.po
@@ -374,7 +374,7 @@ msgstr "サーバー %s を %s ネットワークに追加しました。\n"
 #: ../src/common/outbound.c:368
 #, c-format
 msgid "Already marked away: %s\n"
-msgstr "すでに離席状態です： %s\n"
+msgstr "すでに離席状態です: %s\n"
 
 #: ../src/common/outbound.c:405
 msgid "Already marked back.\n"
@@ -3243,8 +3243,8 @@ msgstr "チャンネルタブの間だけバン一覧ウィンドウを開くこ
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr "XChat: バン一覧 (%s)"
+msgid "Ban List (%s) - "
+msgstr "バン一覧 (%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3282,8 +3282,8 @@ msgstr "トピックテキストをコピー(_T)"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr "XChat: チャンネル一覧 (%s)"
+msgid "Channel List (%s) - "
+msgstr "チャンネル一覧 (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3374,8 +3374,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "2 人から同じファイルを再開できません。"
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr ": アップロードとダウンロード"
+msgid "Uploads and Downloads - "
+msgstr "アップロードとダウンロード - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3432,8 +3432,8 @@ msgid "Open Folder..."
 msgstr "フォルダーを開く..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr "XChat: DCC チャット一覧"
+msgid "DCC Chat List - "
+msgstr "DCC チャット一覧 - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3629,8 +3629,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr "XChat: キーボードショートカット"
+msgid "Keyboard Shortcuts - "
+msgstr "キーボードショートカット - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3674,8 +3674,8 @@ msgid "Enter mask to ignore:"
 msgstr "無視するマスクを入力:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr "XChat: 無視一覧"
+msgid "Ignore list - "
+msgstr "無視一覧 - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3710,8 +3710,8 @@ msgid "Channel name too short, try again."
 msgstr "チャンネル名が短すぎます。もう一度試してください。"
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr "XChat: 接続完了"
+msgid "Connection Complete - "
+msgstr "接続完了 - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4037,8 +4037,8 @@ msgid "_Auto-Connect"
 msgstr "自動接続(_A)"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr "XChat: ユーザーメニュー"
+msgid "User menu - "
+msgstr "ユーザーメニュー - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4158,36 +4158,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr "XChat: ユーザー定義コマンドの"
+msgid "User Defined Commands - "
+msgstr "ユーザー定義コマンドの - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr "XChat: ユーザー一覧のポップアップメニュー"
+msgid "Userlist Popup menu - "
+msgstr "ユーザー一覧のポップアップメニュー - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "置換"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr "XChat: 置換"
+msgid "Replace - "
+msgstr "置換 - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr "XChat: URL ハンドラー"
+msgid "URL Handlers - "
+msgstr "URL ハンドラー - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr "XChat: ユーザーリストのボタン"
+msgid "Userlist buttons - "
+msgstr "ユーザーリストのボタン - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr "XChat: ダイアログボタン"
+msgid "Dialog buttons - "
+msgstr "ダイアログボタン - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr "XChat: CTCP 応答"
+msgid "CTCP Replies - "
+msgstr "CTCP 応答 - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4487,15 +4487,15 @@ msgstr "新ニックネームを入力:"
 
 #: ../src/fe-gtk/notifygui.c:372
 msgid "Notify on these networks:"
-msgstr "これらのネットワークで通知："
+msgstr "これらのネットワークで通知:"
 
 #: ../src/fe-gtk/notifygui.c:383
 msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
-msgstr ": フレンドリスト"
+msgid "Friends List - "
+msgstr "フレンドリスト - "
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4533,7 +4533,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
+msgid "Connected to %u networks and %u channels - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4575,42 +4575,42 @@ msgstr "着席(_B)"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
+msgid "Private message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
+msgid "File offer from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4626,7 +4626,7 @@ msgid "Select a Plugin or Script to load"
 msgstr "読み込むプラグインかスクリプトを選択する"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
+msgid "Plugins and Scripts - "
 msgstr "XChat プラグインとスクリプト"
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4648,8 +4648,8 @@ msgstr "別名で保存..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
-msgstr ": 生ログ (%s)"
+msgid "Raw Log (%s) - "
+msgstr "生ログ (%s) - "
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4684,8 +4684,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr "XChat: %s 編集"
+msgid "Edit %s - "
+msgstr "%s 編集 - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4776,8 +4776,8 @@ msgid "Character set:"
 msgstr "文字集合:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr "XChat: ネットワーク一覧"
+msgid "Network List - "
+msgstr "ネットワーク一覧 - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6141,8 +6141,8 @@ msgid ""
 msgstr "*警告*\nホーム・ディレクトリへ自動DCC受け取りを有効にする\nことは悪戯される危険があり, 勧められません. 例えば,\n誰からがあなたへ『.bash_profile』ファイルを転送す\nると, 勝手にシェルの設定が上書きされてしまいます。"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr "XChat: 設定"
+msgid "Preferences - "
+msgstr "設定 - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6206,8 +6206,8 @@ msgid "OK"
 msgstr "OK"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr "XChat: URL 取り込み"
+msgid "URL Grabber - "
+msgstr "URL 取り込み - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/kn.po
+++ b/po/kn.po
@@ -3239,8 +3239,8 @@ msgstr "ಒಂದು ಚಾನಲ್‌ ಹಾಳೆಯಲ್ಲಿದ್ದಾ�
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "ನಿಶೇಧ ಪಟ್ಟಿ (%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "ನಿಶೇಧ ಪಟ್ಟಿ (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3278,8 +3278,8 @@ msgstr "ವಿಷಯದ ಪಠ್ಯವನ್ನು ಕಾಪಿ ಮಾಡು(_T
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr "ಚಾನಲ್‌ ಪಟ್ಟಿ (%s) - "
+msgid "Channel List (%s) - %s"
+msgstr "ಚಾನಲ್‌ ಪಟ್ಟಿ (%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3370,8 +3370,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "ಒಂದೇ ಕಡತವನ್ನು ಎರಡು ವ್ಯಕ್ತಿಗಳಿಗಾಗಿ ಮರಳಿ ಆರಂಭಿಸಲು ಸಾಧ್ಯವಿಲ್ಲ."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "ಅಪ್‌ಲೋಡ್‌ಗಳು ಹಾಗು ಡೌನ್‌ಲೋಡ್‌ಗಳು - "
+msgid "Uploads and Downloads - %s"
+msgstr "ಅಪ್‌ಲೋಡ್‌ಗಳು ಹಾಗು ಡೌನ್‌ಲೋಡ್‌ಗಳು - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3428,8 +3428,8 @@ msgid "Open Folder..."
 msgstr "ಕಡತಕೋಶವನ್ನು ತೆರೆ..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "DCC ಮಾತುಕತೆಯ ಪಟ್ಟಿ - "
+msgid "DCC Chat List - %s"
+msgstr "DCC ಮಾತುಕತೆಯ ಪಟ್ಟಿ - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3625,8 +3625,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "ಕೀಲಿಮಣೆ ಶಾರ್ಟ್-ಕಟ್‌ಗಳು - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "ಕೀಲಿಮಣೆ ಶಾರ್ಟ್-ಕಟ್‌ಗಳು - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3670,8 +3670,8 @@ msgid "Enter mask to ignore:"
 msgstr "ಕಡೆಗಣಿಸಲು ಮುಸುಕನ್ನು ನಮೂದಿಸಿ:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "ಕಡೆಗಣಿಸಬೇಕಿರುವ ಪಟ್ಟಿ - "
+msgid "Ignore list - %s"
+msgstr "ಕಡೆಗಣಿಸಬೇಕಿರುವ ಪಟ್ಟಿ - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3706,8 +3706,8 @@ msgid "Channel name too short, try again."
 msgstr "ಚಾನಲ್ ಹೆಸರು ಬಹಳ ಸಣ್ಣದಾಗಿದೆ, ಇನ್ನೊಮ್ಮೆ ಪ್ರಯತ್ನಿಸಿ."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "ಸಂಪರ್ಕವು ಪೂರ್ಣಗೊಂಡಿದೆ - "
+msgid "Connection Complete - %s"
+msgstr "ಸಂಪರ್ಕವು ಪೂರ್ಣಗೊಂಡಿದೆ - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4033,8 +4033,8 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "ಬಳಕೆದಾರ ಮೆನು - "
+msgid "User menu - %s"
+msgstr "ಬಳಕೆದಾರ ಮೆನು - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4154,36 +4154,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "ಬಳಕೆದಾರರಿಂದ ಸೂಚಿತ ಆಜ್ಞೆಗಳು - "
+msgid "User Defined Commands - %s"
+msgstr "ಬಳಕೆದಾರರಿಂದ ಸೂಚಿತ ಆಜ್ಞೆಗಳು - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "ಬಳಕೆದಾರಪಟ್ಟಿಯ ಪುಟಿಕೆ ಮೆನು - "
+msgid "Userlist Popup menu - %s"
+msgstr "ಬಳಕೆದಾರಪಟ್ಟಿಯ ಪುಟಿಕೆ ಮೆನು - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "ಇದರೊಂದಿಗೆ ಬದಲಿಸು"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "ಬದಲಿಸು - "
+msgid "Replace - %s"
+msgstr "ಬದಲಿಸು - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "URL ಹ್ಯಾಂಡ್ಲರುಗಳು - "
+msgid "URL Handlers - %s"
+msgstr "URL ಹ್ಯಾಂಡ್ಲರುಗಳು - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "ಬಳಕೆದಾರಪಟ್ಟಿ ಗುಂಡಿಗಳು - "
+msgid "Userlist buttons - %s"
+msgstr "ಬಳಕೆದಾರಪಟ್ಟಿ ಗುಂಡಿಗಳು - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "ಸಂವಾದ ಗುಂಡಿಗಳು - "
+msgid "Dialog buttons - %s"
+msgstr "ಸಂವಾದ ಗುಂಡಿಗಳು - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "CTCP ಪ್ರತ್ಯುತ್ತರಗಳು - "
+msgid "CTCP Replies - %s"
+msgstr "CTCP ಪ್ರತ್ಯುತ್ತರಗಳು - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4490,8 +4490,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "ವಿರಾಮಚಿಹ್ನೆಗಳಿಂದ ಬೇರ್ಪಡಿಸಲಾದ ಅಂಗೀಕರಿಸಲಾದ ಜಾಲಬಂಧಗಳ ಪಟ್ಟಿ."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
-msgstr "ಗೆಳೆಯರ ಪಟ್ಟಿ - "
+msgid "Friends List - %s"
+msgstr "ಗೆಳೆಯರ ಪಟ್ಟಿ - %s"
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4529,8 +4529,8 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
-msgstr "ನೀವು %u ಜಾಲಬಂಧಗಳೊಂದಿಗೆ ಹಾಗು %u ಚಾನಲ್‌ನೊಂದಿಗೆ ಸಂಪರ್ಕಿತಗೊಂಡಿದ್ದೀರಿ - "
+msgid "Connected to %u networks and %u channels - %s"
+msgstr "ನೀವು %u ಜಾಲಬಂಧಗಳೊಂದಿಗೆ ಹಾಗು %u ಚಾನಲ್‌ನೊಂದಿಗೆ ಸಂಪರ್ಕಿತಗೊಂಡಿದ್ದೀರಿ - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4571,43 +4571,43 @@ msgstr "ಹಿಂದೆ(_B)"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
-msgstr "ಇವರಿಂದ ಹೈಲೈಟ್ ಮಾಡಲಾದ ಸಂದೇಶ : %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
+msgstr "ಇವರಿಂದ ಹೈಲೈಟ್ ಮಾಡಲಾದ ಸಂದೇಶ : %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
-msgstr "%u ರವರು ಸಂದೇಶವನ್ನು ಹೈಲೈಟ್ ಮಾಡಿದ್ದಾರೆ, ಇತ್ತೀಚಿನದು: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
+msgstr "%u ರವರು ಸಂದೇಶವನ್ನು ಹೈಲೈಟ್ ಮಾಡಿದ್ದಾರೆ, ಇತ್ತೀಚಿನದು: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
-msgstr "ಇವರಿಮದ ಖಾಸಗಿ ಸಂದೇಶ: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
+msgstr "ಇವರಿಮದ ಖಾಸಗಿ ಸಂದೇಶ: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
-msgstr "%u ರವರಿಂದ ಖಾಸಗಿ ಸಂದೇಶ, ಇತ್ತೀಚಿನದು: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
+msgstr "%u ರವರಿಂದ ಖಾಸಗಿ ಸಂದೇಶ, ಇತ್ತೀಚಿನದು: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
-msgstr "ಇವರು ಕಡತವನ್ನು ನೀಡಲು ಬಯಸಿದ್ದಾರೆ: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
+msgstr "ಇವರು ಕಡತವನ್ನು ನೀಡಲು ಬಯಸಿದ್ದಾರೆ: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
-msgstr "%u ರು ಕಡತ ನೀಡಲು ಬಯಸಿದ್ದಾರೆ, ಇತ್ತೀಚಿನದು: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
+msgstr "%u ರು ಕಡತ ನೀಡಲು ಬಯಸಿದ್ದಾರೆ, ಇತ್ತೀಚಿನದು: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4622,8 +4622,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "ಅನುಸ್ಥಾಪಿಸಲು ಪ್ಲಗ್‌ಇನ್ ಅಥವ ಸ್ಕ್ರಿಪ್ಟನ್ನು ಆಯ್ಕೆ ಮಾಡಿ"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "ಪ್ಲಗಿನ್‍ಗಳು ಹಾಗು ಸ್ಕ್ರಿಪ್ಟುಗಳು - "
+msgid "Plugins and Scripts - %s"
+msgstr "ಪ್ಲಗಿನ್‍ಗಳು ಹಾಗು ಸ್ಕ್ರಿಪ್ಟುಗಳು - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4644,7 +4644,7 @@ msgstr "ಹೀಗೆ ಉಳಿಸು..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4680,8 +4680,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "%s ಅನ್ನು ಸಂಪಾದಿಸು - "
+msgid "Edit %s - %s"
+msgstr "%s ಅನ್ನು ಸಂಪಾದಿಸು - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4772,8 +4772,8 @@ msgid "Character set:"
 msgstr "ಚಿಹ್ನೆಯ ನಕ್ಷೆ:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "ಜಾಲಬಂಧ ಪಟ್ಟಿ - "
+msgid "Network List - %s"
+msgstr "ಜಾಲಬಂಧ ಪಟ್ಟಿ - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6137,8 +6137,8 @@ msgid ""
 msgstr "*ಎಚ್ಚರಿಕೆ*\nDCC ಅನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗು ನಿಮ್ಮ ನೆಲೆ ಕೋಶಕ್ಕೆ ಒಪ್ಪಿಕೊಳ್ಳುವುದು\nಅಪಾಯಕಾರಿ ಹಾಗು ಮೋಸದ ಬಳಕೆಗೆ ಕಾರಣವಾಗಬಹುದು. ಉದಾ:\nಯಾರಾದರೂ ನಿಮಗೆ ಒಂದು .bash_profile ಅನ್ನು ಕಳುಹಿಸಬಹುದು"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "ಆದ್ಯತೆಗಳು - "
+msgid "Preferences - %s"
+msgstr "ಆದ್ಯತೆಗಳು - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6202,8 +6202,8 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "URL ಸೆಳೆದುಕೊಳ್ಳುವವ - "
+msgid "URL Grabber - %s"
+msgstr "URL ಸೆಳೆದುಕೊಳ್ಳುವವ - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/kn.po
+++ b/po/kn.po
@@ -3239,8 +3239,8 @@ msgstr "ಒಂದು ಚಾನಲ್‌ ಹಾಳೆಯಲ್ಲಿದ್ದಾ�
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr ": ನಿಶೇಧ ಪಟ್ಟಿ (%s)"
+msgid "Ban List (%s) - "
+msgstr "ನಿಶೇಧ ಪಟ್ಟಿ (%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3278,8 +3278,8 @@ msgstr "ವಿಷಯದ ಪಠ್ಯವನ್ನು ಕಾಪಿ ಮಾಡು(_T
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr ": ಚಾನಲ್‌ ಪಟ್ಟಿ (%s)"
+msgid "Channel List (%s) - "
+msgstr "ಚಾನಲ್‌ ಪಟ್ಟಿ (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3370,8 +3370,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "ಒಂದೇ ಕಡತವನ್ನು ಎರಡು ವ್ಯಕ್ತಿಗಳಿಗಾಗಿ ಮರಳಿ ಆರಂಭಿಸಲು ಸಾಧ್ಯವಿಲ್ಲ."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr ": ಅಪ್‌ಲೋಡ್‌ಗಳು ಹಾಗು ಡೌನ್‌ಲೋಡ್‌ಗಳು"
+msgid "Uploads and Downloads - "
+msgstr "ಅಪ್‌ಲೋಡ್‌ಗಳು ಹಾಗು ಡೌನ್‌ಲೋಡ್‌ಗಳು - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3428,8 +3428,8 @@ msgid "Open Folder..."
 msgstr "ಕಡತಕೋಶವನ್ನು ತೆರೆ..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr ": DCC ಮಾತುಕತೆಯ ಪಟ್ಟಿ"
+msgid "DCC Chat List - "
+msgstr "DCC ಮಾತುಕತೆಯ ಪಟ್ಟಿ - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3625,8 +3625,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr ": ಕೀಲಿಮಣೆ ಶಾರ್ಟ್-ಕಟ್‌ಗಳು"
+msgid "Keyboard Shortcuts - "
+msgstr "ಕೀಲಿಮಣೆ ಶಾರ್ಟ್-ಕಟ್‌ಗಳು - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3670,8 +3670,8 @@ msgid "Enter mask to ignore:"
 msgstr "ಕಡೆಗಣಿಸಲು ಮುಸುಕನ್ನು ನಮೂದಿಸಿ:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr ": ಕಡೆಗಣಿಸಬೇಕಿರುವ ಪಟ್ಟಿ"
+msgid "Ignore list - "
+msgstr "ಕಡೆಗಣಿಸಬೇಕಿರುವ ಪಟ್ಟಿ - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3706,8 +3706,8 @@ msgid "Channel name too short, try again."
 msgstr "ಚಾನಲ್ ಹೆಸರು ಬಹಳ ಸಣ್ಣದಾಗಿದೆ, ಇನ್ನೊಮ್ಮೆ ಪ್ರಯತ್ನಿಸಿ."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr ": ಸಂಪರ್ಕವು ಪೂರ್ಣಗೊಂಡಿದೆ"
+msgid "Connection Complete - "
+msgstr "ಸಂಪರ್ಕವು ಪೂರ್ಣಗೊಂಡಿದೆ - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4033,8 +4033,8 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr ": ಬಳಕೆದಾರ ಮೆನು"
+msgid "User menu - "
+msgstr "ಬಳಕೆದಾರ ಮೆನು - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4154,36 +4154,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr ": ಬಳಕೆದಾರರಿಂದ ಸೂಚಿತ ಆಜ್ಞೆಗಳು"
+msgid "User Defined Commands - "
+msgstr "ಬಳಕೆದಾರರಿಂದ ಸೂಚಿತ ಆಜ್ಞೆಗಳು - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr ": ಬಳಕೆದಾರಪಟ್ಟಿಯ ಪುಟಿಕೆ ಮೆನು"
+msgid "Userlist Popup menu - "
+msgstr "ಬಳಕೆದಾರಪಟ್ಟಿಯ ಪುಟಿಕೆ ಮೆನು - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "ಇದರೊಂದಿಗೆ ಬದಲಿಸು"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr ": ಬದಲಿಸು"
+msgid "Replace - "
+msgstr "ಬದಲಿಸು - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr ": URL ಹ್ಯಾಂಡ್ಲರುಗಳು"
+msgid "URL Handlers - "
+msgstr "URL ಹ್ಯಾಂಡ್ಲರುಗಳು - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr ": ಬಳಕೆದಾರಪಟ್ಟಿ ಗುಂಡಿಗಳು"
+msgid "Userlist buttons - "
+msgstr "ಬಳಕೆದಾರಪಟ್ಟಿ ಗುಂಡಿಗಳು - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr ": ಸಂವಾದ ಗುಂಡಿಗಳು"
+msgid "Dialog buttons - "
+msgstr "ಸಂವಾದ ಗುಂಡಿಗಳು - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr ": CTCP ಪ್ರತ್ಯುತ್ತರಗಳು"
+msgid "CTCP Replies - "
+msgstr "CTCP ಪ್ರತ್ಯುತ್ತರಗಳು - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4490,8 +4490,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "ವಿರಾಮಚಿಹ್ನೆಗಳಿಂದ ಬೇರ್ಪಡಿಸಲಾದ ಅಂಗೀಕರಿಸಲಾದ ಜಾಲಬಂಧಗಳ ಪಟ್ಟಿ."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
-msgstr ": ಗೆಳೆಯರ ಪಟ್ಟಿ"
+msgid "Friends List - "
+msgstr "ಗೆಳೆಯರ ಪಟ್ಟಿ - "
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4529,8 +4529,8 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
-msgstr ": ನೀವು %u ಜಾಲಬಂಧಗಳೊಂದಿಗೆ ಹಾಗು %u ಚಾನಲ್‌ನೊಂದಿಗೆ ಸಂಪರ್ಕಿತಗೊಂಡಿದ್ದೀರಿ"
+msgid "Connected to %u networks and %u channels - "
+msgstr "ನೀವು %u ಜಾಲಬಂಧಗಳೊಂದಿಗೆ ಹಾಗು %u ಚಾನಲ್‌ನೊಂದಿಗೆ ಸಂಪರ್ಕಿತಗೊಂಡಿದ್ದೀರಿ - "
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4571,43 +4571,43 @@ msgstr "ಹಿಂದೆ(_B)"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
-msgstr ": ಇವರಿಂದ ಹೈಲೈಟ್ ಮಾಡಲಾದ ಸಂದೇಶ : %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
+msgstr "ಇವರಿಂದ ಹೈಲೈಟ್ ಮಾಡಲಾದ ಸಂದೇಶ : %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
-msgstr ": %u ರವರು ಸಂದೇಶವನ್ನು ಹೈಲೈಟ್ ಮಾಡಿದ್ದಾರೆ, ಇತ್ತೀಚಿನದು: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
+msgstr "%u ರವರು ಸಂದೇಶವನ್ನು ಹೈಲೈಟ್ ಮಾಡಿದ್ದಾರೆ, ಇತ್ತೀಚಿನದು: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
-msgstr ": ಇವರಿಮದ ಖಾಸಗಿ ಸಂದೇಶ: %s (%s)"
+msgid "Private message from: %s (%s) - "
+msgstr "ಇವರಿಮದ ಖಾಸಗಿ ಸಂದೇಶ: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
-msgstr ": %u ರವರಿಂದ ಖಾಸಗಿ ಸಂದೇಶ, ಇತ್ತೀಚಿನದು: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
+msgstr "%u ರವರಿಂದ ಖಾಸಗಿ ಸಂದೇಶ, ಇತ್ತೀಚಿನದು: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
-msgstr ": ಇವರು ಕಡತವನ್ನು ನೀಡಲು ಬಯಸಿದ್ದಾರೆ: %s (%s)"
+msgid "File offer from: %s (%s) - "
+msgstr "ಇವರು ಕಡತವನ್ನು ನೀಡಲು ಬಯಸಿದ್ದಾರೆ: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
-msgstr ": %u ರು ಕಡತ ನೀಡಲು ಬಯಸಿದ್ದಾರೆ, ಇತ್ತೀಚಿನದು: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
+msgstr "%u ರು ಕಡತ ನೀಡಲು ಬಯಸಿದ್ದಾರೆ, ಇತ್ತೀಚಿನದು: %s (%s) - "
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4622,8 +4622,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "ಅನುಸ್ಥಾಪಿಸಲು ಪ್ಲಗ್‌ಇನ್ ಅಥವ ಸ್ಕ್ರಿಪ್ಟನ್ನು ಆಯ್ಕೆ ಮಾಡಿ"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr ": ಪ್ಲಗಿನ್‍ಗಳು ಹಾಗು ಸ್ಕ್ರಿಪ್ಟುಗಳು"
+msgid "Plugins and Scripts - "
+msgstr "ಪ್ಲಗಿನ್‍ಗಳು ಹಾಗು ಸ್ಕ್ರಿಪ್ಟುಗಳು - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4644,7 +4644,7 @@ msgstr "ಹೀಗೆ ಉಳಿಸು..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4680,8 +4680,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr ": %s ಅನ್ನು ಸಂಪಾದಿಸು"
+msgid "Edit %s - "
+msgstr "%s ಅನ್ನು ಸಂಪಾದಿಸು - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4772,8 +4772,8 @@ msgid "Character set:"
 msgstr "ಚಿಹ್ನೆಯ ನಕ್ಷೆ:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr ": ಜಾಲಬಂಧ ಪಟ್ಟಿ"
+msgid "Network List - "
+msgstr "ಜಾಲಬಂಧ ಪಟ್ಟಿ - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6137,8 +6137,8 @@ msgid ""
 msgstr "*ಎಚ್ಚರಿಕೆ*\nDCC ಅನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗು ನಿಮ್ಮ ನೆಲೆ ಕೋಶಕ್ಕೆ ಒಪ್ಪಿಕೊಳ್ಳುವುದು\nಅಪಾಯಕಾರಿ ಹಾಗು ಮೋಸದ ಬಳಕೆಗೆ ಕಾರಣವಾಗಬಹುದು. ಉದಾ:\nಯಾರಾದರೂ ನಿಮಗೆ ಒಂದು .bash_profile ಅನ್ನು ಕಳುಹಿಸಬಹುದು"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr ": ಆದ್ಯತೆಗಳು"
+msgid "Preferences - "
+msgstr "ಆದ್ಯತೆಗಳು - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6202,8 +6202,8 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr ": URL ಸೆಳೆದುಕೊಳ್ಳುವವ"
+msgid "URL Grabber - "
+msgstr "URL ಸೆಳೆದುಕೊಳ್ಳುವವ - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/ko.po
+++ b/po/ko.po
@@ -3240,8 +3240,8 @@ msgstr "대화방 탭에서만 입장 금지 목록을 열 수 있습니다."
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "입장 금지 목록(%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "입장 금지 목록(%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3279,8 +3279,8 @@ msgstr "주제 복사(_T)"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr "대화방 목록(%s) - "
+msgid "Channel List (%s) - %s"
+msgstr "대화방 목록(%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3371,8 +3371,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "두 사람에게서 같은 파일을 받을 경우 이어 받을 수 없습니다."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "보내기 및 받기 - "
+msgid "Uploads and Downloads - %s"
+msgstr "보내기 및 받기 - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3429,8 +3429,8 @@ msgid "Open Folder..."
 msgstr "디렉터리 열기..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "DCC 대화 목록 - "
+msgid "DCC Chat List - %s"
+msgstr "DCC 대화 목록 - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3626,8 +3626,8 @@ msgid "Select a row to get help information on its Action."
 msgstr "이 동작에 대한 도움말을 보시려면 항목을 선택하십시오."
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "단축키 - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "단축키 - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3671,8 +3671,8 @@ msgid "Enter mask to ignore:"
 msgstr "무시할 마스크 입력:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "무시 목록 - "
+msgid "Ignore list - %s"
+msgstr "무시 목록 - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3707,8 +3707,8 @@ msgid "Channel name too short, try again."
 msgstr "대화방 이름이 너무 짧습니다. 다시 시도하십시오."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "연결 완료 - "
+msgid "Connection Complete - %s"
+msgstr "연결 완료 - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4034,8 +4034,8 @@ msgid "_Auto-Connect"
 msgstr "자동 연결(_A)"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "사용자 메뉴 - "
+msgid "User menu - %s"
+msgstr "사용자 메뉴 - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4155,36 +4155,36 @@ msgid ""
 msgstr "URL 처리기 - 특수 코드:\n\n%s  =  URL 문자열\n\n명령 앞에 ! 문자를 놓으십시오\n헥스채트 대신 쉘로 보내야 함을\n나타냅니다"
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "사용자 정의 명령 - "
+msgid "User Defined Commands - %s"
+msgstr "사용자 정의 명령 - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "참여자 목록 단축 메뉴 - "
+msgid "Userlist Popup menu - %s"
+msgstr "참여자 목록 단축 메뉴 - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "바꿀 텍스트"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "바꾸기 - "
+msgid "Replace - %s"
+msgstr "바꾸기 - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "URL 관리기 - "
+msgid "URL Handlers - %s"
+msgstr "URL 관리기 - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "참여자 목록 버튼 - "
+msgid "Userlist buttons - %s"
+msgstr "참여자 목록 버튼 - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "대화창 버튼 - "
+msgid "Dialog buttons - %s"
+msgstr "대화창 버튼 - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "CTCP 회신 - "
+msgid "CTCP Replies - %s"
+msgstr "CTCP 회신 - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4491,8 +4491,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "쉼표로 구분한 네트워크 목록을 허용합니다."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
-msgstr "친구 목록 - "
+msgid "Friends List - %s"
+msgstr "친구 목록 - %s"
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4530,8 +4530,8 @@ msgstr "개인 메시지: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
-msgstr "%u 네트워크의 %u 대화방에 연결함 - "
+msgid "Connected to %u networks and %u channels - %s"
+msgstr "%u 네트워크의 %u 대화방에 연결함 - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4572,43 +4572,43 @@ msgstr "돌아옴(_B)"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
-msgstr "다음 참여자의 강조 메시지: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
+msgstr "다음 참여자의 강조 메시지: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
-msgstr "메시지 알림 %u개가 있습니다. 마지막 참여자: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
+msgstr "메시지 알림 %u개가 있습니다. 마지막 참여자: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
-msgstr "대화방 메시지: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
+msgstr "대화방 메시지: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
-msgstr "대화방 메시지 %u개가 있습니다. - "
+msgid "%u channel messages. - %s"
+msgstr "대화방 메시지 %u개가 있습니다. - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
-msgstr "비공개 메시지: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
+msgstr "비공개 메시지: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
-msgstr "귓속말 메시지 %u개가 있습니다. 마지막 참여자: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
+msgstr "귓속말 메시지 %u개가 있습니다. 마지막 참여자: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
-msgstr "다음 참여자가 파일 전송: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
+msgstr "다음 참여자가 파일 전송: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
-msgstr "파일 전송 %u개가 있습니다. 마지막 참여자: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
+msgstr "파일 전송 %u개가 있습니다. 마지막 참여자: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4623,8 +4623,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "불러올 추가 기능 또는 스크립트를 선택하십시오"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "추가 기능과 스크립트 - "
+msgid "Plugins and Scripts - %s"
+msgstr "추가 기능과 스크립트 - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4645,8 +4645,8 @@ msgstr "다른 이름으로 저장..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
-msgstr "원시 로그(%s) - "
+msgid "Raw Log (%s) - %s"
+msgstr "원시 로그(%s) - %s"
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4681,8 +4681,8 @@ msgstr "서버에 자신을 인증하는 방법입니다. 사용자 정의 로�
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "%s 편집 - "
+msgid "Edit %s - %s"
+msgstr "%s 편집 - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4773,8 +4773,8 @@ msgid "Character set:"
 msgstr "문자세트:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "네트워크 목록 - "
+msgid "Network List - %s"
+msgstr "네트워크 목록 - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6138,8 +6138,8 @@ msgid ""
 msgstr "*경고*\n홈 디렉터리로 자동 받기를 할 경우 상당히 위험합니다.\n예:\n어떤 사용자가 .bash_profile을 전송했을 때"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "기본 설정 - "
+msgid "Preferences - %s"
+msgstr "기본 설정 - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6203,8 +6203,8 @@ msgid "OK"
 msgstr "확인"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "URL 잡기 도구 - "
+msgid "URL Grabber - %s"
+msgstr "URL 잡기 도구 - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/ko.po
+++ b/po/ko.po
@@ -3240,8 +3240,8 @@ msgstr "대화방 탭에서만 입장 금지 목록을 열 수 있습니다."
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr ": 입장 금지 목록(%s)"
+msgid "Ban List (%s) - "
+msgstr "입장 금지 목록(%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3279,8 +3279,8 @@ msgstr "주제 복사(_T)"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr ": 대화방 목록(%s)"
+msgid "Channel List (%s) - "
+msgstr "대화방 목록(%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3371,8 +3371,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "두 사람에게서 같은 파일을 받을 경우 이어 받을 수 없습니다."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr ": 보내기 및 받기"
+msgid "Uploads and Downloads - "
+msgstr "보내기 및 받기 - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3429,8 +3429,8 @@ msgid "Open Folder..."
 msgstr "디렉터리 열기..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr ": DCC 대화 목록"
+msgid "DCC Chat List - "
+msgstr "DCC 대화 목록 - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3626,8 +3626,8 @@ msgid "Select a row to get help information on its Action."
 msgstr "이 동작에 대한 도움말을 보시려면 항목을 선택하십시오."
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr ": 단축키"
+msgid "Keyboard Shortcuts - "
+msgstr "단축키 - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3671,8 +3671,8 @@ msgid "Enter mask to ignore:"
 msgstr "무시할 마스크 입력:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr ": 무시 목록"
+msgid "Ignore list - "
+msgstr "무시 목록 - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3707,8 +3707,8 @@ msgid "Channel name too short, try again."
 msgstr "대화방 이름이 너무 짧습니다. 다시 시도하십시오."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr ": 연결 완료"
+msgid "Connection Complete - "
+msgstr "연결 완료 - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4034,8 +4034,8 @@ msgid "_Auto-Connect"
 msgstr "자동 연결(_A)"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr ": 사용자 메뉴"
+msgid "User menu - "
+msgstr "사용자 메뉴 - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4155,36 +4155,36 @@ msgid ""
 msgstr "URL 처리기 - 특수 코드:\n\n%s  =  URL 문자열\n\n명령 앞에 ! 문자를 놓으십시오\n헥스채트 대신 쉘로 보내야 함을\n나타냅니다"
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr ": 사용자 정의 명령"
+msgid "User Defined Commands - "
+msgstr "사용자 정의 명령 - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr ": 참여자 목록 단축 메뉴"
+msgid "Userlist Popup menu - "
+msgstr "참여자 목록 단축 메뉴 - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "바꿀 텍스트"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr ": 바꾸기"
+msgid "Replace - "
+msgstr "바꾸기 - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr ": URL 관리기"
+msgid "URL Handlers - "
+msgstr "URL 관리기 - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr ": 참여자 목록 버튼"
+msgid "Userlist buttons - "
+msgstr "참여자 목록 버튼 - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr ": 대화창 버튼"
+msgid "Dialog buttons - "
+msgstr "대화창 버튼 - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr ": CTCP 회신"
+msgid "CTCP Replies - "
+msgstr "CTCP 회신 - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4491,8 +4491,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "쉼표로 구분한 네트워크 목록을 허용합니다."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
-msgstr ": 친구 목록"
+msgid "Friends List - "
+msgstr "친구 목록 - "
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4530,8 +4530,8 @@ msgstr "개인 메시지: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
-msgstr ": %u 네트워크의 %u 대화방에 연결함"
+msgid "Connected to %u networks and %u channels - "
+msgstr "%u 네트워크의 %u 대화방에 연결함 - "
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4572,43 +4572,43 @@ msgstr "돌아옴(_B)"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
-msgstr ": 다음 참여자의 강조 메시지: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
+msgstr "다음 참여자의 강조 메시지: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
-msgstr ": 메시지 알림 %u개가 있습니다. 마지막 참여자: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
+msgstr "메시지 알림 %u개가 있습니다. 마지막 참여자: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
-msgstr ": 대화방 메시지: %s (%s)"
+msgid "Channel message from: %s (%s) - "
+msgstr "대화방 메시지: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
-msgstr ": 대화방 메시지 %u개가 있습니다."
+msgid "%u channel messages. - "
+msgstr "대화방 메시지 %u개가 있습니다. - "
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
-msgstr ": 비공개 메시지: %s (%s)"
+msgid "Private message from: %s (%s) - "
+msgstr "비공개 메시지: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
-msgstr ": 귓속말 메시지 %u개가 있습니다. 마지막 참여자: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
+msgstr "귓속말 메시지 %u개가 있습니다. 마지막 참여자: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
-msgstr ": 다음 참여자가 파일 전송: %s (%s)"
+msgid "File offer from: %s (%s) - "
+msgstr "다음 참여자가 파일 전송: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
-msgstr ": 파일 전송 %u개가 있습니다. 마지막 참여자: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
+msgstr "파일 전송 %u개가 있습니다. 마지막 참여자: %s (%s) - "
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4623,8 +4623,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "불러올 추가 기능 또는 스크립트를 선택하십시오"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr ": 추가 기능과 스크립트"
+msgid "Plugins and Scripts - "
+msgstr "추가 기능과 스크립트 - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4645,8 +4645,8 @@ msgstr "다른 이름으로 저장..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
-msgstr ": 원시 로그(%s)"
+msgid "Raw Log (%s) - "
+msgstr "원시 로그(%s) - "
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4681,8 +4681,8 @@ msgstr "서버에 자신을 인증하는 방법입니다. 사용자 정의 로�
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr ": %s 편집"
+msgid "Edit %s - "
+msgstr "%s 편집 - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4773,8 +4773,8 @@ msgid "Character set:"
 msgstr "문자세트:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr ": 네트워크 목록"
+msgid "Network List - "
+msgstr "네트워크 목록 - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6138,8 +6138,8 @@ msgid ""
 msgstr "*경고*\n홈 디렉터리로 자동 받기를 할 경우 상당히 위험합니다.\n예:\n어떤 사용자가 .bash_profile을 전송했을 때"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr ": 기본 설정"
+msgid "Preferences - "
+msgstr "기본 설정 - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6203,8 +6203,8 @@ msgid "OK"
 msgstr "확인"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr ": URL 잡기 도구"
+msgid "URL Grabber - "
+msgstr "URL 잡기 도구 - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/lt.po
+++ b/po/lt.po
@@ -3244,8 +3244,8 @@ msgstr "Jus galite tik atidaryti Blokų sąrašo langą kol esate kanalo kortel�
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "Blokų sąrašas (%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "Blokų sąrašas (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3283,8 +3283,8 @@ msgstr "Kopijuoti _temos tekstą"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr "Kanalų sąrašas (%s) - "
+msgid "Channel List (%s) - %s"
+msgstr "Kanalų sąrašas (%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3375,8 +3375,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Negalite tęsti to paties failo iš kelių skirtingų žmonių."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "Išsiuntimai ir atsiuntimai - "
+msgid "Uploads and Downloads - %s"
+msgstr "Išsiuntimai ir atsiuntimai - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3433,8 +3433,8 @@ msgid "Open Folder..."
 msgstr "Atverti aplanką..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "DCC Pokalbių sąrašas - "
+msgid "DCC Chat List - %s"
+msgstr "DCC Pokalbių sąrašas - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3630,8 +3630,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "Klaviatūros trumpiniai - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "Klaviatūros trumpiniai - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3675,8 +3675,8 @@ msgid "Enter mask to ignore:"
 msgstr "Įveskite ignoravimo kaukę:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "Ignoravimo sąrašas - "
+msgid "Ignore list - %s"
+msgstr "Ignoravimo sąrašas - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3711,8 +3711,8 @@ msgid "Channel name too short, try again."
 msgstr "kanalo pavadinimas per trumpas, bandykite dar kartą."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "Prisijungimas užbaigtas - "
+msgid "Connection Complete - %s"
+msgstr "Prisijungimas užbaigtas - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4038,7 +4038,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
+msgid "User menu - %s"
 msgstr ""
 
 #. sep
@@ -4159,11 +4159,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "Naudotojo apibrėžtos komandos - "
+msgid "User Defined Commands - %s"
+msgstr "Naudotojo apibrėžtos komandos - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
+msgid "Userlist Popup menu - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4171,24 +4171,24 @@ msgid "Replace with"
 msgstr "Kuo pakeisti"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
+msgid "Replace - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "URL doroklės - "
+msgid "URL Handlers - %s"
+msgstr "URL doroklės - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "Naudotojų sąrašo mygtukai - "
+msgid "Userlist buttons - %s"
+msgstr "Naudotojų sąrašo mygtukai - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "Dialogo mygtukai - "
+msgid "Dialog buttons - %s"
+msgstr "Dialogo mygtukai - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "CTCP atsakai - "
+msgid "CTCP Replies - %s"
+msgstr "CTCP atsakai - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4495,8 +4495,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
-msgstr "Draugų sąrašas - "
+msgid "Friends List - %s"
+msgstr "Draugų sąrašas - %s"
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4534,7 +4534,7 @@ msgstr "Privati žinutė nuo: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
+msgid "Connected to %u networks and %u channels - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4576,42 +4576,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4627,8 +4627,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Pasirinkite norimą įkelti įskiepį ar scenarijų"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "Įskiepiai ir scenarijai - "
+msgid "Plugins and Scripts - %s"
+msgstr "Įskiepiai ir scenarijai - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4649,8 +4649,8 @@ msgstr "Išsaugoti kaip..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
-msgstr "Neapdorotas žurnalas (%s) - "
+msgid "Raw Log (%s) - %s"
+msgstr "Neapdorotas žurnalas (%s) - %s"
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4685,8 +4685,8 @@ msgstr "Būdas kaip prisistatote serveriui. Tinkintiems prisijungimo metodams na
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "Redaguoti %s - "
+msgid "Edit %s - %s"
+msgstr "Redaguoti %s - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4777,8 +4777,8 @@ msgid "Character set:"
 msgstr "Simbolių rinkinys:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "Tinklų sąrašas - "
+msgid "Network List - %s"
+msgstr "Tinklų sąrašas - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6142,8 +6142,8 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "Nuostatos - "
+msgid "Preferences - %s"
+msgstr "Nuostatos - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6207,8 +6207,8 @@ msgid "OK"
 msgstr "Gerai"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "adresų glemžikas - "
+msgid "URL Grabber - %s"
+msgstr "adresų glemžikas - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/lt.po
+++ b/po/lt.po
@@ -3244,8 +3244,8 @@ msgstr "Jus galite tik atidaryti Blokų sąrašo langą kol esate kanalo kortel�
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr ": Blokų sąrašas (%s)"
+msgid "Ban List (%s) - "
+msgstr "Blokų sąrašas (%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3283,8 +3283,8 @@ msgstr "Kopijuoti _temos tekstą"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr ": Kanalų sąrašas (%s)"
+msgid "Channel List (%s) - "
+msgstr "Kanalų sąrašas (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3375,8 +3375,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Negalite tęsti to paties failo iš kelių skirtingų žmonių."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr ": Išsiuntimai ir atsiuntimai"
+msgid "Uploads and Downloads - "
+msgstr "Išsiuntimai ir atsiuntimai - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3433,8 +3433,8 @@ msgid "Open Folder..."
 msgstr "Atverti aplanką..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr ": DCC Pokalbių sąrašas"
+msgid "DCC Chat List - "
+msgstr "DCC Pokalbių sąrašas - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3630,8 +3630,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr ": Klaviatūros trumpiniai"
+msgid "Keyboard Shortcuts - "
+msgstr "Klaviatūros trumpiniai - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3675,8 +3675,8 @@ msgid "Enter mask to ignore:"
 msgstr "Įveskite ignoravimo kaukę:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr "  : Ignoravimo sąrašas"
+msgid "Ignore list - "
+msgstr "Ignoravimo sąrašas - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3711,8 +3711,8 @@ msgid "Channel name too short, try again."
 msgstr "kanalo pavadinimas per trumpas, bandykite dar kartą."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr ": Prisijungimas užbaigtas"
+msgid "Connection Complete - "
+msgstr "Prisijungimas užbaigtas - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4038,7 +4038,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
+msgid "User menu - "
 msgstr ""
 
 #. sep
@@ -4159,11 +4159,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr ": Naudotojo apibrėžtos komandos"
+msgid "User Defined Commands - "
+msgstr "Naudotojo apibrėžtos komandos - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
+msgid "Userlist Popup menu - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4171,24 +4171,24 @@ msgid "Replace with"
 msgstr "Kuo pakeisti"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
+msgid "Replace - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr ": URL doroklės"
+msgid "URL Handlers - "
+msgstr "URL doroklės - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr ": Naudotojų sąrašo mygtukai"
+msgid "Userlist buttons - "
+msgstr "Naudotojų sąrašo mygtukai - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr ": Dialogo mygtukai"
+msgid "Dialog buttons - "
+msgstr "Dialogo mygtukai - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr ": CTCP atsakai"
+msgid "CTCP Replies - "
+msgstr "CTCP atsakai - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4495,8 +4495,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
-msgstr ": Draugų sąrašas"
+msgid "Friends List - "
+msgstr "Draugų sąrašas - "
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4534,7 +4534,7 @@ msgstr "Privati žinutė nuo: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
+msgid "Connected to %u networks and %u channels - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4576,42 +4576,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
+msgid "Private message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
+msgid "File offer from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4627,8 +4627,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Pasirinkite norimą įkelti įskiepį ar scenarijų"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr ": Įskiepiai ir scenarijai"
+msgid "Plugins and Scripts - "
+msgstr "Įskiepiai ir scenarijai - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4649,8 +4649,8 @@ msgstr "Išsaugoti kaip..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
-msgstr ": Neapdorotas žurnalas (%s)"
+msgid "Raw Log (%s) - "
+msgstr "Neapdorotas žurnalas (%s) - "
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4685,8 +4685,8 @@ msgstr "Būdas kaip prisistatote serveriui. Tinkintiems prisijungimo metodams na
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr ": Redaguoti %s"
+msgid "Edit %s - "
+msgstr "Redaguoti %s - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4777,8 +4777,8 @@ msgid "Character set:"
 msgstr "Simbolių rinkinys:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr ": Tinklų sąrašas"
+msgid "Network List - "
+msgstr "Tinklų sąrašas - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6142,8 +6142,8 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr ": Nuostatos"
+msgid "Preferences - "
+msgstr "Nuostatos - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6207,8 +6207,8 @@ msgid "OK"
 msgstr "Gerai"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr ": adresų glemžikas"
+msgid "URL Grabber - "
+msgstr "adresų glemžikas - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/lv.po
+++ b/po/lv.po
@@ -3239,7 +3239,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
+msgid "Ban List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3278,7 +3278,7 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
+msgid "Channel List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3370,7 +3370,7 @@ msgid "Cannot resume the same file from two people."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
+msgid "Uploads and Downloads - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3428,7 +3428,7 @@ msgid "Open Folder..."
 msgstr "Atvērt mapi..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
+msgid "DCC Chat List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3625,7 +3625,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
+msgid "Keyboard Shortcuts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3670,7 +3670,7 @@ msgid "Enter mask to ignore:"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
+msgid "Ignore list - %s"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3706,7 +3706,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
+msgid "Connection Complete - %s"
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4033,8 +4033,8 @@ msgid "_Auto-Connect"
 msgstr "_Automātiski pieslēgties"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "Lietotāja izvēlne - "
+msgid "User menu - %s"
+msgstr "Lietotāja izvēlne - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4154,11 +4154,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
+msgid "User Defined Commands - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
+msgid "Userlist Popup menu - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4166,23 +4166,23 @@ msgid "Replace with"
 msgstr "Aizstāt ar"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
+msgid "Replace - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
+msgid "URL Handlers - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
+msgid "Userlist buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
+msgid "Dialog buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
+msgid "CTCP Replies - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4490,8 +4490,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
-msgstr "Draugu saraksts - "
+msgid "Friends List - %s"
+msgstr "Draugu saraksts - %s"
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4529,7 +4529,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
+msgid "Connected to %u networks and %u channels - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4571,42 +4571,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4622,7 +4622,7 @@ msgid "Select a Plugin or Script to load"
 msgstr "Izvēlieties Iespraudni vai Skriptu, ko ielādēt"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
+msgid "Plugins and Scripts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4644,7 +4644,7 @@ msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4680,7 +4680,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
+msgid "Edit %s - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4772,7 +4772,7 @@ msgid "Character set:"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
+msgid "Network List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6137,8 +6137,8 @@ msgid ""
 msgstr "*BRĪDINĀJUMS*\nAutomātiski akceptēt DCC uz savu mājas direktoriju\nvar būt bīstami un viegli exploitējams. Piem.:\nKāds var atsūtīt tev .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "Iestatījumi - "
+msgid "Preferences - %s"
+msgstr "Iestatījumi - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6202,7 +6202,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
+msgid "URL Grabber - %s"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/lv.po
+++ b/po/lv.po
@@ -3239,7 +3239,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
+msgid "Ban List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3278,7 +3278,7 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
+msgid "Channel List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3370,7 +3370,7 @@ msgid "Cannot resume the same file from two people."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
+msgid "Uploads and Downloads - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3428,7 +3428,7 @@ msgid "Open Folder..."
 msgstr "Atvērt mapi..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
+msgid "DCC Chat List - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3625,7 +3625,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
+msgid "Keyboard Shortcuts - "
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3670,7 +3670,7 @@ msgid "Enter mask to ignore:"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
+msgid "Ignore list - "
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3706,7 +3706,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
+msgid "Connection Complete - "
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4033,8 +4033,8 @@ msgid "_Auto-Connect"
 msgstr "_Automātiski pieslēgties"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr ": Lietotāja izvēlne"
+msgid "User menu - "
+msgstr "Lietotāja izvēlne - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4154,11 +4154,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
+msgid "User Defined Commands - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
+msgid "Userlist Popup menu - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4166,23 +4166,23 @@ msgid "Replace with"
 msgstr "Aizstāt ar"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
+msgid "Replace - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
+msgid "URL Handlers - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
+msgid "Userlist buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
+msgid "Dialog buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
+msgid "CTCP Replies - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4490,8 +4490,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
-msgstr ": Draugu saraksts"
+msgid "Friends List - "
+msgstr "Draugu saraksts - "
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4529,7 +4529,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
+msgid "Connected to %u networks and %u channels - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4571,42 +4571,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
+msgid "Private message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
+msgid "File offer from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4622,7 +4622,7 @@ msgid "Select a Plugin or Script to load"
 msgstr "Izvēlieties Iespraudni vai Skriptu, ko ielādēt"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
+msgid "Plugins and Scripts - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4644,7 +4644,7 @@ msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4680,7 +4680,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
+msgid "Edit %s - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4772,7 +4772,7 @@ msgid "Character set:"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
+msgid "Network List - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6137,8 +6137,8 @@ msgid ""
 msgstr "*BRĪDINĀJUMS*\nAutomātiski akceptēt DCC uz savu mājas direktoriju\nvar būt bīstami un viegli exploitējams. Piem.:\nKāds var atsūtīt tev .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr ": Iestatījumi"
+msgid "Preferences - "
+msgstr "Iestatījumi - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6202,7 +6202,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
+msgid "URL Grabber - "
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/mk.po
+++ b/po/mk.po
@@ -3238,8 +3238,8 @@ msgstr "Можете да го отворите прозорецот на лис
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr "XChat: Бан листа (%s)"
+msgid "Ban List (%s) - "
+msgstr "Бан листа (%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3277,8 +3277,8 @@ msgstr "Копирај го текстот од _насловот"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr "XChat: Листа на канали (%s)"
+msgid "Channel List (%s) - "
+msgstr "Листа на канали (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3369,8 +3369,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Не можам да ја примам истата датотека од двајца."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr "XChat: Качувања и преземања"
+msgid "Uploads and Downloads - "
+msgstr "Качувања и преземања - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3427,8 +3427,8 @@ msgid "Open Folder..."
 msgstr "Отвори папка..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr "XChat: Листа на DCC Chat"
+msgid "DCC Chat List - "
+msgstr "Листа на DCC Chat - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3624,8 +3624,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr "XChat: Кратенки за тастатура"
+msgid "Keyboard Shortcuts - "
+msgstr "Кратенки за тастатура - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3669,8 +3669,8 @@ msgid "Enter mask to ignore:"
 msgstr "Внеси маска за игнорирање:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr "XChat: Листа на игнорирани"
+msgid "Ignore list - "
+msgstr "Листа на игнорирани - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3705,8 +3705,8 @@ msgid "Channel name too short, try again."
 msgstr "Името на каналот е прекратно, обидете се повторно."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr "XChat: Врската заврши"
+msgid "Connection Complete - "
+msgstr "Врската заврши - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4032,8 +4032,8 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr "XChat: Корисничко мени"
+msgid "User menu - "
+msgstr "Корисничко мени - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4153,36 +4153,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr "XChat: Команди дефинирани од корисникот"
+msgid "User Defined Commands - "
+msgstr "Команди дефинирани од корисникот - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr "XChat: Скокачко мени на корисничката листа"
+msgid "Userlist Popup menu - "
+msgstr "Скокачко мени на корисничката листа - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Замени со"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr "XChat: Замени"
+msgid "Replace - "
+msgstr "Замени - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr "XChat: URL справувачи"
+msgid "URL Handlers - "
+msgstr "URL справувачи - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr "XChat: Копчиња за корисничката листа"
+msgid "Userlist buttons - "
+msgstr "Копчиња за корисничката листа - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr "XChat: Копчиња за дијалог"
+msgid "Dialog buttons - "
+msgstr "Копчиња за дијалог - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr "XChat: CTCP реплики"
+msgid "CTCP Replies - "
+msgstr "CTCP реплики - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4489,7 +4489,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Се прифаќа листа на мрежи разделена со запирки."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
+msgid "Friends List - "
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4528,8 +4528,8 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
-msgstr "XChat: Поврзан сум со %u мрежи и %u канали"
+msgid "Connected to %u networks and %u channels - "
+msgstr "Поврзан сум со %u мрежи и %u канали - "
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4570,43 +4570,43 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
-msgstr "XChat: Осветлена порака од: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
+msgstr "Осветлена порака од: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
-msgstr "XChat: %u осветлени пораки, најновата од: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
+msgstr "%u осветлени пораки, најновата од: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
-msgstr "XChat: Приватни пораки од: %s (%s)"
+msgid "Private message from: %s (%s) - "
+msgstr "Приватни пораки од: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
-msgstr "XChat: %u приватни пораки, најновата од: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
+msgstr "%u приватни пораки, најновата од: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
-msgstr "XChat: Понуда за датотека од: %s (%s)"
+msgid "File offer from: %s (%s) - "
+msgstr "Понуда за датотека од: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
-msgstr "XChat: %u понуди за датотеки, најновата од: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
+msgstr "%u понуди за датотеки, најновата од: %s (%s) - "
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4621,8 +4621,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Избери додаток или скрипта за вчитување"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr "XChat: Додатоци и скрипти"
+msgid "Plugins and Scripts - "
+msgstr "Додатоци и скрипти - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4643,7 +4643,7 @@ msgstr "Сними како..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4679,8 +4679,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr "XChat: Уреди %s"
+msgid "Edit %s - "
+msgstr "Уреди %s - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4771,8 +4771,8 @@ msgid "Character set:"
 msgstr "Множество на знаци:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr "XChat: Листа на мрежи"
+msgid "Network List - "
+msgstr "Листа на мрежи - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6136,8 +6136,8 @@ msgid ""
 msgstr "*ПРЕДУПРЕДУВАЊЕ*\nАвтоматско прифаќање на DCC во твојот домашен директориум\nможе да биде опасно. Пр:\nНекој може да ти испрати „.bash_profile“"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr "XChat: Преференци"
+msgid "Preferences - "
+msgstr "Преференци - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6201,8 +6201,8 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr "XChat: URL фаќач"
+msgid "URL Grabber - "
+msgstr "URL фаќач - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/mk.po
+++ b/po/mk.po
@@ -3238,8 +3238,8 @@ msgstr "Можете да го отворите прозорецот на лис
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "Бан листа (%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "Бан листа (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3277,8 +3277,8 @@ msgstr "Копирај го текстот од _насловот"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr "Листа на канали (%s) - "
+msgid "Channel List (%s) - %s"
+msgstr "Листа на канали (%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3369,8 +3369,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Не можам да ја примам истата датотека од двајца."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "Качувања и преземања - "
+msgid "Uploads and Downloads - %s"
+msgstr "Качувања и преземања - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3427,8 +3427,8 @@ msgid "Open Folder..."
 msgstr "Отвори папка..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "Листа на DCC Chat - "
+msgid "DCC Chat List - %s"
+msgstr "Листа на DCC Chat - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3624,8 +3624,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "Кратенки за тастатура - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "Кратенки за тастатура - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3669,8 +3669,8 @@ msgid "Enter mask to ignore:"
 msgstr "Внеси маска за игнорирање:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "Листа на игнорирани - "
+msgid "Ignore list - %s"
+msgstr "Листа на игнорирани - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3705,8 +3705,8 @@ msgid "Channel name too short, try again."
 msgstr "Името на каналот е прекратно, обидете се повторно."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "Врската заврши - "
+msgid "Connection Complete - %s"
+msgstr "Врската заврши - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4032,8 +4032,8 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "Корисничко мени - "
+msgid "User menu - %s"
+msgstr "Корисничко мени - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4153,36 +4153,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "Команди дефинирани од корисникот - "
+msgid "User Defined Commands - %s"
+msgstr "Команди дефинирани од корисникот - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "Скокачко мени на корисничката листа - "
+msgid "Userlist Popup menu - %s"
+msgstr "Скокачко мени на корисничката листа - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Замени со"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "Замени - "
+msgid "Replace - %s"
+msgstr "Замени - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "URL справувачи - "
+msgid "URL Handlers - %s"
+msgstr "URL справувачи - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "Копчиња за корисничката листа - "
+msgid "Userlist buttons - %s"
+msgstr "Копчиња за корисничката листа - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "Копчиња за дијалог - "
+msgid "Dialog buttons - %s"
+msgstr "Копчиња за дијалог - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "CTCP реплики - "
+msgid "CTCP Replies - %s"
+msgstr "CTCP реплики - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4489,7 +4489,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Се прифаќа листа на мрежи разделена со запирки."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
+msgid "Friends List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4528,8 +4528,8 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
-msgstr "Поврзан сум со %u мрежи и %u канали - "
+msgid "Connected to %u networks and %u channels - %s"
+msgstr "Поврзан сум со %u мрежи и %u канали - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4570,43 +4570,43 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
-msgstr "Осветлена порака од: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
+msgstr "Осветлена порака од: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
-msgstr "%u осветлени пораки, најновата од: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
+msgstr "%u осветлени пораки, најновата од: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
-msgstr "Приватни пораки од: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
+msgstr "Приватни пораки од: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
-msgstr "%u приватни пораки, најновата од: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
+msgstr "%u приватни пораки, најновата од: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
-msgstr "Понуда за датотека од: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
+msgstr "Понуда за датотека од: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
-msgstr "%u понуди за датотеки, најновата од: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
+msgstr "%u понуди за датотеки, најновата од: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4621,8 +4621,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Избери додаток или скрипта за вчитување"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "Додатоци и скрипти - "
+msgid "Plugins and Scripts - %s"
+msgstr "Додатоци и скрипти - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4643,7 +4643,7 @@ msgstr "Сними како..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4679,8 +4679,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "Уреди %s - "
+msgid "Edit %s - %s"
+msgstr "Уреди %s - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4771,8 +4771,8 @@ msgid "Character set:"
 msgstr "Множество на знаци:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "Листа на мрежи - "
+msgid "Network List - %s"
+msgstr "Листа на мрежи - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6136,8 +6136,8 @@ msgid ""
 msgstr "*ПРЕДУПРЕДУВАЊЕ*\nАвтоматско прифаќање на DCC во твојот домашен директориум\nможе да биде опасно. Пр:\nНекој може да ти испрати „.bash_profile“"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "Преференци - "
+msgid "Preferences - %s"
+msgstr "Преференци - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6201,8 +6201,8 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "URL фаќач - "
+msgid "URL Grabber - %s"
+msgstr "URL фаќач - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/ml.po
+++ b/po/ml.po
@@ -3156,7 +3156,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:813
 #, c-format
-msgid ": Ban List (%s)"
+msgid "Ban List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:848 ../src/fe-gtk/notifygui.c:425
@@ -3195,7 +3195,7 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
+msgid "Channel List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3287,7 +3287,7 @@ msgid "Cannot resume the same file from two people."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:798
-msgid ": Uploads and Downloads"
+msgid "Uploads and Downloads - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:815 ../src/fe-gtk/dccgui.c:1056
@@ -3345,7 +3345,7 @@ msgid "Open Folder..."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1045
-msgid ": DCC Chat List"
+msgid "DCC Chat List - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1058
@@ -3541,7 +3541,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:809
-msgid ": Keyboard Shortcuts"
+msgid "Keyboard Shortcuts - "
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:108
@@ -3586,7 +3586,7 @@ msgid "Enter mask to ignore:"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
+msgid "Ignore list - "
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3622,7 +3622,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
+msgid "Connection Complete - "
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -3962,7 +3962,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
+msgid "User menu - "
 msgstr ""
 
 #. sep
@@ -4083,11 +4083,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
+msgid "User Defined Commands - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
+msgid "Userlist Popup menu - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4095,23 +4095,23 @@ msgid "Replace with"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
+msgid "Replace - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
+msgid "URL Handlers - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
+msgid "Userlist buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
+msgid "Dialog buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
+msgid "CTCP Replies - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1743
@@ -4419,7 +4419,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:407
-msgid ": Friends List"
+msgid "Friends List - "
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:429
@@ -4428,7 +4428,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:264
 #, c-format
-msgid ": Connected to %u networks and %u channels"
+msgid "Connected to %u networks and %u channels - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:628
@@ -4470,12 +4470,12 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:714
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:717
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
@@ -4485,12 +4485,12 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:740
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:743
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:747
@@ -4500,12 +4500,12 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:771
 #, c-format
-msgid ": Private message from: %s (%s)"
+msgid "Private message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:774
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:779
@@ -4515,12 +4515,12 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:818
 #, c-format
-msgid ": File offer from: %s (%s)"
+msgid "File offer from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:821
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:826
@@ -4541,7 +4541,7 @@ msgid "Select a Plugin or Script to load"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:252
-msgid ": Plugins and Scripts"
+msgid "Plugins and Scripts - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:267
@@ -4563,7 +4563,7 @@ msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4595,7 +4595,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1704
 #, c-format
-msgid ": Edit %s"
+msgid "Edit %s - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1725
@@ -4687,7 +4687,7 @@ msgid "Character set:"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1970
-msgid ": Network List"
+msgid "Network List - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1981
@@ -6024,7 +6024,7 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/setup.c:2198
-msgid ": Preferences"
+msgid "Preferences - "
 msgstr ""
 
 #: ../src/fe-gtk/sexy-spell-entry.c:545
@@ -6089,7 +6089,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
+msgid "URL Grabber - "
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/ml.po
+++ b/po/ml.po
@@ -3156,7 +3156,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:813
 #, c-format
-msgid "Ban List (%s) - "
+msgid "Ban List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:848 ../src/fe-gtk/notifygui.c:425
@@ -3195,7 +3195,7 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
+msgid "Channel List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3287,7 +3287,7 @@ msgid "Cannot resume the same file from two people."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:798
-msgid "Uploads and Downloads - "
+msgid "Uploads and Downloads - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:815 ../src/fe-gtk/dccgui.c:1056
@@ -3345,7 +3345,7 @@ msgid "Open Folder..."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1045
-msgid "DCC Chat List - "
+msgid "DCC Chat List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1058
@@ -3541,7 +3541,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:809
-msgid "Keyboard Shortcuts - "
+msgid "Keyboard Shortcuts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:108
@@ -3586,7 +3586,7 @@ msgid "Enter mask to ignore:"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
+msgid "Ignore list - %s"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3622,7 +3622,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
+msgid "Connection Complete - %s"
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -3962,7 +3962,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
+msgid "User menu - %s"
 msgstr ""
 
 #. sep
@@ -4083,11 +4083,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
+msgid "User Defined Commands - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
+msgid "Userlist Popup menu - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4095,23 +4095,23 @@ msgid "Replace with"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
+msgid "Replace - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
+msgid "URL Handlers - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
+msgid "Userlist buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
+msgid "Dialog buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
+msgid "CTCP Replies - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1743
@@ -4419,7 +4419,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:407
-msgid "Friends List - "
+msgid "Friends List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:429
@@ -4428,7 +4428,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:264
 #, c-format
-msgid "Connected to %u networks and %u channels - "
+msgid "Connected to %u networks and %u channels - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:628
@@ -4470,12 +4470,12 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:714
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:717
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
@@ -4485,12 +4485,12 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:740
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:743
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:747
@@ -4500,12 +4500,12 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:771
 #, c-format
-msgid "Private message from: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:774
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:779
@@ -4515,12 +4515,12 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:818
 #, c-format
-msgid "File offer from: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:821
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:826
@@ -4541,7 +4541,7 @@ msgid "Select a Plugin or Script to load"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:252
-msgid "Plugins and Scripts - "
+msgid "Plugins and Scripts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:267
@@ -4563,7 +4563,7 @@ msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4595,7 +4595,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1704
 #, c-format
-msgid "Edit %s - "
+msgid "Edit %s - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1725
@@ -4687,7 +4687,7 @@ msgid "Character set:"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1970
-msgid "Network List - "
+msgid "Network List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1981
@@ -6024,7 +6024,7 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/setup.c:2198
-msgid "Preferences - "
+msgid "Preferences - %s"
 msgstr ""
 
 #: ../src/fe-gtk/sexy-spell-entry.c:545
@@ -6089,7 +6089,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
+msgid "URL Grabber - %s"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/ms.po
+++ b/po/ms.po
@@ -3238,7 +3238,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
+msgid "Ban List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3277,7 +3277,7 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
+msgid "Channel List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3369,7 +3369,7 @@ msgid "Cannot resume the same file from two people."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
+msgid "Uploads and Downloads - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3427,7 +3427,7 @@ msgid "Open Folder..."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
+msgid "DCC Chat List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3624,7 +3624,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
+msgid "Keyboard Shortcuts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3669,7 +3669,7 @@ msgid "Enter mask to ignore:"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
+msgid "Ignore list - %s"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3705,7 +3705,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
+msgid "Connection Complete - %s"
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4032,7 +4032,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
+msgid "User menu - %s"
 msgstr ""
 
 #. sep
@@ -4153,11 +4153,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
+msgid "User Defined Commands - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
+msgid "Userlist Popup menu - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4165,23 +4165,23 @@ msgid "Replace with"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
+msgid "Replace - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
+msgid "URL Handlers - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
+msgid "Userlist buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
+msgid "Dialog buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
+msgid "CTCP Replies - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4489,7 +4489,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
+msgid "Friends List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4528,7 +4528,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
+msgid "Connected to %u networks and %u channels - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4570,42 +4570,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4621,7 +4621,7 @@ msgid "Select a Plugin or Script to load"
 msgstr "Pilih Plugin atau skrip  untuk dimuatkan"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
+msgid "Plugins and Scripts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4643,7 +4643,7 @@ msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4679,7 +4679,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
+msgid "Edit %s - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4771,7 +4771,7 @@ msgid "Character set:"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
+msgid "Network List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6136,7 +6136,7 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
+msgid "Preferences - %s"
 msgstr ""
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6201,7 +6201,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
+msgid "URL Grabber - %s"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/ms.po
+++ b/po/ms.po
@@ -3238,7 +3238,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
+msgid "Ban List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3277,7 +3277,7 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
+msgid "Channel List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3369,7 +3369,7 @@ msgid "Cannot resume the same file from two people."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
+msgid "Uploads and Downloads - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3427,7 +3427,7 @@ msgid "Open Folder..."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
+msgid "DCC Chat List - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3624,7 +3624,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
+msgid "Keyboard Shortcuts - "
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3669,7 +3669,7 @@ msgid "Enter mask to ignore:"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
+msgid "Ignore list - "
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3705,7 +3705,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
+msgid "Connection Complete - "
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4032,7 +4032,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
+msgid "User menu - "
 msgstr ""
 
 #. sep
@@ -4153,11 +4153,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
+msgid "User Defined Commands - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
+msgid "Userlist Popup menu - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4165,23 +4165,23 @@ msgid "Replace with"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
+msgid "Replace - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
+msgid "URL Handlers - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
+msgid "Userlist buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
+msgid "Dialog buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
+msgid "CTCP Replies - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4489,7 +4489,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
+msgid "Friends List - "
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4528,7 +4528,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
+msgid "Connected to %u networks and %u channels - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4570,42 +4570,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
+msgid "Private message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
+msgid "File offer from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4621,7 +4621,7 @@ msgid "Select a Plugin or Script to load"
 msgstr "Pilih Plugin atau skrip  untuk dimuatkan"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
+msgid "Plugins and Scripts - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4643,7 +4643,7 @@ msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4679,7 +4679,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
+msgid "Edit %s - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4771,7 +4771,7 @@ msgid "Character set:"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
+msgid "Network List - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6136,7 +6136,7 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
+msgid "Preferences - "
 msgstr ""
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6201,7 +6201,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
+msgid "URL Grabber - "
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/nb.po
+++ b/po/nb.po
@@ -3246,8 +3246,8 @@ msgstr "Listen for utestengelser kan kun åpnes opp mens du er i en kanal."
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr ": Utestengelsesliste (%s)"
+msgid "Ban List (%s) - "
+msgstr "Utestengelsesliste (%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3285,8 +3285,8 @@ msgstr "Kopier emne_tekst"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr "XChat: Kanalliste (%s)"
+msgid "Channel List (%s) - "
+msgstr "Kanalliste (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3377,8 +3377,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Kan ikke gjenoppta samme fil fra to personer."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr ": Opplastninger og nedlastninger"
+msgid "Uploads and Downloads - "
+msgstr "Opplastninger og nedlastninger - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3435,8 +3435,8 @@ msgid "Open Folder..."
 msgstr "Åpne mappe..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr "XChat: Liste med DCC-prat"
+msgid "DCC Chat List - "
+msgstr "Liste med DCC-prat - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3632,8 +3632,8 @@ msgid "Select a row to get help information on its Action."
 msgstr "Velg en rad for å få hjelpeinformasjon om dens handling."
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr "XChat: tastatursnarveier"
+msgid "Keyboard Shortcuts - "
+msgstr "tastatursnarveier - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3677,8 +3677,8 @@ msgid "Enter mask to ignore:"
 msgstr "Skriv ignoreringsmaske:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr ": Ignoreringsliste"
+msgid "Ignore list - "
+msgstr "Ignoreringsliste - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3713,8 +3713,8 @@ msgid "Channel name too short, try again."
 msgstr "Kanalnavn for kort, prøv igjen."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr ": Tilkobling fullført"
+msgid "Connection Complete - "
+msgstr "Tilkobling fullført - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4040,8 +4040,8 @@ msgid "_Auto-Connect"
 msgstr "_Automatisk koble til"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr "XChat: Brukermeny"
+msgid "User menu - "
+msgstr "Brukermeny - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4161,36 +4161,36 @@ msgid ""
 msgstr "URL-behandlere - spesialkoder:\n\n%s  =  URL-strengen\n\nPlassering av ! foran kommandoen\nindikerer at den skal sendes til et\nshell i steden for HexChat"
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr "XChat: Brukerdefinerte kommandoer"
+msgid "User Defined Commands - "
+msgstr "Brukerdefinerte kommandoer - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr ": Popup-meny i brukerliste"
+msgid "Userlist Popup menu - "
+msgstr "Popup-meny i brukerliste - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Erstatt med"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr "XChat: Erstatt"
+msgid "Replace - "
+msgstr "Erstatt - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr "XChat: URL-håndterere"
+msgid "URL Handlers - "
+msgstr "URL-håndterere - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr "XChat: Brukerlisteknapper"
+msgid "Userlist buttons - "
+msgstr "Brukerlisteknapper - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr "XChat: Dialogknapper"
+msgid "Dialog buttons - "
+msgstr "Dialogknapper - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr "XChat: CTCP-svar"
+msgid "CTCP Replies - "
+msgstr "CTCP-svar - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4497,8 +4497,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Komma-separert liste av nettverk aksepteres."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
-msgstr ": Venneliste"
+msgid "Friends List - "
+msgstr "Venneliste - "
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4536,8 +4536,8 @@ msgstr "Privat melding fra: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
-msgstr ": Tilkoblet %u nettverk og %u kanaler"
+msgid "Connected to %u networks and %u channels - "
+msgstr "Tilkoblet %u nettverk og %u kanaler - "
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4578,43 +4578,43 @@ msgstr "_Tilbake"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
-msgstr ": Framhevet melding fra: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
+msgstr "Framhevet melding fra: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
-msgstr ": %u framhevede meldinger, nylig fra: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
+msgstr "%u framhevede meldinger, nylig fra: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
-msgstr ": Kanalmelding fra: %s (%s)"
+msgid "Channel message from: %s (%s) - "
+msgstr "Kanalmelding fra: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
-msgstr ": %u kanalmeldinger."
+msgid "%u channel messages. - "
+msgstr "%u kanalmeldinger. - "
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
-msgstr ": Privat melding fra: %s (%s)"
+msgid "Private message from: %s (%s) - "
+msgstr "Privat melding fra: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
-msgstr ": %u private meldinger, nylig fra: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
+msgstr "%u private meldinger, nylig fra: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
-msgstr ": Filtilbud fra: %s (%s)"
+msgid "File offer from: %s (%s) - "
+msgstr "Filtilbud fra: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
-msgstr ": %u filtilbud, nylig fra: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
+msgstr "%u filtilbud, nylig fra: %s (%s) - "
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4629,8 +4629,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Last et tillegg eller skript"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr "XChat: tillegg og skript"
+msgid "Plugins and Scripts - "
+msgstr "tillegg og skript - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4651,8 +4651,8 @@ msgstr "Lagre som..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
-msgstr ": Rå-logg (%s)"
+msgid "Raw Log (%s) - "
+msgstr "Rå-logg (%s) - "
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4687,8 +4687,8 @@ msgstr "Fremgangsmåte for identifikasjon mot tjener. For egendefinerte innloggi
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr "XChat: Rediger %s"
+msgid "Edit %s - "
+msgstr "Rediger %s - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4779,8 +4779,8 @@ msgid "Character set:"
 msgstr "Tegnsett:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr "XChat: nettverksliste"
+msgid "Network List - "
+msgstr "nettverksliste - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6144,8 +6144,8 @@ msgid ""
 msgstr "*ADVARSEL*\nAuto akseptere DCC til hjemmekatalogen\nkan være farlig og kan utnyttes. Eks:\nNoen kunne sende deg en .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr "XChat: Brukervalg"
+msgid "Preferences - "
+msgstr "Brukervalg - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6209,8 +6209,8 @@ msgid "OK"
 msgstr "OK"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr "XChat: URL-henter"
+msgid "URL Grabber - "
+msgstr "URL-henter - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/nb.po
+++ b/po/nb.po
@@ -3246,8 +3246,8 @@ msgstr "Listen for utestengelser kan kun åpnes opp mens du er i en kanal."
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "Utestengelsesliste (%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "Utestengelsesliste (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3285,8 +3285,8 @@ msgstr "Kopier emne_tekst"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr "Kanalliste (%s) - "
+msgid "Channel List (%s) - %s"
+msgstr "Kanalliste (%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3377,8 +3377,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Kan ikke gjenoppta samme fil fra to personer."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "Opplastninger og nedlastninger - "
+msgid "Uploads and Downloads - %s"
+msgstr "Opplastninger og nedlastninger - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3435,8 +3435,8 @@ msgid "Open Folder..."
 msgstr "Åpne mappe..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "Liste med DCC-prat - "
+msgid "DCC Chat List - %s"
+msgstr "Liste med DCC-prat - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3632,8 +3632,8 @@ msgid "Select a row to get help information on its Action."
 msgstr "Velg en rad for å få hjelpeinformasjon om dens handling."
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "tastatursnarveier - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "tastatursnarveier - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3677,8 +3677,8 @@ msgid "Enter mask to ignore:"
 msgstr "Skriv ignoreringsmaske:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "Ignoreringsliste - "
+msgid "Ignore list - %s"
+msgstr "Ignoreringsliste - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3713,8 +3713,8 @@ msgid "Channel name too short, try again."
 msgstr "Kanalnavn for kort, prøv igjen."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "Tilkobling fullført - "
+msgid "Connection Complete - %s"
+msgstr "Tilkobling fullført - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4040,8 +4040,8 @@ msgid "_Auto-Connect"
 msgstr "_Automatisk koble til"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "Brukermeny - "
+msgid "User menu - %s"
+msgstr "Brukermeny - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4161,36 +4161,36 @@ msgid ""
 msgstr "URL-behandlere - spesialkoder:\n\n%s  =  URL-strengen\n\nPlassering av ! foran kommandoen\nindikerer at den skal sendes til et\nshell i steden for HexChat"
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "Brukerdefinerte kommandoer - "
+msgid "User Defined Commands - %s"
+msgstr "Brukerdefinerte kommandoer - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "Popup-meny i brukerliste - "
+msgid "Userlist Popup menu - %s"
+msgstr "Popup-meny i brukerliste - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Erstatt med"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "Erstatt - "
+msgid "Replace - %s"
+msgstr "Erstatt - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "URL-håndterere - "
+msgid "URL Handlers - %s"
+msgstr "URL-håndterere - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "Brukerlisteknapper - "
+msgid "Userlist buttons - %s"
+msgstr "Brukerlisteknapper - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "Dialogknapper - "
+msgid "Dialog buttons - %s"
+msgstr "Dialogknapper - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "CTCP-svar - "
+msgid "CTCP Replies - %s"
+msgstr "CTCP-svar - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4497,8 +4497,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Komma-separert liste av nettverk aksepteres."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
-msgstr "Venneliste - "
+msgid "Friends List - %s"
+msgstr "Venneliste - %s"
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4536,8 +4536,8 @@ msgstr "Privat melding fra: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
-msgstr "Tilkoblet %u nettverk og %u kanaler - "
+msgid "Connected to %u networks and %u channels - %s"
+msgstr "Tilkoblet %u nettverk og %u kanaler - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4578,43 +4578,43 @@ msgstr "_Tilbake"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
-msgstr "Framhevet melding fra: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
+msgstr "Framhevet melding fra: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
-msgstr "%u framhevede meldinger, nylig fra: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
+msgstr "%u framhevede meldinger, nylig fra: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
-msgstr "Kanalmelding fra: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
+msgstr "Kanalmelding fra: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
-msgstr "%u kanalmeldinger. - "
+msgid "%u channel messages. - %s"
+msgstr "%u kanalmeldinger. - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
-msgstr "Privat melding fra: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
+msgstr "Privat melding fra: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
-msgstr "%u private meldinger, nylig fra: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
+msgstr "%u private meldinger, nylig fra: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
-msgstr "Filtilbud fra: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
+msgstr "Filtilbud fra: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
-msgstr "%u filtilbud, nylig fra: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
+msgstr "%u filtilbud, nylig fra: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4629,8 +4629,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Last et tillegg eller skript"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "tillegg og skript - "
+msgid "Plugins and Scripts - %s"
+msgstr "tillegg og skript - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4651,8 +4651,8 @@ msgstr "Lagre som..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
-msgstr "Rå-logg (%s) - "
+msgid "Raw Log (%s) - %s"
+msgstr "Rå-logg (%s) - %s"
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4687,8 +4687,8 @@ msgstr "Fremgangsmåte for identifikasjon mot tjener. For egendefinerte innloggi
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "Rediger %s - "
+msgid "Edit %s - %s"
+msgstr "Rediger %s - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4779,8 +4779,8 @@ msgid "Character set:"
 msgstr "Tegnsett:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "nettverksliste - "
+msgid "Network List - %s"
+msgstr "nettverksliste - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6144,8 +6144,8 @@ msgid ""
 msgstr "*ADVARSEL*\nAuto akseptere DCC til hjemmekatalogen\nkan være farlig og kan utnyttes. Eks:\nNoen kunne sende deg en .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "Brukervalg - "
+msgid "Preferences - %s"
+msgstr "Brukervalg - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6209,8 +6209,8 @@ msgid "OK"
 msgstr "OK"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "URL-henter - "
+msgid "URL Grabber - %s"
+msgstr "URL-henter - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/nl.po
+++ b/po/nl.po
@@ -3242,8 +3242,8 @@ msgstr "U kunt het Ban List venster enkel openen wanneer u zich in een kanaaltab
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "verbanlijst (%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "verbanlijst (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3281,8 +3281,8 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr "Kanaallijst (%s) - "
+msgid "Channel List (%s) - %s"
+msgstr "Kanaallijst (%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3373,7 +3373,7 @@ msgid "Cannot resume the same file from two people."
 msgstr "Kan hetzelfde bestand van twee personen niet pauzeren."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
+msgid "Uploads and Downloads - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3431,8 +3431,8 @@ msgid "Open Folder..."
 msgstr "Open Map..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "DCC Chat lijst - "
+msgid "DCC Chat List - %s"
+msgstr "DCC Chat lijst - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3628,8 +3628,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "Sneltoetsen - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "Sneltoetsen - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3673,8 +3673,8 @@ msgid "Enter mask to ignore:"
 msgstr "Geef het te negeren masker:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "Negeerlijst - "
+msgid "Ignore list - %s"
+msgstr "Negeerlijst - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3709,8 +3709,8 @@ msgid "Channel name too short, try again."
 msgstr "Naam van kanaal is te kort, probeer opnieuw."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "verbinding vervolledigd - "
+msgid "Connection Complete - %s"
+msgstr "verbinding vervolledigd - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4036,8 +4036,8 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "Gebruikersmenu - "
+msgid "User menu - %s"
+msgstr "Gebruikersmenu - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4157,11 +4157,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "Door gebruiker gedefinieerde opdrachten - "
+msgid "User Defined Commands - %s"
+msgstr "Door gebruiker gedefinieerde opdrachten - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
+msgid "Userlist Popup menu - %s"
 msgstr "XChat Gebruikerslijst Popup menu"
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4169,24 +4169,24 @@ msgid "Replace with"
 msgstr "Vervang met"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "Vervangen - "
+msgid "Replace - %s"
+msgstr "Vervangen - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "URL Programma's - "
+msgid "URL Handlers - %s"
+msgstr "URL Programma's - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "Gebruikerslijst Knoppen - "
+msgid "Userlist buttons - %s"
+msgstr "Gebruikerslijst Knoppen - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "Dialoogknoppen - "
+msgid "Dialog buttons - %s"
+msgstr "Dialoogknoppen - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "CTCP Antwoorden - "
+msgid "CTCP Replies - %s"
+msgstr "CTCP Antwoorden - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4493,8 +4493,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
-msgstr "Vrienden Lijst - "
+msgid "Friends List - %s"
+msgstr "Vrienden Lijst - %s"
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4532,7 +4532,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
+msgid "Connected to %u networks and %u channels - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4574,42 +4574,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4625,8 +4625,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Kies een Plugin of Script om te laden"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "Plugins en scripts - "
+msgid "Plugins and Scripts - %s"
+msgstr "Plugins en scripts - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4647,7 +4647,7 @@ msgstr "Opslaan Als..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4683,8 +4683,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "%s bewerken - "
+msgid "Edit %s - %s"
+msgstr "%s bewerken - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4775,8 +4775,8 @@ msgid "Character set:"
 msgstr "Tekenset:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "Netwerklijst - "
+msgid "Network List - %s"
+msgstr "Netwerklijst - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6140,8 +6140,8 @@ msgid ""
 msgstr "*WAARSCHUWING*\nAuto accepteren van DCC naar uw persoonlijke\nmap is gevaarlijk en er kan misbruik van worden\ngemaakt.\nIemand kan u bijvoorbeeld een .bash_profile\nbestand opsturen."
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "Voorkeuren - "
+msgid "Preferences - %s"
+msgstr "Voorkeuren - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6205,8 +6205,8 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "URL Grijper - "
+msgid "URL Grabber - %s"
+msgstr "URL Grijper - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/nl.po
+++ b/po/nl.po
@@ -3242,8 +3242,8 @@ msgstr "U kunt het Ban List venster enkel openen wanneer u zich in een kanaaltab
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr "XChat: verbanlijst (%s)"
+msgid "Ban List (%s) - "
+msgstr "verbanlijst (%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3281,8 +3281,8 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr "XChat: Kanaallijst (%s)"
+msgid "Channel List (%s) - "
+msgstr "Kanaallijst (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3373,7 +3373,7 @@ msgid "Cannot resume the same file from two people."
 msgstr "Kan hetzelfde bestand van twee personen niet pauzeren."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
+msgid "Uploads and Downloads - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3431,8 +3431,8 @@ msgid "Open Folder..."
 msgstr "Open Map..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr "XChat: DCC Chat lijst"
+msgid "DCC Chat List - "
+msgstr "DCC Chat lijst - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3628,8 +3628,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr "XChat: Sneltoetsen"
+msgid "Keyboard Shortcuts - "
+msgstr "Sneltoetsen - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3673,8 +3673,8 @@ msgid "Enter mask to ignore:"
 msgstr "Geef het te negeren masker:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr "XChat: Negeerlijst"
+msgid "Ignore list - "
+msgstr "Negeerlijst - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3709,8 +3709,8 @@ msgid "Channel name too short, try again."
 msgstr "Naam van kanaal is te kort, probeer opnieuw."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr "XChat: verbinding vervolledigd"
+msgid "Connection Complete - "
+msgstr "verbinding vervolledigd - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4036,8 +4036,8 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr "XChat: Gebruikersmenu"
+msgid "User menu - "
+msgstr "Gebruikersmenu - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4157,11 +4157,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr "XChat: Door gebruiker gedefinieerde opdrachten"
+msgid "User Defined Commands - "
+msgstr "Door gebruiker gedefinieerde opdrachten - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
+msgid "Userlist Popup menu - "
 msgstr "XChat Gebruikerslijst Popup menu"
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4169,24 +4169,24 @@ msgid "Replace with"
 msgstr "Vervang met"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr "XChat: Vervangen"
+msgid "Replace - "
+msgstr "Vervangen - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr "XChat: URL Programma's"
+msgid "URL Handlers - "
+msgstr "URL Programma's - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr "XChat: Gebruikerslijst Knoppen"
+msgid "Userlist buttons - "
+msgstr "Gebruikerslijst Knoppen - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr "XChat: Dialoogknoppen"
+msgid "Dialog buttons - "
+msgstr "Dialoogknoppen - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr "XChat: CTCP Antwoorden"
+msgid "CTCP Replies - "
+msgstr "CTCP Antwoorden - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4493,8 +4493,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
-msgstr ": Vrienden Lijst"
+msgid "Friends List - "
+msgstr "Vrienden Lijst - "
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4532,7 +4532,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
+msgid "Connected to %u networks and %u channels - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4574,42 +4574,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
+msgid "Private message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
+msgid "File offer from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4625,8 +4625,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Kies een Plugin of Script om te laden"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr "XChat: Plugins en scripts"
+msgid "Plugins and Scripts - "
+msgstr "Plugins en scripts - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4647,7 +4647,7 @@ msgstr "Opslaan Als..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4683,8 +4683,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr "XChat: %s bewerken"
+msgid "Edit %s - "
+msgstr "%s bewerken - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4775,8 +4775,8 @@ msgid "Character set:"
 msgstr "Tekenset:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr "XChat: Netwerklijst"
+msgid "Network List - "
+msgstr "Netwerklijst - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6140,8 +6140,8 @@ msgid ""
 msgstr "*WAARSCHUWING*\nAuto accepteren van DCC naar uw persoonlijke\nmap is gevaarlijk en er kan misbruik van worden\ngemaakt.\nIemand kan u bijvoorbeeld een .bash_profile\nbestand opsturen."
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr "XChat: Voorkeuren"
+msgid "Preferences - "
+msgstr "Voorkeuren - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6205,8 +6205,8 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr "XChat: URL Grijper"
+msgid "URL Grabber - "
+msgstr "URL Grijper - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/no.po
+++ b/po/no.po
@@ -3060,7 +3060,7 @@ msgstr ""
 
 #: src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
+msgid "Ban List (%s) - "
 msgstr ""
 
 #: src/fe-gtk/banlist.c:843 src/fe-gtk/notifygui.c:425
@@ -3098,7 +3098,7 @@ msgstr ""
 
 #: src/fe-gtk/chanlist.c:717
 #, c-format
-msgid ": Channel List (%s)"
+msgid "Channel List (%s) - "
 msgstr ""
 
 #: src/fe-gtk/chanlist.c:791
@@ -3185,7 +3185,7 @@ msgid "Cannot resume the same file from two people."
 msgstr ""
 
 #: src/fe-gtk/dccgui.c:800
-msgid ": Uploads and Downloads"
+msgid "Uploads and Downloads - "
 msgstr ""
 
 #: src/fe-gtk/dccgui.c:817 src/fe-gtk/dccgui.c:1058 src/fe-gtk/notifygui.c:124
@@ -3241,7 +3241,7 @@ msgid "Open Folder..."
 msgstr ""
 
 #: src/fe-gtk/dccgui.c:1047
-msgid ": DCC Chat List"
+msgid "DCC Chat List - "
 msgstr ""
 
 #: src/fe-gtk/dccgui.c:1060
@@ -3484,7 +3484,7 @@ msgid "Action"
 msgstr ""
 
 #: src/fe-gtk/fkeys.c:707
-msgid ": Keyboard Shortcuts"
+msgid "Keyboard Shortcuts - "
 msgstr ""
 
 #: src/fe-gtk/fkeys.c:785
@@ -3582,7 +3582,7 @@ msgid "Enter mask to ignore:"
 msgstr ""
 
 #: src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
+msgid "Ignore list - "
 msgstr ""
 
 #: src/fe-gtk/ignoregui.c:358
@@ -3618,7 +3618,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
+msgid "Connection Complete - "
 msgstr ""
 
 #: src/fe-gtk/joind.c:158
@@ -3916,7 +3916,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: src/fe-gtk/menu.c:1112
-msgid ": User menu"
+msgid "User menu - "
 msgstr ""
 
 #: src/fe-gtk/menu.c:1121
@@ -4010,11 +4010,11 @@ msgid ""
 msgstr ""
 
 #: src/fe-gtk/menu.c:1486
-msgid ": User Defined Commands"
+msgid "User Defined Commands - "
 msgstr ""
 
 #: src/fe-gtk/menu.c:1493
-msgid ": Userlist Popup menu"
+msgid "Userlist Popup menu - "
 msgstr ""
 
 #: src/fe-gtk/menu.c:1500
@@ -4022,23 +4022,23 @@ msgid "Replace with"
 msgstr ""
 
 #: src/fe-gtk/menu.c:1500
-msgid ": Replace"
+msgid "Replace - "
 msgstr ""
 
 #: src/fe-gtk/menu.c:1507
-msgid ": URL Handlers"
+msgid "URL Handlers - "
 msgstr ""
 
 #: src/fe-gtk/menu.c:1526
-msgid ": Userlist buttons"
+msgid "Userlist buttons - "
 msgstr ""
 
 #: src/fe-gtk/menu.c:1533
-msgid ": Dialog buttons"
+msgid "Dialog buttons - "
 msgstr ""
 
 #: src/fe-gtk/menu.c:1540
-msgid ": CTCP Replies"
+msgid "CTCP Replies - "
 msgstr ""
 
 #: src/fe-gtk/menu.c:1702
@@ -4337,7 +4337,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: src/fe-gtk/notifygui.c:407
-msgid ": Friends List"
+msgid "Friends List - "
 msgstr ""
 
 #: src/fe-gtk/notifygui.c:429
@@ -4346,7 +4346,7 @@ msgstr ""
 
 #: src/fe-gtk/plugin-tray.c:264
 #, c-format
-msgid ": Connected to %u networks and %u channels"
+msgid "Connected to %u networks and %u channels - "
 msgstr ""
 
 #: src/fe-gtk/plugin-tray.c:624
@@ -4387,12 +4387,12 @@ msgstr ""
 
 #: src/fe-gtk/plugin-tray.c:710
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
 msgstr ""
 
 #: src/fe-gtk/plugin-tray.c:713
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
 msgstr ""
 
 #: src/fe-gtk/plugin-tray.c:718
@@ -4402,12 +4402,12 @@ msgstr ""
 
 #: src/fe-gtk/plugin-tray.c:736
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: src/fe-gtk/plugin-tray.c:739
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: src/fe-gtk/plugin-tray.c:743
@@ -4417,12 +4417,12 @@ msgstr ""
 
 #: src/fe-gtk/plugin-tray.c:765
 #, c-format
-msgid ": Private message from: %s (%s)"
+msgid "Private message from: %s (%s) - "
 msgstr ""
 
 #: src/fe-gtk/plugin-tray.c:768
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
 msgstr ""
 
 #: src/fe-gtk/plugin-tray.c:772
@@ -4432,12 +4432,12 @@ msgstr ""
 
 #: src/fe-gtk/plugin-tray.c:818
 #, c-format
-msgid ": File offer from: %s (%s)"
+msgid "File offer from: %s (%s) - "
 msgstr ""
 
 #: src/fe-gtk/plugin-tray.c:821
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
 msgstr ""
 
 #: src/fe-gtk/plugin-tray.c:826
@@ -4458,7 +4458,7 @@ msgid "Select a Plugin or Script to load"
 msgstr ""
 
 #: src/fe-gtk/plugingui.c:252
-msgid ": Plugins and Scripts"
+msgid "Plugins and Scripts - "
 msgstr ""
 
 #: src/fe-gtk/plugingui.c:267
@@ -4480,7 +4480,7 @@ msgstr ""
 
 #: src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: src/fe-gtk/rawlog.c:143
@@ -4570,7 +4570,7 @@ msgstr ""
 
 #: src/fe-gtk/servlistgui.c:1650
 #, c-format
-msgid ": Edit %s"
+msgid "Edit %s - "
 msgstr ""
 
 #: src/fe-gtk/servlistgui.c:1672
@@ -4662,7 +4662,7 @@ msgid "Character set:"
 msgstr ""
 
 #: src/fe-gtk/servlistgui.c:1918
-msgid ": Network List"
+msgid "Network List - "
 msgstr ""
 
 #: src/fe-gtk/servlistgui.c:1930
@@ -6005,7 +6005,7 @@ msgid ""
 msgstr ""
 
 #: src/fe-gtk/setup.c:2271
-msgid ": Preferences"
+msgid "Preferences - "
 msgstr ""
 
 #: src/fe-gtk/sexy-spell-entry.c:463
@@ -6064,7 +6064,7 @@ msgid "Test All"
 msgstr "Test alle"
 
 #: src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
+msgid "URL Grabber - "
 msgstr ""
 
 #: src/fe-gtk/urlgrab.c:212

--- a/po/no.po
+++ b/po/no.po
@@ -3060,7 +3060,7 @@ msgstr ""
 
 #: src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
+msgid "Ban List (%s) - %s"
 msgstr ""
 
 #: src/fe-gtk/banlist.c:843 src/fe-gtk/notifygui.c:425
@@ -3098,7 +3098,7 @@ msgstr ""
 
 #: src/fe-gtk/chanlist.c:717
 #, c-format
-msgid "Channel List (%s) - "
+msgid "Channel List (%s) - %s"
 msgstr ""
 
 #: src/fe-gtk/chanlist.c:791
@@ -3185,7 +3185,7 @@ msgid "Cannot resume the same file from two people."
 msgstr ""
 
 #: src/fe-gtk/dccgui.c:800
-msgid "Uploads and Downloads - "
+msgid "Uploads and Downloads - %s"
 msgstr ""
 
 #: src/fe-gtk/dccgui.c:817 src/fe-gtk/dccgui.c:1058 src/fe-gtk/notifygui.c:124
@@ -3241,7 +3241,7 @@ msgid "Open Folder..."
 msgstr ""
 
 #: src/fe-gtk/dccgui.c:1047
-msgid "DCC Chat List - "
+msgid "DCC Chat List - %s"
 msgstr ""
 
 #: src/fe-gtk/dccgui.c:1060
@@ -3484,7 +3484,7 @@ msgid "Action"
 msgstr ""
 
 #: src/fe-gtk/fkeys.c:707
-msgid "Keyboard Shortcuts - "
+msgid "Keyboard Shortcuts - %s"
 msgstr ""
 
 #: src/fe-gtk/fkeys.c:785
@@ -3582,7 +3582,7 @@ msgid "Enter mask to ignore:"
 msgstr ""
 
 #: src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
+msgid "Ignore list - %s"
 msgstr ""
 
 #: src/fe-gtk/ignoregui.c:358
@@ -3618,7 +3618,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
+msgid "Connection Complete - %s"
 msgstr ""
 
 #: src/fe-gtk/joind.c:158
@@ -3916,7 +3916,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: src/fe-gtk/menu.c:1112
-msgid "User menu - "
+msgid "User menu - %s"
 msgstr ""
 
 #: src/fe-gtk/menu.c:1121
@@ -4010,11 +4010,11 @@ msgid ""
 msgstr ""
 
 #: src/fe-gtk/menu.c:1486
-msgid "User Defined Commands - "
+msgid "User Defined Commands - %s"
 msgstr ""
 
 #: src/fe-gtk/menu.c:1493
-msgid "Userlist Popup menu - "
+msgid "Userlist Popup menu - %s"
 msgstr ""
 
 #: src/fe-gtk/menu.c:1500
@@ -4022,23 +4022,23 @@ msgid "Replace with"
 msgstr ""
 
 #: src/fe-gtk/menu.c:1500
-msgid "Replace - "
+msgid "Replace - %s"
 msgstr ""
 
 #: src/fe-gtk/menu.c:1507
-msgid "URL Handlers - "
+msgid "URL Handlers - %s"
 msgstr ""
 
 #: src/fe-gtk/menu.c:1526
-msgid "Userlist buttons - "
+msgid "Userlist buttons - %s"
 msgstr ""
 
 #: src/fe-gtk/menu.c:1533
-msgid "Dialog buttons - "
+msgid "Dialog buttons - %s"
 msgstr ""
 
 #: src/fe-gtk/menu.c:1540
-msgid "CTCP Replies - "
+msgid "CTCP Replies - %s"
 msgstr ""
 
 #: src/fe-gtk/menu.c:1702
@@ -4337,7 +4337,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: src/fe-gtk/notifygui.c:407
-msgid "Friends List - "
+msgid "Friends List - %s"
 msgstr ""
 
 #: src/fe-gtk/notifygui.c:429
@@ -4346,7 +4346,7 @@ msgstr ""
 
 #: src/fe-gtk/plugin-tray.c:264
 #, c-format
-msgid "Connected to %u networks and %u channels - "
+msgid "Connected to %u networks and %u channels - %s"
 msgstr ""
 
 #: src/fe-gtk/plugin-tray.c:624
@@ -4387,12 +4387,12 @@ msgstr ""
 
 #: src/fe-gtk/plugin-tray.c:710
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
 msgstr ""
 
 #: src/fe-gtk/plugin-tray.c:713
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: src/fe-gtk/plugin-tray.c:718
@@ -4402,12 +4402,12 @@ msgstr ""
 
 #: src/fe-gtk/plugin-tray.c:736
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: src/fe-gtk/plugin-tray.c:739
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: src/fe-gtk/plugin-tray.c:743
@@ -4417,12 +4417,12 @@ msgstr ""
 
 #: src/fe-gtk/plugin-tray.c:765
 #, c-format
-msgid "Private message from: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
 msgstr ""
 
 #: src/fe-gtk/plugin-tray.c:768
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: src/fe-gtk/plugin-tray.c:772
@@ -4432,12 +4432,12 @@ msgstr ""
 
 #: src/fe-gtk/plugin-tray.c:818
 #, c-format
-msgid "File offer from: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
 msgstr ""
 
 #: src/fe-gtk/plugin-tray.c:821
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
 msgstr ""
 
 #: src/fe-gtk/plugin-tray.c:826
@@ -4458,7 +4458,7 @@ msgid "Select a Plugin or Script to load"
 msgstr ""
 
 #: src/fe-gtk/plugingui.c:252
-msgid "Plugins and Scripts - "
+msgid "Plugins and Scripts - %s"
 msgstr ""
 
 #: src/fe-gtk/plugingui.c:267
@@ -4480,7 +4480,7 @@ msgstr ""
 
 #: src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: src/fe-gtk/rawlog.c:143
@@ -4570,7 +4570,7 @@ msgstr ""
 
 #: src/fe-gtk/servlistgui.c:1650
 #, c-format
-msgid "Edit %s - "
+msgid "Edit %s - %s"
 msgstr ""
 
 #: src/fe-gtk/servlistgui.c:1672
@@ -4662,7 +4662,7 @@ msgid "Character set:"
 msgstr ""
 
 #: src/fe-gtk/servlistgui.c:1918
-msgid "Network List - "
+msgid "Network List - %s"
 msgstr ""
 
 #: src/fe-gtk/servlistgui.c:1930
@@ -6005,7 +6005,7 @@ msgid ""
 msgstr ""
 
 #: src/fe-gtk/setup.c:2271
-msgid "Preferences - "
+msgid "Preferences - %s"
 msgstr ""
 
 #: src/fe-gtk/sexy-spell-entry.c:463
@@ -6064,7 +6064,7 @@ msgid "Test All"
 msgstr "Test alle"
 
 #: src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
+msgid "URL Grabber - %s"
 msgstr ""
 
 #: src/fe-gtk/urlgrab.c:212

--- a/po/pa.po
+++ b/po/pa.po
@@ -3239,8 +3239,8 @@ msgstr "ਤੁਸੀਂ ਇੱਕ ਪਾਬੰਦੀ ਮੇਨੂ ਵਿੰਡ�
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr ": ਪਾਬੰਦੀ ਲਿਸਟ (%s)"
+msgid "Ban List (%s) - "
+msgstr "ਪਾਬੰਦੀ ਲਿਸਟ (%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3278,8 +3278,8 @@ msgstr "ਵਿਸ਼ਾ ਟੈਕਸਟ ਕਾਪੀ ਕਰੋ(_T)"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr ": ਚੈਨਲ ਲਿਸਟ (%s)"
+msgid "Channel List (%s) - "
+msgstr "ਚੈਨਲ ਲਿਸਟ (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3370,8 +3370,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "ਦੋ ਲੋਕਾਂ ਤੋਂ ਇੱਕੋ ਫਾਇਲ ਮੁੜ ਪ੍ਰਾਪਤ ਨਹੀਂ ਕੀਤੀ ਜਾ ਸਕਦੀ।"
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr ": ਅੱਪਲੋਡ ਅਤੇ ਡਾਊਨਲੋਡ"
+msgid "Uploads and Downloads - "
+msgstr "ਅੱਪਲੋਡ ਅਤੇ ਡਾਊਨਲੋਡ - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3428,8 +3428,8 @@ msgid "Open Folder..."
 msgstr "...ਫੋਲਡਰ ਖੋਲ੍ਹੋ"
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr ": DCC ਗੱਲਬਾਤ ਲਿਸਟ"
+msgid "DCC Chat List - "
+msgstr "DCC ਗੱਲਬਾਤ ਲਿਸਟ - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3625,8 +3625,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr ": ਕੀ-ਬੋਰਡ ਸ਼ਾਰਟਕੱਟ"
+msgid "Keyboard Shortcuts - "
+msgstr "ਕੀ-ਬੋਰਡ ਸ਼ਾਰਟਕੱਟ - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3670,8 +3670,8 @@ msgid "Enter mask to ignore:"
 msgstr "ਅਣਡਿੱਠਾ ਕਰਨ ਲਈ ਮਾਸਕ ਦਿਓ:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr ": ਅਣਡਿੱਠੀ ਲਿਸਟ"
+msgid "Ignore list - "
+msgstr "ਅਣਡਿੱਠੀ ਲਿਸਟ - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3706,8 +3706,8 @@ msgid "Channel name too short, try again."
 msgstr "ਚੈਨਲ ਨਾਂ ਬਹੁਤ ਛੋਟਾ ਹੈ, ਫੇਰ ਟਰਾਈ ਕਰੋ ਜੀ।"
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr ": ਕੁਨੈਕਸ਼ਨ ਪੂਰਾ"
+msgid "Connection Complete - "
+msgstr "ਕੁਨੈਕਸ਼ਨ ਪੂਰਾ - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4033,8 +4033,8 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr ": ਯੂਜ਼ਰ ਮੇਨੂ"
+msgid "User menu - "
+msgstr "ਯੂਜ਼ਰ ਮੇਨੂ - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4154,36 +4154,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr ": ਯੂਜ਼ਰ ਪ੍ਰਭਾਸ਼ਿਤ ਕਮਾਂਡ"
+msgid "User Defined Commands - "
+msgstr "ਯੂਜ਼ਰ ਪ੍ਰਭਾਸ਼ਿਤ ਕਮਾਂਡ - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr ": ਯੂਜ਼ਰ-ਲਿਸਟ ਪੋਪਅੱਪ ਮੇਨੂ"
+msgid "Userlist Popup menu - "
+msgstr "ਯੂਜ਼ਰ-ਲਿਸਟ ਪੋਪਅੱਪ ਮੇਨੂ - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "ਇਸ ਨਾਲ ਤਬਦੀਲ"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr ": ਤਬਦੀਲ"
+msgid "Replace - "
+msgstr "ਤਬਦੀਲ - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr ": URL ਹੈਂਡਲਰ"
+msgid "URL Handlers - "
+msgstr "URL ਹੈਂਡਲਰ - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr ": ਯੂਜ਼ਰ-ਲਿਸਟ ਬਟਨ"
+msgid "Userlist buttons - "
+msgstr "ਯੂਜ਼ਰ-ਲਿਸਟ ਬਟਨ - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr ": ਗੱਲਬਾਤ ਬਟਨ"
+msgid "Dialog buttons - "
+msgstr "ਗੱਲਬਾਤ ਬਟਨ - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr ":CTCP ਜਵਾਬ"
+msgid "CTCP Replies - "
+msgstr "CTCP ਜਵਾਬ - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4490,8 +4490,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
-msgstr ": ਦੋਸਤ ਲਿਸਟ"
+msgid "Friends List - "
+msgstr "ਦੋਸਤ ਲਿਸਟ - "
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4529,7 +4529,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
+msgid "Connected to %u networks and %u channels - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4571,42 +4571,42 @@ msgstr "ਵਾਪਸ(_B)"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
-msgstr ": %s (%s): ਵਲੋਂ ਹਾਈਲਾਈਟ ਕੀਤਾ ਸੁਨੇਹਾ"
+msgid "Highlighted message from: %s (%s) - "
+msgstr "%s (%s): ਵਲੋਂ ਹਾਈਲਾਈਟ ਕੀਤਾ ਸੁਨੇਹਾ - "
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
-msgstr ": %u ਹਾਈਲਾਈਟ ਕੀਤੇ ਸੁਨੇਹਾ, ਆਖਰੀ ਵਲੋਂ: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
+msgstr "%u ਹਾਈਲਾਈਟ ਕੀਤੇ ਸੁਨੇਹਾ, ਆਖਰੀ ਵਲੋਂ: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
-msgstr ": %s (%s): ਵਲੋਂ ਪ੍ਰਾਈਵੇਟ ਸੁਨੇਹੇ"
+msgid "Private message from: %s (%s) - "
+msgstr "%s (%s): ਵਲੋਂ ਪ੍ਰਾਈਵੇਟ ਸੁਨੇਹੇ - "
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
-msgstr ": %u ਪ੍ਰਾਈਵੇਟ ਸੁਨੇਹੇ: %s (%s) ਵਲੋਂ ਆਖਰੀ"
+msgid "%u private messages, latest from: %s (%s) - "
+msgstr "%u ਪ੍ਰਾਈਵੇਟ ਸੁਨੇਹੇ: %s (%s) ਵਲੋਂ ਆਖਰੀ - "
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
-msgstr ": %s (%s) ਵਲੋਂ ਫਾਈਲ ਭੇਜੀ"
+msgid "File offer from: %s (%s) - "
+msgstr "%s (%s) ਵਲੋਂ ਫਾਈਲ ਭੇਜੀ - "
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4622,8 +4622,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "ਲੋਡ ਕਰਨ ਲਈ ਪਲੱਗਇਨ ਤੇ ਸਕ੍ਰਿਪਟ ਚੁਣੋ"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr ": ਪਲੱਗਇਨ ਅਤੇ ਸਕ੍ਰਿਪਟਾਂ"
+msgid "Plugins and Scripts - "
+msgstr "ਪਲੱਗਇਨ ਅਤੇ ਸਕ੍ਰਿਪਟਾਂ - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4644,7 +4644,7 @@ msgstr "ਇੰਞ ਸੰਭਾਲੋ..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4680,8 +4680,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr ": %s ਸੋਧ"
+msgid "Edit %s - "
+msgstr "%s ਸੋਧ - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4772,8 +4772,8 @@ msgid "Character set:"
 msgstr "ਕਰੈਕਟਰ ਸੈੱਟ:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr ": ਨੈੱਟਵਰਕ ਲਿਸਟ"
+msgid "Network List - "
+msgstr "ਨੈੱਟਵਰਕ ਲਿਸਟ - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6137,8 +6137,8 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr ": ਮੇਰੀ ਪਸੰਦ"
+msgid "Preferences - "
+msgstr "ਮੇਰੀ ਪਸੰਦ - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6202,8 +6202,8 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr ": URL ਖੋਜੀ"
+msgid "URL Grabber - "
+msgstr "URL ਖੋਜੀ - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/pa.po
+++ b/po/pa.po
@@ -3239,8 +3239,8 @@ msgstr "ਤੁਸੀਂ ਇੱਕ ਪਾਬੰਦੀ ਮੇਨੂ ਵਿੰਡ�
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "ਪਾਬੰਦੀ ਲਿਸਟ (%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "ਪਾਬੰਦੀ ਲਿਸਟ (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3278,8 +3278,8 @@ msgstr "ਵਿਸ਼ਾ ਟੈਕਸਟ ਕਾਪੀ ਕਰੋ(_T)"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr "ਚੈਨਲ ਲਿਸਟ (%s) - "
+msgid "Channel List (%s) - %s"
+msgstr "ਚੈਨਲ ਲਿਸਟ (%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3370,8 +3370,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "ਦੋ ਲੋਕਾਂ ਤੋਂ ਇੱਕੋ ਫਾਇਲ ਮੁੜ ਪ੍ਰਾਪਤ ਨਹੀਂ ਕੀਤੀ ਜਾ ਸਕਦੀ।"
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "ਅੱਪਲੋਡ ਅਤੇ ਡਾਊਨਲੋਡ - "
+msgid "Uploads and Downloads - %s"
+msgstr "ਅੱਪਲੋਡ ਅਤੇ ਡਾਊਨਲੋਡ - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3428,8 +3428,8 @@ msgid "Open Folder..."
 msgstr "...ਫੋਲਡਰ ਖੋਲ੍ਹੋ"
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "DCC ਗੱਲਬਾਤ ਲਿਸਟ - "
+msgid "DCC Chat List - %s"
+msgstr "DCC ਗੱਲਬਾਤ ਲਿਸਟ - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3625,8 +3625,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "ਕੀ-ਬੋਰਡ ਸ਼ਾਰਟਕੱਟ - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "ਕੀ-ਬੋਰਡ ਸ਼ਾਰਟਕੱਟ - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3670,8 +3670,8 @@ msgid "Enter mask to ignore:"
 msgstr "ਅਣਡਿੱਠਾ ਕਰਨ ਲਈ ਮਾਸਕ ਦਿਓ:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "ਅਣਡਿੱਠੀ ਲਿਸਟ - "
+msgid "Ignore list - %s"
+msgstr "ਅਣਡਿੱਠੀ ਲਿਸਟ - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3706,8 +3706,8 @@ msgid "Channel name too short, try again."
 msgstr "ਚੈਨਲ ਨਾਂ ਬਹੁਤ ਛੋਟਾ ਹੈ, ਫੇਰ ਟਰਾਈ ਕਰੋ ਜੀ।"
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "ਕੁਨੈਕਸ਼ਨ ਪੂਰਾ - "
+msgid "Connection Complete - %s"
+msgstr "ਕੁਨੈਕਸ਼ਨ ਪੂਰਾ - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4033,8 +4033,8 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "ਯੂਜ਼ਰ ਮੇਨੂ - "
+msgid "User menu - %s"
+msgstr "ਯੂਜ਼ਰ ਮੇਨੂ - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4154,36 +4154,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "ਯੂਜ਼ਰ ਪ੍ਰਭਾਸ਼ਿਤ ਕਮਾਂਡ - "
+msgid "User Defined Commands - %s"
+msgstr "ਯੂਜ਼ਰ ਪ੍ਰਭਾਸ਼ਿਤ ਕਮਾਂਡ - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "ਯੂਜ਼ਰ-ਲਿਸਟ ਪੋਪਅੱਪ ਮੇਨੂ - "
+msgid "Userlist Popup menu - %s"
+msgstr "ਯੂਜ਼ਰ-ਲਿਸਟ ਪੋਪਅੱਪ ਮੇਨੂ - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "ਇਸ ਨਾਲ ਤਬਦੀਲ"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "ਤਬਦੀਲ - "
+msgid "Replace - %s"
+msgstr "ਤਬਦੀਲ - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "URL ਹੈਂਡਲਰ - "
+msgid "URL Handlers - %s"
+msgstr "URL ਹੈਂਡਲਰ - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "ਯੂਜ਼ਰ-ਲਿਸਟ ਬਟਨ - "
+msgid "Userlist buttons - %s"
+msgstr "ਯੂਜ਼ਰ-ਲਿਸਟ ਬਟਨ - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "ਗੱਲਬਾਤ ਬਟਨ - "
+msgid "Dialog buttons - %s"
+msgstr "ਗੱਲਬਾਤ ਬਟਨ - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "CTCP ਜਵਾਬ - "
+msgid "CTCP Replies - %s"
+msgstr "CTCP ਜਵਾਬ - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4490,8 +4490,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
-msgstr "ਦੋਸਤ ਲਿਸਟ - "
+msgid "Friends List - %s"
+msgstr "ਦੋਸਤ ਲਿਸਟ - %s"
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4529,7 +4529,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
+msgid "Connected to %u networks and %u channels - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4571,42 +4571,42 @@ msgstr "ਵਾਪਸ(_B)"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
-msgstr "%s (%s): ਵਲੋਂ ਹਾਈਲਾਈਟ ਕੀਤਾ ਸੁਨੇਹਾ - "
+msgid "Highlighted message from: %s (%s) - %s"
+msgstr "%s (%s): ਵਲੋਂ ਹਾਈਲਾਈਟ ਕੀਤਾ ਸੁਨੇਹਾ - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
-msgstr "%u ਹਾਈਲਾਈਟ ਕੀਤੇ ਸੁਨੇਹਾ, ਆਖਰੀ ਵਲੋਂ: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
+msgstr "%u ਹਾਈਲਾਈਟ ਕੀਤੇ ਸੁਨੇਹਾ, ਆਖਰੀ ਵਲੋਂ: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
-msgstr "%s (%s): ਵਲੋਂ ਪ੍ਰਾਈਵੇਟ ਸੁਨੇਹੇ - "
+msgid "Private message from: %s (%s) - %s"
+msgstr "%s (%s): ਵਲੋਂ ਪ੍ਰਾਈਵੇਟ ਸੁਨੇਹੇ - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
-msgstr "%u ਪ੍ਰਾਈਵੇਟ ਸੁਨੇਹੇ: %s (%s) ਵਲੋਂ ਆਖਰੀ - "
+msgid "%u private messages, latest from: %s (%s) - %s"
+msgstr "%u ਪ੍ਰਾਈਵੇਟ ਸੁਨੇਹੇ: %s (%s) ਵਲੋਂ ਆਖਰੀ - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
-msgstr "%s (%s) ਵਲੋਂ ਫਾਈਲ ਭੇਜੀ - "
+msgid "File offer from: %s (%s) - %s"
+msgstr "%s (%s) ਵਲੋਂ ਫਾਈਲ ਭੇਜੀ - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4622,8 +4622,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "ਲੋਡ ਕਰਨ ਲਈ ਪਲੱਗਇਨ ਤੇ ਸਕ੍ਰਿਪਟ ਚੁਣੋ"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "ਪਲੱਗਇਨ ਅਤੇ ਸਕ੍ਰਿਪਟਾਂ - "
+msgid "Plugins and Scripts - %s"
+msgstr "ਪਲੱਗਇਨ ਅਤੇ ਸਕ੍ਰਿਪਟਾਂ - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4644,7 +4644,7 @@ msgstr "ਇੰਞ ਸੰਭਾਲੋ..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4680,8 +4680,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "%s ਸੋਧ - "
+msgid "Edit %s - %s"
+msgstr "%s ਸੋਧ - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4772,8 +4772,8 @@ msgid "Character set:"
 msgstr "ਕਰੈਕਟਰ ਸੈੱਟ:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "ਨੈੱਟਵਰਕ ਲਿਸਟ - "
+msgid "Network List - %s"
+msgstr "ਨੈੱਟਵਰਕ ਲਿਸਟ - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6137,8 +6137,8 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "ਮੇਰੀ ਪਸੰਦ - "
+msgid "Preferences - %s"
+msgstr "ਮੇਰੀ ਪਸੰਦ - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6202,8 +6202,8 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "URL ਖੋਜੀ - "
+msgid "URL Grabber - %s"
+msgstr "URL ਖੋਜੀ - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/pl.po
+++ b/po/pl.po
@@ -3249,7 +3249,7 @@ msgstr "Możesz otworzyć okno listy banów tylko wtedy gdy znajdujesz się na k
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
+msgid "Ban List (%s) - %s"
 msgstr " Lista banów (%s)"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3288,7 +3288,7 @@ msgstr "Kopiuj tekst _tematu"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
+msgid "Channel List (%s) - %s"
 msgstr " Lista kanałów (%s)"
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3380,8 +3380,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Nie można wznowić tego samego pliku od dwóch osób."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "Wysyłania i Pobierania - "
+msgid "Uploads and Downloads - %s"
+msgstr "Wysyłania i Pobierania - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3438,7 +3438,7 @@ msgid "Open Folder..."
 msgstr "Otwórz folder..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
+msgid "DCC Chat List - %s"
 msgstr " Lista Czatów Bezpośrednich"
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3635,7 +3635,7 @@ msgid "Select a row to get help information on its Action."
 msgstr "Wybierz wiersz by uzyskać informacje o akcji"
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
+msgid "Keyboard Shortcuts - %s"
 msgstr " Skróty klawiszowe"
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3680,7 +3680,7 @@ msgid "Enter mask to ignore:"
 msgstr "Podaj maskę którą zignorować:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
+msgid "Ignore list - %s"
 msgstr " Lista ignorowanych"
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3716,8 +3716,8 @@ msgid "Channel name too short, try again."
 msgstr "Nazwa kanału jest za krótka, spróbuj ponownie."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "Połączenie zakończone - "
+msgid "Connection Complete - %s"
+msgstr "Połączenie zakończone - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4043,8 +4043,8 @@ msgid "_Auto-Connect"
 msgstr "_Autopołączenie"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "Menu użytkownika - "
+msgid "User menu - %s"
+msgstr "Menu użytkownika - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4164,36 +4164,36 @@ msgid ""
 msgstr "Zarządanie Linkami - Kody specjalne:\n\n%s  =  ciąg z linkiem\n\nDodanie ! na początku komendy\noznacza, że zostanie ona wysłana\ndo terminala zamiast do HexChata"
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "Komendy zdefiniowane przez użytkownika - "
+msgid "User Defined Commands - %s"
+msgstr "Komendy zdefiniowane przez użytkownika - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "Podręczne menu Listy Użytkowników - "
+msgid "Userlist Popup menu - %s"
+msgstr "Podręczne menu Listy Użytkowników - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Zamień na"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "Zamiana - "
+msgid "Replace - %s"
+msgstr "Zamiana - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "Przechwycone Adresy URL - "
+msgid "URL Handlers - %s"
+msgstr "Przechwycone Adresy URL - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "Przyciski pod Listą Użytkowników - "
+msgid "Userlist buttons - %s"
+msgstr "Przyciski pod Listą Użytkowników - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "Przyciski rozmowy - "
+msgid "Dialog buttons - %s"
+msgstr "Przyciski rozmowy - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "Odpowiedzi CTCP - "
+msgid "CTCP Replies - %s"
+msgstr "Odpowiedzi CTCP - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4500,7 +4500,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Akceptowana jest lista sieci, dzielonych przecinkami."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
+msgid "Friends List - %s"
 msgstr " Lista znajomych"
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4539,8 +4539,8 @@ msgstr "Prywatna wiadomość od: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
-msgstr "Podłączony do %u sieci i %u kanałów - "
+msgid "Connected to %u networks and %u channels - %s"
+msgstr "Podłączony do %u sieci i %u kanałów - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4581,43 +4581,43 @@ msgstr "_Wstecz"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
-msgstr "Podświetl wiadomość od: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
+msgstr "Podświetl wiadomość od: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
-msgstr "%u wiadomości podświetlonych, najnowsza z: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
+msgstr "%u wiadomości podświetlonych, najnowsza z: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
-msgstr "Wiadomość kanłu od: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
+msgstr "Wiadomość kanłu od: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ": %u wiadomości kanału."
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
 msgstr ": Prywatna wiadomość od: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
 msgstr ": %u wiadomości prywatnych, najnowsza z: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
-msgstr "Oferta pliku od: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
+msgstr "Oferta pliku od: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
-msgstr "%u ofert pliku, najnowsza z: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
+msgstr "%u ofert pliku, najnowsza z: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4632,8 +4632,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Wybierz wtyczkę lub skrypt do załadowania"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "Wtyczki i skrypty - "
+msgid "Plugins and Scripts - %s"
+msgstr "Wtyczki i skrypty - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4654,8 +4654,8 @@ msgstr "Zapisz jako..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
-msgstr "Surowy log (%s) - "
+msgid "Raw Log (%s) - %s"
+msgstr "Surowy log (%s) - %s"
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4690,8 +4690,8 @@ msgstr "Metody identyfikacji z serwerem. Dla własnej metody użyj komend po pod
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "Edycja %s - "
+msgid "Edit %s - %s"
+msgstr "Edycja %s - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4782,8 +4782,8 @@ msgid "Character set:"
 msgstr "Zestaw znaków:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "Lista Sieci - "
+msgid "Network List - %s"
+msgstr "Lista Sieci - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6147,8 +6147,8 @@ msgid ""
 msgstr "*OSTRZEŻENIE*\nAutomatyczne przyjmowanie Czatu Bezpośredniego do twojego\nkatalogu domowego może być niebezpieczne i jest wykorzystywane.\nNp.: Ktoś mógłby ci wysłać profil .bash"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "Preferencje - "
+msgid "Preferences - %s"
+msgstr "Preferencje - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6212,8 +6212,8 @@ msgid "OK"
 msgstr "OK"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "Przechwycone Adresy URL - "
+msgid "URL Grabber - %s"
+msgstr "Przechwycone Adresy URL - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/pl.po
+++ b/po/pl.po
@@ -3249,7 +3249,7 @@ msgstr "Możesz otworzyć okno listy banów tylko wtedy gdy znajdujesz się na k
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
+msgid "Ban List (%s) - "
 msgstr " Lista banów (%s)"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3288,7 +3288,7 @@ msgstr "Kopiuj tekst _tematu"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
+msgid "Channel List (%s) - "
 msgstr " Lista kanałów (%s)"
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3380,8 +3380,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Nie można wznowić tego samego pliku od dwóch osób."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr ": Wysyłania i Pobierania"
+msgid "Uploads and Downloads - "
+msgstr "Wysyłania i Pobierania - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3438,7 +3438,7 @@ msgid "Open Folder..."
 msgstr "Otwórz folder..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
+msgid "DCC Chat List - "
 msgstr " Lista Czatów Bezpośrednich"
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3635,7 +3635,7 @@ msgid "Select a row to get help information on its Action."
 msgstr "Wybierz wiersz by uzyskać informacje o akcji"
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
+msgid "Keyboard Shortcuts - "
 msgstr " Skróty klawiszowe"
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3680,7 +3680,7 @@ msgid "Enter mask to ignore:"
 msgstr "Podaj maskę którą zignorować:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
+msgid "Ignore list - "
 msgstr " Lista ignorowanych"
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3716,8 +3716,8 @@ msgid "Channel name too short, try again."
 msgstr "Nazwa kanału jest za krótka, spróbuj ponownie."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr ": Połączenie zakończone"
+msgid "Connection Complete - "
+msgstr "Połączenie zakończone - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4043,8 +4043,8 @@ msgid "_Auto-Connect"
 msgstr "_Autopołączenie"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr ": Menu użytkownika"
+msgid "User menu - "
+msgstr "Menu użytkownika - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4164,36 +4164,36 @@ msgid ""
 msgstr "Zarządanie Linkami - Kody specjalne:\n\n%s  =  ciąg z linkiem\n\nDodanie ! na początku komendy\noznacza, że zostanie ona wysłana\ndo terminala zamiast do HexChata"
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr ": Komendy zdefiniowane przez użytkownika"
+msgid "User Defined Commands - "
+msgstr "Komendy zdefiniowane przez użytkownika - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr ": Podręczne menu Listy Użytkowników"
+msgid "Userlist Popup menu - "
+msgstr "Podręczne menu Listy Użytkowników - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Zamień na"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr ": Zamiana"
+msgid "Replace - "
+msgstr "Zamiana - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr ": Przechwycone Adresy URL"
+msgid "URL Handlers - "
+msgstr "Przechwycone Adresy URL - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr ": Przyciski pod Listą Użytkowników"
+msgid "Userlist buttons - "
+msgstr "Przyciski pod Listą Użytkowników - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr ": Przyciski rozmowy"
+msgid "Dialog buttons - "
+msgstr "Przyciski rozmowy - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr ": Odpowiedzi CTCP"
+msgid "CTCP Replies - "
+msgstr "Odpowiedzi CTCP - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4500,7 +4500,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Akceptowana jest lista sieci, dzielonych przecinkami."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
+msgid "Friends List - "
 msgstr " Lista znajomych"
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4539,8 +4539,8 @@ msgstr "Prywatna wiadomość od: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
-msgstr ": Podłączony do %u sieci i %u kanałów"
+msgid "Connected to %u networks and %u channels - "
+msgstr "Podłączony do %u sieci i %u kanałów - "
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4581,43 +4581,43 @@ msgstr "_Wstecz"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
-msgstr ": Podświetl wiadomość od: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
+msgstr "Podświetl wiadomość od: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
-msgstr ": %u wiadomości podświetlonych, najnowsza z: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
+msgstr "%u wiadomości podświetlonych, najnowsza z: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
-msgstr ": Wiadomość kanłu od: %s (%s)"
+msgid "Channel message from: %s (%s) - "
+msgstr "Wiadomość kanłu od: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ": %u wiadomości kanału."
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
+msgid "Private message from: %s (%s) - "
 msgstr ": Prywatna wiadomość od: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
 msgstr ": %u wiadomości prywatnych, najnowsza z: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
-msgstr ": Oferta pliku od: %s (%s)"
+msgid "File offer from: %s (%s) - "
+msgstr "Oferta pliku od: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
-msgstr ": %u ofert pliku, najnowsza z: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
+msgstr "%u ofert pliku, najnowsza z: %s (%s) - "
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4632,8 +4632,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Wybierz wtyczkę lub skrypt do załadowania"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr ": Wtyczki i skrypty"
+msgid "Plugins and Scripts - "
+msgstr "Wtyczki i skrypty - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4654,8 +4654,8 @@ msgstr "Zapisz jako..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
-msgstr ": Surowy log (%s)"
+msgid "Raw Log (%s) - "
+msgstr "Surowy log (%s) - "
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4690,8 +4690,8 @@ msgstr "Metody identyfikacji z serwerem. Dla własnej metody użyj komend po pod
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr ": Edycja %s"
+msgid "Edit %s - "
+msgstr "Edycja %s - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4782,8 +4782,8 @@ msgid "Character set:"
 msgstr "Zestaw znaków:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr ": Lista Sieci"
+msgid "Network List - "
+msgstr "Lista Sieci - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6147,8 +6147,8 @@ msgid ""
 msgstr "*OSTRZEŻENIE*\nAutomatyczne przyjmowanie Czatu Bezpośredniego do twojego\nkatalogu domowego może być niebezpieczne i jest wykorzystywane.\nNp.: Ktoś mógłby ci wysłać profil .bash"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr ": Preferencje"
+msgid "Preferences - "
+msgstr "Preferencje - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6212,8 +6212,8 @@ msgid "OK"
 msgstr "OK"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr ": Przechwycone Adresy URL"
+msgid "URL Grabber - "
+msgstr "Przechwycone Adresy URL - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/pt.po
+++ b/po/pt.po
@@ -3241,8 +3241,8 @@ msgstr "Só podes ver a Lista de banimentos enquanto estás num canal."
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr ": Lista de Banimentos (%s)"
+msgid "Ban List (%s) - "
+msgstr "Lista de Banimentos (%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3280,8 +3280,8 @@ msgstr "Copiar Texto do _Tópico "
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr ": Lista de Canais (%s)"
+msgid "Channel List (%s) - "
+msgstr "Lista de Canais (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3372,8 +3372,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Impossível continuar o mesmo ficheiro de dois utilizadores."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr ": Envios e Transferências"
+msgid "Uploads and Downloads - "
+msgstr "Envios e Transferências - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3430,8 +3430,8 @@ msgid "Open Folder..."
 msgstr "Abrir Pasta..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr ": Lista de Conversas DCC"
+msgid "DCC Chat List - "
+msgstr "Lista de Conversas DCC - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3627,8 +3627,8 @@ msgid "Select a row to get help information on its Action."
 msgstr "Seleciona uma linha para obter ajuda sobre a sua Ação."
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr "XChat: Atalhos de Teclado"
+msgid "Keyboard Shortcuts - "
+msgstr "Atalhos de Teclado - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3672,8 +3672,8 @@ msgid "Enter mask to ignore:"
 msgstr "Introduzir máscara a ignorar:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr ": Lista de Ignorados"
+msgid "Ignore list - "
+msgstr "Lista de Ignorados - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3708,8 +3708,8 @@ msgid "Channel name too short, try again."
 msgstr "Nome do canal é demasiado pequeno, tenta outra vez."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr "XChat: Ligação Completa"
+msgid "Connection Complete - "
+msgstr "Ligação Completa - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4035,8 +4035,8 @@ msgid "_Auto-Connect"
 msgstr "Ligar _Automaticamente"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr "XChat: Menu de utilizador"
+msgid "User menu - "
+msgstr "Menu de utilizador - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4156,36 +4156,36 @@ msgid ""
 msgstr "URL Manipuladores- Códigos especiais:\n\n%s  =  string URL \nInserir um! na frente do comando\nindica que deve ser enviado para uma\nshell em vez HexChat"
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr "XChat: Comandos Definidos pelo Utilizador"
+msgid "User Defined Commands - "
+msgstr "Comandos Definidos pelo Utilizador - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr ":Lista de utilizadores Menu de contexto"
+msgid "Userlist Popup menu - "
+msgstr "Lista de utilizadores Menu de contexto - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Substituir por"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr ": Substituir"
+msgid "Replace - "
+msgstr "Substituir - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr "XChat: Gestor de URL"
+msgid "URL Handlers - "
+msgstr "Gestor de URL - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr "XChat: Botões da Lista de Utilizadores"
+msgid "Userlist buttons - "
+msgstr "Botões da Lista de Utilizadores - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr "XChat: Botões de Diálogo"
+msgid "Dialog buttons - "
+msgstr "Botões de Diálogo - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr "XChat: Respostas CTCP"
+msgid "CTCP Replies - "
+msgstr "Respostas CTCP - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4492,8 +4492,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Lista separada por vírgula de redes permitida."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
-msgstr ": Lista de Amigos"
+msgid "Friends List - "
+msgstr "Lista de Amigos - "
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4531,8 +4531,8 @@ msgstr "Mensagem privada de: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
-msgstr ": Ligado a %u redes e %u canais"
+msgid "Connected to %u networks and %u channels - "
+msgstr "Ligado a %u redes e %u canais - "
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4573,43 +4573,43 @@ msgstr "_de Volta"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
-msgstr ": Mensagem marcada de: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
+msgstr "Mensagem marcada de: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
-msgstr ": %u mensagens marcadas, última de: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
+msgstr "%u mensagens marcadas, última de: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
-msgstr ": Mensagem de canal de: %s (%s)"
+msgid "Channel message from: %s (%s) - "
+msgstr "Mensagem de canal de: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
-msgstr ": %u mensagens de canal."
+msgid "%u channel messages. - "
+msgstr "%u mensagens de canal. - "
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
+msgid "Private message from: %s (%s) - "
 msgstr ": Mensagem Privada de: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
 msgstr ": %u mensagens privadas, última de: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
-msgstr ": Oferta de ficheiro de: %s (%s)"
+msgid "File offer from: %s (%s) - "
+msgstr "Oferta de ficheiro de: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
-msgstr ": %u oferta ficheiro, último de: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
+msgstr "%u oferta ficheiro, último de: %s (%s) - "
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4624,8 +4624,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Seleccionar um Plugin ou Script para carregar"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr "XChat: Plugins e Scripts"
+msgid "Plugins and Scripts - "
+msgstr "Plugins e Scripts - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4646,7 +4646,7 @@ msgstr "Guardar como..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ": Raw registo (%s)"
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4682,8 +4682,8 @@ msgstr "A forma como te identificas ao servidor. Para métodos de login personal
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr ": Editar %s"
+msgid "Edit %s - "
+msgstr "Editar %s - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4774,8 +4774,8 @@ msgid "Character set:"
 msgstr "Conjunto de caracteres:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr ": Lista de Redes"
+msgid "Network List - "
+msgstr "Lista de Redes - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6139,7 +6139,7 @@ msgid ""
 msgstr "*AVISO*\nAceitar automaticamente DCC no diretório do utilizador pode ser perigoso. Por exemplo, uma pessoal mal intencionada pode enviar-te um .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
+msgid "Preferences - "
 msgstr ": Preferências"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6204,7 +6204,7 @@ msgid "OK"
 msgstr "OK"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
+msgid "URL Grabber - "
 msgstr "XChat: Captura de URL"
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/pt.po
+++ b/po/pt.po
@@ -3241,8 +3241,8 @@ msgstr "Só podes ver a Lista de banimentos enquanto estás num canal."
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "Lista de Banimentos (%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "Lista de Banimentos (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3280,7 +3280,7 @@ msgstr "Copiar Texto do _Tópico "
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
+msgid "Channel List (%s) - %s"
 msgstr "Lista de Canais (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3372,8 +3372,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Impossível continuar o mesmo ficheiro de dois utilizadores."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "Envios e Transferências - "
+msgid "Uploads and Downloads - %s"
+msgstr "Envios e Transferências - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3430,8 +3430,8 @@ msgid "Open Folder..."
 msgstr "Abrir Pasta..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "Lista de Conversas DCC - "
+msgid "DCC Chat List - %s"
+msgstr "Lista de Conversas DCC - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3627,8 +3627,8 @@ msgid "Select a row to get help information on its Action."
 msgstr "Seleciona uma linha para obter ajuda sobre a sua Ação."
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "Atalhos de Teclado - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "Atalhos de Teclado - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3672,8 +3672,8 @@ msgid "Enter mask to ignore:"
 msgstr "Introduzir máscara a ignorar:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "Lista de Ignorados - "
+msgid "Ignore list - %s"
+msgstr "Lista de Ignorados - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3708,8 +3708,8 @@ msgid "Channel name too short, try again."
 msgstr "Nome do canal é demasiado pequeno, tenta outra vez."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "Ligação Completa - "
+msgid "Connection Complete - %s"
+msgstr "Ligação Completa - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4035,8 +4035,8 @@ msgid "_Auto-Connect"
 msgstr "Ligar _Automaticamente"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "Menu de utilizador - "
+msgid "User menu - %s"
+msgstr "Menu de utilizador - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4156,36 +4156,36 @@ msgid ""
 msgstr "URL Manipuladores- Códigos especiais:\n\n%s  =  string URL \nInserir um! na frente do comando\nindica que deve ser enviado para uma\nshell em vez HexChat"
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "Comandos Definidos pelo Utilizador - "
+msgid "User Defined Commands - %s"
+msgstr "Comandos Definidos pelo Utilizador - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "Lista de utilizadores Menu de contexto - "
+msgid "Userlist Popup menu - %s"
+msgstr "Lista de utilizadores Menu de contexto - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Substituir por"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "Substituir - "
+msgid "Replace - %s"
+msgstr "Substituir - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "Gestor de URL - "
+msgid "URL Handlers - %s"
+msgstr "Gestor de URL - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "Botões da Lista de Utilizadores - "
+msgid "Userlist buttons - %s"
+msgstr "Botões da Lista de Utilizadores - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "Botões de Diálogo - "
+msgid "Dialog buttons - %s"
+msgstr "Botões de Diálogo - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "Respostas CTCP - "
+msgid "CTCP Replies - %s"
+msgstr "Respostas CTCP - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4492,8 +4492,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Lista separada por vírgula de redes permitida."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
-msgstr "Lista de Amigos - "
+msgid "Friends List - %s"
+msgstr "Lista de Amigos - %s"
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4531,8 +4531,8 @@ msgstr "Mensagem privada de: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
-msgstr "Ligado a %u redes e %u canais - "
+msgid "Connected to %u networks and %u channels - %s"
+msgstr "Ligado a %u redes e %u canais - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4573,43 +4573,43 @@ msgstr "_de Volta"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
-msgstr "Mensagem marcada de: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
+msgstr "Mensagem marcada de: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
-msgstr "%u mensagens marcadas, última de: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
+msgstr "%u mensagens marcadas, última de: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
-msgstr "Mensagem de canal de: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
+msgstr "Mensagem de canal de: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
-msgstr "%u mensagens de canal. - "
+msgid "%u channel messages. - %s"
+msgstr "%u mensagens de canal. - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
 msgstr ": Mensagem Privada de: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
 msgstr ": %u mensagens privadas, última de: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
-msgstr "Oferta de ficheiro de: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
+msgstr "Oferta de ficheiro de: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
-msgstr "%u oferta ficheiro, último de: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
+msgstr "%u oferta ficheiro, último de: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4624,8 +4624,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Seleccionar um Plugin ou Script para carregar"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "Plugins e Scripts - "
+msgid "Plugins and Scripts - %s"
+msgstr "Plugins e Scripts - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4646,7 +4646,7 @@ msgstr "Guardar como..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ": Raw registo (%s)"
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4682,8 +4682,8 @@ msgstr "A forma como te identificas ao servidor. Para métodos de login personal
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "Editar %s - "
+msgid "Edit %s - %s"
+msgstr "Editar %s - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4774,8 +4774,8 @@ msgid "Character set:"
 msgstr "Conjunto de caracteres:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "Lista de Redes - "
+msgid "Network List - %s"
+msgstr "Lista de Redes - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6139,7 +6139,7 @@ msgid ""
 msgstr "*AVISO*\nAceitar automaticamente DCC no diretório do utilizador pode ser perigoso. Por exemplo, uma pessoal mal intencionada pode enviar-te um .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
+msgid "Preferences - %s"
 msgstr ": Preferências"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6204,8 +6204,8 @@ msgid "OK"
 msgstr "OK"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "XChat: Captura de URL"
+msgid "URL Grabber - %s"
+msgstr "Captura de URL - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -3245,8 +3245,8 @@ msgstr "Só é possível abrir a lista de banimentos enquanto a janela do canal 
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "Banimentos (%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "Banimentos (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3284,8 +3284,8 @@ msgstr "Copiar _tópico"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr "Canais da rede (%s) - "
+msgid "Channel List (%s) - %s"
+msgstr "Canais da rede (%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3376,8 +3376,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Não é possível continuar a baixar o mesmo arquivo de pessoas diferentes."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "Transferências - "
+msgid "Uploads and Downloads - %s"
+msgstr "Transferências - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3434,8 +3434,8 @@ msgid "Open Folder..."
 msgstr "Abrir pasta"
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "Conversas via DCC - "
+msgid "DCC Chat List - %s"
+msgstr "Conversas via DCC - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3631,8 +3631,8 @@ msgid "Select a row to get help information on its Action."
 msgstr "Selecione uma linha para obter ajuda em suas ações"
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "Atalhos de teclado - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "Atalhos de teclado - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3676,8 +3676,8 @@ msgid "Enter mask to ignore:"
 msgstr "Informe a máscara a ignorar:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "Ignorados - "
+msgid "Ignore list - %s"
+msgstr "Ignorados - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3712,8 +3712,8 @@ msgid "Channel name too short, try again."
 msgstr "Nome do canal pequeno demais, tente outro maior."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "Conexão concluída - "
+msgid "Connection Complete - %s"
+msgstr "Conexão concluída - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4039,8 +4039,8 @@ msgid "_Auto-Connect"
 msgstr "_Conexão automática"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "Menu do usuário - "
+msgid "User menu - %s"
+msgstr "Menu do usuário - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4160,36 +4160,36 @@ msgid ""
 msgstr "Manipuladores de URL - códigos especiais:\n\n%s  =  linha da URL\n\nAdicionando ! na frente do comando\nque ele deve ser executado em\nshell ao invés do HexChat"
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "Comandos definidos pelo usuário - "
+msgid "User Defined Commands - %s"
+msgstr "Comandos definidos pelo usuário - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "Menu da lista de usuários - "
+msgid "Userlist Popup menu - %s"
+msgstr "Menu da lista de usuários - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Substituir com"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "Substituir - "
+msgid "Replace - %s"
+msgstr "Substituir - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "Manipuladores de URL - "
+msgid "URL Handlers - %s"
+msgstr "Manipuladores de URL - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "Botões da lista de usuários - "
+msgid "Userlist buttons - %s"
+msgstr "Botões da lista de usuários - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "Botões da janela de conversa - "
+msgid "Dialog buttons - %s"
+msgstr "Botões da janela de conversa - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "Respostas de CTCP - "
+msgid "CTCP Replies - %s"
+msgstr "Respostas de CTCP - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4496,8 +4496,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Você pode utilizar uma lista de redes separadas por vírgulas."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
-msgstr "Lista de amigos - "
+msgid "Friends List - %s"
+msgstr "Lista de amigos - %s"
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4535,8 +4535,8 @@ msgstr "Mensagem privada de: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
-msgstr "Conectado a rede %u e %u canais - "
+msgid "Connected to %u networks and %u channels - %s"
+msgstr "Conectado a rede %u e %u canais - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4577,43 +4577,43 @@ msgstr "_Voltar"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
-msgstr "Mensagem de: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
+msgstr "Mensagem de: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
-msgstr "%u mensagens destacadas, ultima de: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
+msgstr "%u mensagens destacadas, ultima de: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
-msgstr "Mensagem no canal de: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
+msgstr "Mensagem no canal de: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
-msgstr "%u mensagens no canal. - "
+msgid "%u channel messages. - %s"
+msgstr "%u mensagens no canal. - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
-msgstr "Mensagem privada de: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
+msgstr "Mensagem privada de: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
 msgstr ": %u mensagens privadas, ultima de: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
 msgstr ": Oferta de arquivo de: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
-msgstr "%u oferecimentos de arquivos, ultima de: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
+msgstr "%u oferecimentos de arquivos, ultima de: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4628,8 +4628,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Escolha um complemento para carregar"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "Complementos - "
+msgid "Plugins and Scripts - %s"
+msgstr "Complementos - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4650,8 +4650,8 @@ msgstr "Salvar como..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
-msgstr "Mensagens do servidor (%s) - "
+msgid "Raw Log (%s) - %s"
+msgstr "Mensagens do servidor (%s) - %s"
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4686,8 +4686,8 @@ msgstr "Forma como você se identifica com o servidor. Para métodos personaliza
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "Editar %s - "
+msgid "Edit %s - %s"
+msgstr "Editar %s - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4778,8 +4778,8 @@ msgid "Character set:"
 msgstr "Codificação:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "Redes - "
+msgid "Network List - %s"
+msgstr "Redes - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6143,8 +6143,8 @@ msgid ""
 msgstr "*AVISO*\nAceitar DCC automaticamente para seu diretório pessoal\npode ser extremamente perigoso e altamente explorável.\nEx: alguém pode lhe enviar um novo arquivo .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "Preferências - "
+msgid "Preferences - %s"
+msgstr "Preferências - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6208,8 +6208,8 @@ msgid "OK"
 msgstr "OK"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "Registrador de URL - "
+msgid "URL Grabber - %s"
+msgstr "Registrador de URL - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -3245,8 +3245,8 @@ msgstr "Só é possível abrir a lista de banimentos enquanto a janela do canal 
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr ": Banimentos (%s)"
+msgid "Ban List (%s) - "
+msgstr "Banimentos (%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3284,8 +3284,8 @@ msgstr "Copiar _tópico"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr ": Canais da rede (%s)"
+msgid "Channel List (%s) - "
+msgstr "Canais da rede (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3376,8 +3376,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Não é possível continuar a baixar o mesmo arquivo de pessoas diferentes."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr ": Transferências"
+msgid "Uploads and Downloads - "
+msgstr "Transferências - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3434,8 +3434,8 @@ msgid "Open Folder..."
 msgstr "Abrir pasta"
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr ": Conversas via DCC"
+msgid "DCC Chat List - "
+msgstr "Conversas via DCC - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3631,8 +3631,8 @@ msgid "Select a row to get help information on its Action."
 msgstr "Selecione uma linha para obter ajuda em suas ações"
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr ": Atalhos de teclado"
+msgid "Keyboard Shortcuts - "
+msgstr "Atalhos de teclado - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3676,8 +3676,8 @@ msgid "Enter mask to ignore:"
 msgstr "Informe a máscara a ignorar:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr ": Ignorados"
+msgid "Ignore list - "
+msgstr "Ignorados - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3712,8 +3712,8 @@ msgid "Channel name too short, try again."
 msgstr "Nome do canal pequeno demais, tente outro maior."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr ": Conexão concluída"
+msgid "Connection Complete - "
+msgstr "Conexão concluída - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4039,8 +4039,8 @@ msgid "_Auto-Connect"
 msgstr "_Conexão automática"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr ": Menu do usuário"
+msgid "User menu - "
+msgstr "Menu do usuário - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4160,36 +4160,36 @@ msgid ""
 msgstr "Manipuladores de URL - códigos especiais:\n\n%s  =  linha da URL\n\nAdicionando ! na frente do comando\nque ele deve ser executado em\nshell ao invés do HexChat"
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr ": Comandos definidos pelo usuário"
+msgid "User Defined Commands - "
+msgstr "Comandos definidos pelo usuário - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr ": Menu da lista de usuários"
+msgid "Userlist Popup menu - "
+msgstr "Menu da lista de usuários - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Substituir com"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr ": Substituir"
+msgid "Replace - "
+msgstr "Substituir - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr ": Manipuladores de URL"
+msgid "URL Handlers - "
+msgstr "Manipuladores de URL - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr ": Botões da lista de usuários"
+msgid "Userlist buttons - "
+msgstr "Botões da lista de usuários - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr ": Botões da janela de conversa"
+msgid "Dialog buttons - "
+msgstr "Botões da janela de conversa - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr ": Respostas de CTCP"
+msgid "CTCP Replies - "
+msgstr "Respostas de CTCP - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4496,8 +4496,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Você pode utilizar uma lista de redes separadas por vírgulas."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
-msgstr ": Lista de amigos"
+msgid "Friends List - "
+msgstr "Lista de amigos - "
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4535,8 +4535,8 @@ msgstr "Mensagem privada de: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
-msgstr ": Conectado a rede %u e %u canais"
+msgid "Connected to %u networks and %u channels - "
+msgstr "Conectado a rede %u e %u canais - "
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4577,43 +4577,43 @@ msgstr "_Voltar"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
-msgstr ": Mensagem de: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
+msgstr "Mensagem de: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
-msgstr ": %u mensagens destacadas, ultima de: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
+msgstr "%u mensagens destacadas, ultima de: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
-msgstr ": Mensagem no canal de: %s (%s)"
+msgid "Channel message from: %s (%s) - "
+msgstr "Mensagem no canal de: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
-msgstr ": %u mensagens no canal."
+msgid "%u channel messages. - "
+msgstr "%u mensagens no canal. - "
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
-msgstr ": Mensagem privada de: %s (%s)"
+msgid "Private message from: %s (%s) - "
+msgstr "Mensagem privada de: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
 msgstr ": %u mensagens privadas, ultima de: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
+msgid "File offer from: %s (%s) - "
 msgstr ": Oferta de arquivo de: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
-msgstr ": %u oferecimentos de arquivos, ultima de: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
+msgstr "%u oferecimentos de arquivos, ultima de: %s (%s) - "
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4628,8 +4628,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Escolha um complemento para carregar"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr ": Complementos"
+msgid "Plugins and Scripts - "
+msgstr "Complementos - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4650,8 +4650,8 @@ msgstr "Salvar como..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
-msgstr ": Mensagens do servidor (%s)"
+msgid "Raw Log (%s) - "
+msgstr "Mensagens do servidor (%s) - "
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4686,8 +4686,8 @@ msgstr "Forma como você se identifica com o servidor. Para métodos personaliza
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr ": Editar %s"
+msgid "Edit %s - "
+msgstr "Editar %s - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4778,8 +4778,8 @@ msgid "Character set:"
 msgstr "Codificação:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr ": Redes"
+msgid "Network List - "
+msgstr "Redes - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6143,8 +6143,8 @@ msgid ""
 msgstr "*AVISO*\nAceitar DCC automaticamente para seu diretório pessoal\npode ser extremamente perigoso e altamente explorável.\nEx: alguém pode lhe enviar um novo arquivo .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr ": Preferências"
+msgid "Preferences - "
+msgstr "Preferências - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6208,8 +6208,8 @@ msgid "OK"
 msgstr "OK"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr ": Registrador de URL"
+msgid "URL Grabber - "
+msgstr "Registrador de URL - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/ru.po
+++ b/po/ru.po
@@ -3250,8 +3250,8 @@ msgstr "Список банов можно отктыть только при о
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "Список банов (%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "Список банов (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3289,8 +3289,8 @@ msgstr "Скопировать _тему общения"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr "Список каналов (%s) - "
+msgid "Channel List (%s) - %s"
+msgstr "Список каналов (%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3381,8 +3381,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Не могу продолжить одинаковый файл от 2 пользователей."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "Прием и передача файлов - "
+msgid "Uploads and Downloads - %s"
+msgstr "Прием и передача файлов - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3439,8 +3439,8 @@ msgid "Open Folder..."
 msgstr "Открыть папку..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "Список разговоров по DCC - "
+msgid "DCC Chat List - %s"
+msgstr "Список разговоров по DCC - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3636,8 +3636,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "Клавиатурные сокращения - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "Клавиатурные сокращения - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3681,8 +3681,8 @@ msgid "Enter mask to ignore:"
 msgstr "Введите маску для игнорирования:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "Черный список - "
+msgid "Ignore list - %s"
+msgstr "Черный список - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3717,8 +3717,8 @@ msgid "Channel name too short, try again."
 msgstr "Имя канала недостаточно длинное."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "Соединение завершено - "
+msgid "Connection Complete - %s"
+msgstr "Соединение завершено - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4044,8 +4044,8 @@ msgid "_Auto-Connect"
 msgstr "_Автосоединение"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "Пользовательское меню - "
+msgid "User menu - %s"
+msgstr "Пользовательское меню - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4165,11 +4165,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "Определенные пользователем команды - "
+msgid "User Defined Commands - %s"
+msgstr "Определенные пользователем команды - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
+msgid "Userlist Popup menu - %s"
 msgstr "Всплывающее меню списка пользователей.."
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4177,24 +4177,24 @@ msgid "Replace with"
 msgstr "Заменить на"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "Замена - "
+msgid "Replace - %s"
+msgstr "Замена - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "Обработчики URL - "
+msgid "URL Handlers - %s"
+msgstr "Обработчики URL - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "Кнопки списка пользователей - "
+msgid "Userlist buttons - %s"
+msgstr "Кнопки списка пользователей - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "Кнопки диалога - "
+msgid "Dialog buttons - %s"
+msgstr "Кнопки диалога - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "Ответы CTCP - "
+msgid "CTCP Replies - %s"
+msgstr "Ответы CTCP - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4501,8 +4501,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Укажите разделенный запятыми список сетей."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
-msgstr "Список друзей - "
+msgid "Friends List - %s"
+msgstr "Список друзей - %s"
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4540,8 +4540,8 @@ msgstr "Индивидуальное сообщение от %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
-msgstr "Подключен; сети: %u, каналы: %u - "
+msgid "Connected to %u networks and %u channels - %s"
+msgstr "Подключен; сети: %u, каналы: %u - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4582,43 +4582,43 @@ msgstr "_Вернулся"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
-msgstr "Выделенное сообщение от %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
+msgstr "Выделенное сообщение от %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
-msgstr "%u выделенных сообщения, последнее от %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
+msgstr "%u выделенных сообщения, последнее от %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
-msgstr "Канал, сообщение от %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
+msgstr "Канал, сообщение от %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
-msgstr "%u сообщений канала. - "
+msgid "%u channel messages. - %s"
+msgstr "%u сообщений канала. - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
-msgstr "XChat: Личное сообщение от %s (%s)"
+msgid "Private message from: %s (%s) - %s"
+msgstr "Личное сообщение от %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
-msgstr "%u личных сообщения, последнее от %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
+msgstr "%u личных сообщения, последнее от %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
-msgstr "XChat: Предложен файл: %s (%s)"
+msgid "File offer from: %s (%s) - %s"
+msgstr "Предложен файл: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
-msgstr "%u предложения файлов, последнее от %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
+msgstr "%u предложения файлов, последнее от %s (%s) - %s"
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4633,8 +4633,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Выберите плагин или скрипт для загрузки"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "Скрипты и плагины - "
+msgid "Plugins and Scripts - %s"
+msgstr "Скрипты и плагины - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4655,8 +4655,8 @@ msgstr "Сохранить как..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
-msgstr "Лог без фильтрации (%s) - "
+msgid "Raw Log (%s) - %s"
+msgstr "Лог без фильтрации (%s) - %s"
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4691,8 +4691,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "Редактирование: %s - "
+msgid "Edit %s - %s"
+msgstr "Редактирование: %s - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4783,8 +4783,8 @@ msgid "Character set:"
 msgstr "Кодировка:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "Список сетей - "
+msgid "Network List - %s"
+msgstr "Список сетей - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6148,8 +6148,8 @@ msgid ""
 msgstr "*ПРЕДУПРЕЖДЕНИЕ*\nАвтоматический прием DCC в ваш домашний каталог\nможет быть опасным и создавать уязвимости. Например:\nКто-нибудь пришлет вам .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "Настройки - "
+msgid "Preferences - %s"
+msgstr "Настройки - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6213,8 +6213,8 @@ msgid "OK"
 msgstr "ОК"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "Сборщик URL - "
+msgid "URL Grabber - %s"
+msgstr "Сборщик URL - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/ru.po
+++ b/po/ru.po
@@ -3250,8 +3250,8 @@ msgstr "Список банов можно отктыть только при о
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr "X-Chat: Список банов (%s)"
+msgid "Ban List (%s) - "
+msgstr "Список банов (%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3289,8 +3289,8 @@ msgstr "Скопировать _тему общения"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr "X-Chat: Список каналов (%s)"
+msgid "Channel List (%s) - "
+msgstr "Список каналов (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3381,8 +3381,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Не могу продолжить одинаковый файл от 2 пользователей."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr "XChat: Прием и передача файлов"
+msgid "Uploads and Downloads - "
+msgstr "Прием и передача файлов - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3439,8 +3439,8 @@ msgid "Open Folder..."
 msgstr "Открыть папку..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr "XChat: Список разговоров по DCC"
+msgid "DCC Chat List - "
+msgstr "Список разговоров по DCC - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3636,8 +3636,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr "X-Chat: Клавиатурные сокращения"
+msgid "Keyboard Shortcuts - "
+msgstr "Клавиатурные сокращения - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3681,8 +3681,8 @@ msgid "Enter mask to ignore:"
 msgstr "Введите маску для игнорирования:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr "X-Chat: Черный список"
+msgid "Ignore list - "
+msgstr "Черный список - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3717,8 +3717,8 @@ msgid "Channel name too short, try again."
 msgstr "Имя канала недостаточно длинное."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr "XChat: Соединение завершено"
+msgid "Connection Complete - "
+msgstr "Соединение завершено - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4044,8 +4044,8 @@ msgid "_Auto-Connect"
 msgstr "_Автосоединение"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr "X-Chat: Пользовательское меню"
+msgid "User menu - "
+msgstr "Пользовательское меню - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4165,11 +4165,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr "X-Chat: Определенные пользователем команды"
+msgid "User Defined Commands - "
+msgstr "Определенные пользователем команды - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
+msgid "Userlist Popup menu - "
 msgstr "Всплывающее меню списка пользователей.."
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4177,24 +4177,24 @@ msgid "Replace with"
 msgstr "Заменить на"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr "X-Chat: Замена"
+msgid "Replace - "
+msgstr "Замена - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr "XChat: Обработчики URL"
+msgid "URL Handlers - "
+msgstr "Обработчики URL - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr "XChat: Кнопки списка пользователей"
+msgid "Userlist buttons - "
+msgstr "Кнопки списка пользователей - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr "XChat: Кнопки диалога"
+msgid "Dialog buttons - "
+msgstr "Кнопки диалога - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr "XChat: Ответы CTCP"
+msgid "CTCP Replies - "
+msgstr "Ответы CTCP - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4501,8 +4501,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Укажите разделенный запятыми список сетей."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
-msgstr "X-Chat: Список друзей"
+msgid "Friends List - "
+msgstr "Список друзей - "
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4540,8 +4540,8 @@ msgstr "Индивидуальное сообщение от %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
-msgstr "XChat: Подключен; сети: %u, каналы: %u"
+msgid "Connected to %u networks and %u channels - "
+msgstr "Подключен; сети: %u, каналы: %u - "
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4582,43 +4582,43 @@ msgstr "_Вернулся"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
-msgstr "XChat: Выделенное сообщение от %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
+msgstr "Выделенное сообщение от %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
-msgstr "XChat: %u выделенных сообщения, последнее от %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
+msgstr "%u выделенных сообщения, последнее от %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
-msgstr ": Канал, сообщение от %s (%s)"
+msgid "Channel message from: %s (%s) - "
+msgstr "Канал, сообщение от %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
-msgstr ": %u сообщений канала."
+msgid "%u channel messages. - "
+msgstr "%u сообщений канала. - "
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
+msgid "Private message from: %s (%s) - "
 msgstr "XChat: Личное сообщение от %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
-msgstr "XChat: %u личных сообщения, последнее от %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
+msgstr "%u личных сообщения, последнее от %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
+msgid "File offer from: %s (%s) - "
 msgstr "XChat: Предложен файл: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
-msgstr "XChat: %u предложения файлов, последнее от %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
+msgstr "%u предложения файлов, последнее от %s (%s) - "
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4633,8 +4633,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Выберите плагин или скрипт для загрузки"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr "X-Chat: Скрипты и плагины"
+msgid "Plugins and Scripts - "
+msgstr "Скрипты и плагины - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4655,8 +4655,8 @@ msgstr "Сохранить как..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
-msgstr ": Лог без фильтрации (%s)"
+msgid "Raw Log (%s) - "
+msgstr "Лог без фильтрации (%s) - "
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4691,8 +4691,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr "X-Chat: Редактирование: %s"
+msgid "Edit %s - "
+msgstr "Редактирование: %s - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4783,8 +4783,8 @@ msgid "Character set:"
 msgstr "Кодировка:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr "X-Chat: Список сетей"
+msgid "Network List - "
+msgstr "Список сетей - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6148,8 +6148,8 @@ msgid ""
 msgstr "*ПРЕДУПРЕЖДЕНИЕ*\nАвтоматический прием DCC в ваш домашний каталог\nможет быть опасным и создавать уязвимости. Например:\nКто-нибудь пришлет вам .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr "X-Chat: Настройки"
+msgid "Preferences - "
+msgstr "Настройки - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6213,8 +6213,8 @@ msgid "OK"
 msgstr "ОК"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr "X-Chat: Сборщик URL"
+msgid "URL Grabber - "
+msgstr "Сборщик URL - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/rw.po
+++ b/po/rw.po
@@ -3246,7 +3246,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
+msgid "Ban List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3285,7 +3285,7 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
+msgid "Channel List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3377,7 +3377,7 @@ msgid "Cannot resume the same file from two people."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
+msgid "Uploads and Downloads - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3435,7 +3435,7 @@ msgid "Open Folder..."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
+msgid "DCC Chat List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3632,7 +3632,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
+msgid "Keyboard Shortcuts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3677,7 +3677,7 @@ msgid "Enter mask to ignore:"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
+msgid "Ignore list - %s"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3713,7 +3713,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
+msgid "Connection Complete - %s"
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4040,7 +4040,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
+msgid "User menu - %s"
 msgstr ""
 
 #. sep
@@ -4161,11 +4161,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
+msgid "User Defined Commands - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
+msgid "Userlist Popup menu - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4173,23 +4173,23 @@ msgid "Replace with"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
+msgid "Replace - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
+msgid "URL Handlers - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
+msgid "Userlist buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
+msgid "Dialog buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
+msgid "CTCP Replies - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4497,7 +4497,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
+msgid "Friends List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4536,7 +4536,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
+msgid "Connected to %u networks and %u channels - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4578,42 +4578,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4629,7 +4629,7 @@ msgid "Select a Plugin or Script to load"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
+msgid "Plugins and Scripts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4651,7 +4651,7 @@ msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4687,7 +4687,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
+msgid "Edit %s - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4779,7 +4779,7 @@ msgid "Character set:"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
+msgid "Network List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6144,7 +6144,7 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
+msgid "Preferences - %s"
 msgstr ""
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6209,7 +6209,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
+msgid "URL Grabber - %s"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/rw.po
+++ b/po/rw.po
@@ -3246,7 +3246,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
+msgid "Ban List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3285,7 +3285,7 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
+msgid "Channel List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3377,7 +3377,7 @@ msgid "Cannot resume the same file from two people."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
+msgid "Uploads and Downloads - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3435,7 +3435,7 @@ msgid "Open Folder..."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
+msgid "DCC Chat List - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3632,7 +3632,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
+msgid "Keyboard Shortcuts - "
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3677,7 +3677,7 @@ msgid "Enter mask to ignore:"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
+msgid "Ignore list - "
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3713,7 +3713,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
+msgid "Connection Complete - "
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4040,7 +4040,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
+msgid "User menu - "
 msgstr ""
 
 #. sep
@@ -4161,11 +4161,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
+msgid "User Defined Commands - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
+msgid "Userlist Popup menu - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4173,23 +4173,23 @@ msgid "Replace with"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
+msgid "Replace - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
+msgid "URL Handlers - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
+msgid "Userlist buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
+msgid "Dialog buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
+msgid "CTCP Replies - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4497,7 +4497,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
+msgid "Friends List - "
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4536,7 +4536,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
+msgid "Connected to %u networks and %u channels - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4578,42 +4578,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
+msgid "Private message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
+msgid "File offer from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4629,7 +4629,7 @@ msgid "Select a Plugin or Script to load"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
+msgid "Plugins and Scripts - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4651,7 +4651,7 @@ msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4687,7 +4687,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
+msgid "Edit %s - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4779,7 +4779,7 @@ msgid "Character set:"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
+msgid "Network List - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6144,7 +6144,7 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
+msgid "Preferences - "
 msgstr ""
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6209,7 +6209,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
+msgid "URL Grabber - "
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/sk.po
+++ b/po/sk.po
@@ -3240,7 +3240,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
+msgid "Ban List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3279,7 +3279,7 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
+msgid "Channel List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3371,7 +3371,7 @@ msgid "Cannot resume the same file from two people."
 msgstr "Nemôžem sťahovať ten istý súbor od dvoch používateľov."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
+msgid "Uploads and Downloads - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3429,7 +3429,7 @@ msgid "Open Folder..."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
+msgid "DCC Chat List - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3626,7 +3626,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
+msgid "Keyboard Shortcuts - "
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3671,7 +3671,7 @@ msgid "Enter mask to ignore:"
 msgstr "Zadajte masku pre ignorovanie:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
+msgid "Ignore list - "
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3707,7 +3707,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
+msgid "Connection Complete - "
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4034,7 +4034,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
+msgid "User menu - "
 msgstr ""
 
 #. sep
@@ -4155,11 +4155,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
+msgid "User Defined Commands - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
+msgid "Userlist Popup menu - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4167,23 +4167,23 @@ msgid "Replace with"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
+msgid "Replace - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
+msgid "URL Handlers - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
+msgid "Userlist buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
+msgid "Dialog buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
+msgid "CTCP Replies - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4491,7 +4491,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
+msgid "Friends List - "
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4530,7 +4530,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
+msgid "Connected to %u networks and %u channels - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4572,42 +4572,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
+msgid "Private message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
+msgid "File offer from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4623,7 +4623,7 @@ msgid "Select a Plugin or Script to load"
 msgstr "Vyberte plugin alebo skript"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
+msgid "Plugins and Scripts - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4645,7 +4645,7 @@ msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4681,7 +4681,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
+msgid "Edit %s - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4773,7 +4773,7 @@ msgid "Character set:"
 msgstr "Znaková sada:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
+msgid "Network List - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6138,7 +6138,7 @@ msgid ""
 msgstr "*VAROVANIE*\nAutomatické prijatie DCC do vášho domovského\npriečinku môže byť nebezpečné. Napríklad:\nniekto by vám mohol poslať súbor .bash_profile."
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
+msgid "Preferences - "
 msgstr ""
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6203,7 +6203,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
+msgid "URL Grabber - "
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/sk.po
+++ b/po/sk.po
@@ -3240,7 +3240,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
+msgid "Ban List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3279,7 +3279,7 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
+msgid "Channel List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3371,7 +3371,7 @@ msgid "Cannot resume the same file from two people."
 msgstr "Nemôžem sťahovať ten istý súbor od dvoch používateľov."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
+msgid "Uploads and Downloads - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3429,7 +3429,7 @@ msgid "Open Folder..."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
+msgid "DCC Chat List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3626,7 +3626,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
+msgid "Keyboard Shortcuts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3671,7 +3671,7 @@ msgid "Enter mask to ignore:"
 msgstr "Zadajte masku pre ignorovanie:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
+msgid "Ignore list - %s"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3707,7 +3707,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
+msgid "Connection Complete - %s"
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4034,7 +4034,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
+msgid "User menu - %s"
 msgstr ""
 
 #. sep
@@ -4155,11 +4155,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
+msgid "User Defined Commands - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
+msgid "Userlist Popup menu - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4167,23 +4167,23 @@ msgid "Replace with"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
+msgid "Replace - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
+msgid "URL Handlers - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
+msgid "Userlist buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
+msgid "Dialog buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
+msgid "CTCP Replies - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4491,7 +4491,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
+msgid "Friends List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4530,7 +4530,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
+msgid "Connected to %u networks and %u channels - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4572,42 +4572,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4623,7 +4623,7 @@ msgid "Select a Plugin or Script to load"
 msgstr "Vyberte plugin alebo skript"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
+msgid "Plugins and Scripts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4645,7 +4645,7 @@ msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4681,7 +4681,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
+msgid "Edit %s - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4773,7 +4773,7 @@ msgid "Character set:"
 msgstr "Znaková sada:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
+msgid "Network List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6138,7 +6138,7 @@ msgid ""
 msgstr "*VAROVANIE*\nAutomatické prijatie DCC do vášho domovského\npriečinku môže byť nebezpečné. Napríklad:\nniekto by vám mohol poslať súbor .bash_profile."
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
+msgid "Preferences - %s"
 msgstr ""
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6203,7 +6203,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
+msgid "URL Grabber - %s"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/sl.po
+++ b/po/sl.po
@@ -3241,7 +3241,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
+msgid "Ban List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3280,7 +3280,7 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
+msgid "Channel List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3372,7 +3372,7 @@ msgid "Cannot resume the same file from two people."
 msgstr "Ne morem nadaljevati datoteke od dveh ljudi."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
+msgid "Uploads and Downloads - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3430,7 +3430,7 @@ msgid "Open Folder..."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
+msgid "DCC Chat List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3627,7 +3627,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
+msgid "Keyboard Shortcuts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3672,7 +3672,7 @@ msgid "Enter mask to ignore:"
 msgstr "Vnesite masko za preziranje:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
+msgid "Ignore list - %s"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3708,7 +3708,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
+msgid "Connection Complete - %s"
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4035,7 +4035,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
+msgid "User menu - %s"
 msgstr ""
 
 #. sep
@@ -4156,11 +4156,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
+msgid "User Defined Commands - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
+msgid "Userlist Popup menu - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4168,23 +4168,23 @@ msgid "Replace with"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
+msgid "Replace - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
+msgid "URL Handlers - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
+msgid "Userlist buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
+msgid "Dialog buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
+msgid "CTCP Replies - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4492,7 +4492,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
+msgid "Friends List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4531,7 +4531,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
+msgid "Connected to %u networks and %u channels - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4573,42 +4573,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4624,7 +4624,7 @@ msgid "Select a Plugin or Script to load"
 msgstr "Izberite dodatek ali skripto za zagon"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
+msgid "Plugins and Scripts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4646,7 +4646,7 @@ msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4682,7 +4682,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
+msgid "Edit %s - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4774,7 +4774,7 @@ msgid "Character set:"
 msgstr "Kodni nabor:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
+msgid "Network List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6139,7 +6139,7 @@ msgid ""
 msgstr "*OPOZORILO*\nSamodejno prejemanje DCC-jev v vaš domač imenik\nje lahko zelo nevarno. Nekdo vam lahko pošlje npr.\n.bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
+msgid "Preferences - %s"
 msgstr ""
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6204,7 +6204,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
+msgid "URL Grabber - %s"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/sl.po
+++ b/po/sl.po
@@ -3241,7 +3241,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
+msgid "Ban List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3280,7 +3280,7 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
+msgid "Channel List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3372,7 +3372,7 @@ msgid "Cannot resume the same file from two people."
 msgstr "Ne morem nadaljevati datoteke od dveh ljudi."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
+msgid "Uploads and Downloads - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3430,7 +3430,7 @@ msgid "Open Folder..."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
+msgid "DCC Chat List - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3627,7 +3627,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
+msgid "Keyboard Shortcuts - "
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3672,7 +3672,7 @@ msgid "Enter mask to ignore:"
 msgstr "Vnesite masko za preziranje:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
+msgid "Ignore list - "
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3708,7 +3708,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
+msgid "Connection Complete - "
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4035,7 +4035,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
+msgid "User menu - "
 msgstr ""
 
 #. sep
@@ -4156,11 +4156,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
+msgid "User Defined Commands - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
+msgid "Userlist Popup menu - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4168,23 +4168,23 @@ msgid "Replace with"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
+msgid "Replace - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
+msgid "URL Handlers - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
+msgid "Userlist buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
+msgid "Dialog buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
+msgid "CTCP Replies - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4492,7 +4492,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
+msgid "Friends List - "
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4531,7 +4531,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
+msgid "Connected to %u networks and %u channels - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4573,42 +4573,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
+msgid "Private message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
+msgid "File offer from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4624,7 +4624,7 @@ msgid "Select a Plugin or Script to load"
 msgstr "Izberite dodatek ali skripto za zagon"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
+msgid "Plugins and Scripts - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4646,7 +4646,7 @@ msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4682,7 +4682,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
+msgid "Edit %s - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4774,7 +4774,7 @@ msgid "Character set:"
 msgstr "Kodni nabor:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
+msgid "Network List - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6139,7 +6139,7 @@ msgid ""
 msgstr "*OPOZORILO*\nSamodejno prejemanje DCC-jev v vaš domač imenik\nje lahko zelo nevarno. Nekdo vam lahko pošlje npr.\n.bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
+msgid "Preferences - "
 msgstr ""
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6204,7 +6204,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
+msgid "URL Grabber - "
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/sq.po
+++ b/po/sq.po
@@ -3241,8 +3241,8 @@ msgstr "Dritaren e Listës së Dëbimeve mundeni ta hapni vetëm kur jeni në nj
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr ": Listë Dëbimesh (%s)"
+msgid "Ban List (%s) - "
+msgstr "Listë Dëbimesh (%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3280,8 +3280,8 @@ msgstr "Kopjo Tekst _Teme"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr ": Listë Kanalesh (%s)"
+msgid "Channel List (%s) - "
+msgstr "Listë Kanalesh (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3372,8 +3372,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Nuk mund të rimerret e njëjta kartelë prej dy personash."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr ": Ngarkime dhe Shkarkime"
+msgid "Uploads and Downloads - "
+msgstr "Ngarkime dhe Shkarkime - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3430,8 +3430,8 @@ msgid "Open Folder..."
 msgstr "Hapni Dosje..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr ": Listë Fjalosjeje DCC"
+msgid "DCC Chat List - "
+msgstr "Listë Fjalosjeje DCC - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3627,8 +3627,8 @@ msgid "Select a row to get help information on its Action."
 msgstr "Përzgjidhni një rresht që të merrni të dhëna ndihme mbi Veprimin e tij."
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr ": Shkurtore Tastiere"
+msgid "Keyboard Shortcuts - "
+msgstr "Shkurtore Tastiere - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3672,8 +3672,8 @@ msgid "Enter mask to ignore:"
 msgstr "Jepni maskë që do të shpërfillet:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr ": Listë shpërfilljesh"
+msgid "Ignore list - "
+msgstr "Listë shpërfilljesh - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3708,8 +3708,8 @@ msgid "Channel name too short, try again."
 msgstr "Emër kanali shumë i shkurtër, riprovoni."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr ": Lidhje e Plotë"
+msgid "Connection Complete - "
+msgstr "Lidhje e Plotë - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4035,8 +4035,8 @@ msgid "_Auto-Connect"
 msgstr "_Vetëlidhu"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr ": Menu përdoruesi"
+msgid "User menu - "
+msgstr "Menu përdoruesi - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4156,36 +4156,36 @@ msgid ""
 msgstr "Trajtues URL-sh - Kode speciale:\n\n%s  =  Vargu URL\n\nVendosja e një ! në fillim të urdhrit\ntregon që do të duhej dërguar te\nnjë shell, në vend se për HexChat-in"
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr ": Urdhra të Përcaktuar nga Përdoruesi"
+msgid "User Defined Commands - "
+msgstr "Urdhra të Përcaktuar nga Përdoruesi - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr ": Menu flluskë Liste Përdoruesish"
+msgid "Userlist Popup menu - "
+msgstr "Menu flluskë Liste Përdoruesish - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Zëvendësoje me"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr ": Zëvendësoje"
+msgid "Replace - "
+msgstr "Zëvendësoje - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr ": Trajtues URL-sh"
+msgid "URL Handlers - "
+msgstr "Trajtues URL-sh - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr ": Butona liste përdoruesish"
+msgid "Userlist buttons - "
+msgstr "Butona liste përdoruesish - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr ": Butona dialogu"
+msgid "Dialog buttons - "
+msgstr "Butona dialogu - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr ": Përgjigje CTCP"
+msgid "CTCP Replies - "
+msgstr "Përgjigje CTCP - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4492,8 +4492,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Pranohet listë rrjetesh ndarë me presje."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
-msgstr ": Listë Shokësh"
+msgid "Friends List - "
+msgstr "Listë Shokësh - "
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4531,8 +4531,8 @@ msgstr "Mesazh vetjak nga: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
-msgstr ": I lidhur me %u rrjete dhe %u kanale"
+msgid "Connected to %u networks and %u channels - "
+msgstr "I lidhur me %u rrjete dhe %u kanale - "
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4573,43 +4573,43 @@ msgstr "I _kthyer"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
-msgstr ": Mesazh i theksuar prej: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
+msgstr "Mesazh i theksuar prej: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
-msgstr ": %u mesazhe të theksuar, i fundit prej: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
+msgstr "%u mesazhe të theksuar, i fundit prej: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
-msgstr ": Mesazh kanali nga: %s (%s)"
+msgid "Channel message from: %s (%s) - "
+msgstr "Mesazh kanali nga: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
-msgstr ": mesazhe kanali %u."
+msgid "%u channel messages. - "
+msgstr "mesazhe kanali %u. - "
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
-msgstr ": Mesazh vetjak prej: %s (%s)"
+msgid "Private message from: %s (%s) - "
+msgstr "Mesazh vetjak prej: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
-msgstr ": %u mesazhe vetjakë, i fundit prej: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
+msgstr "%u mesazhe vetjakë, i fundit prej: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
-msgstr ": Ofertë kartele prej: %s (%s)"
+msgid "File offer from: %s (%s) - "
+msgstr "Ofertë kartele prej: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
-msgstr ": %u oferta kartelash, e fundit prej: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
+msgstr "%u oferta kartelash, e fundit prej: %s (%s) - "
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4624,8 +4624,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Përzgjidhni Shtojcë ose Programth për t’u ngarkuar"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr ": Shtojca dhe Programthe"
+msgid "Plugins and Scripts - "
+msgstr "Shtojca dhe Programthe - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4646,8 +4646,8 @@ msgstr "Ruajeni Si..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
-msgstr ": Regjistër të Papërpunuarash (%s)"
+msgid "Raw Log (%s) - "
+msgstr "Regjistër të Papërpunuarash (%s) - "
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4682,8 +4682,8 @@ msgstr "Mënyra se si identifikoni veten kundrejt shërbyesit. Për metoda të p
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr ": Përpuno %s"
+msgid "Edit %s - "
+msgstr "Përpuno %s - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4774,8 +4774,8 @@ msgid "Character set:"
 msgstr "Shkronja:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr ": Listë Rrjetesh"
+msgid "Network List - "
+msgstr "Listë Rrjetesh - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6139,8 +6139,8 @@ msgid ""
 msgstr "*KUJDES*\nVetëpranimi i DCC-së në drejtorinë tuaj shtëpi\nmund të jetë i rrezikshëm dhe është i shfrytëzueshëm. P.sh:\nDikush mund t’ju dërgojë një .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr ": Parapëlqime"
+msgid "Preferences - "
+msgstr "Parapëlqime - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6204,8 +6204,8 @@ msgid "OK"
 msgstr "OK"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr ": Kopjues URL-sh"
+msgid "URL Grabber - "
+msgstr "Kopjues URL-sh - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/sq.po
+++ b/po/sq.po
@@ -3241,8 +3241,8 @@ msgstr "Dritaren e Listës së Dëbimeve mundeni ta hapni vetëm kur jeni në nj
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "Listë Dëbimesh (%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "Listë Dëbimesh (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3280,8 +3280,8 @@ msgstr "Kopjo Tekst _Teme"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr "Listë Kanalesh (%s) - "
+msgid "Channel List (%s) - %s"
+msgstr "Listë Kanalesh (%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3372,8 +3372,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Nuk mund të rimerret e njëjta kartelë prej dy personash."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "Ngarkime dhe Shkarkime - "
+msgid "Uploads and Downloads - %s"
+msgstr "Ngarkime dhe Shkarkime - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3430,8 +3430,8 @@ msgid "Open Folder..."
 msgstr "Hapni Dosje..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "Listë Fjalosjeje DCC - "
+msgid "DCC Chat List - %s"
+msgstr "Listë Fjalosjeje DCC - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3627,8 +3627,8 @@ msgid "Select a row to get help information on its Action."
 msgstr "Përzgjidhni një rresht që të merrni të dhëna ndihme mbi Veprimin e tij."
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "Shkurtore Tastiere - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "Shkurtore Tastiere - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3672,8 +3672,8 @@ msgid "Enter mask to ignore:"
 msgstr "Jepni maskë që do të shpërfillet:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "Listë shpërfilljesh - "
+msgid "Ignore list - %s"
+msgstr "Listë shpërfilljesh - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3708,8 +3708,8 @@ msgid "Channel name too short, try again."
 msgstr "Emër kanali shumë i shkurtër, riprovoni."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "Lidhje e Plotë - "
+msgid "Connection Complete - %s"
+msgstr "Lidhje e Plotë - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4035,8 +4035,8 @@ msgid "_Auto-Connect"
 msgstr "_Vetëlidhu"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "Menu përdoruesi - "
+msgid "User menu - %s"
+msgstr "Menu përdoruesi - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4156,36 +4156,36 @@ msgid ""
 msgstr "Trajtues URL-sh - Kode speciale:\n\n%s  =  Vargu URL\n\nVendosja e një ! në fillim të urdhrit\ntregon që do të duhej dërguar te\nnjë shell, në vend se për HexChat-in"
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "Urdhra të Përcaktuar nga Përdoruesi - "
+msgid "User Defined Commands - %s"
+msgstr "Urdhra të Përcaktuar nga Përdoruesi - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "Menu flluskë Liste Përdoruesish - "
+msgid "Userlist Popup menu - %s"
+msgstr "Menu flluskë Liste Përdoruesish - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Zëvendësoje me"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "Zëvendësoje - "
+msgid "Replace - %s"
+msgstr "Zëvendësoje - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "Trajtues URL-sh - "
+msgid "URL Handlers - %s"
+msgstr "Trajtues URL-sh - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "Butona liste përdoruesish - "
+msgid "Userlist buttons - %s"
+msgstr "Butona liste përdoruesish - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "Butona dialogu - "
+msgid "Dialog buttons - %s"
+msgstr "Butona dialogu - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "Përgjigje CTCP - "
+msgid "CTCP Replies - %s"
+msgstr "Përgjigje CTCP - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4492,8 +4492,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Pranohet listë rrjetesh ndarë me presje."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
-msgstr "Listë Shokësh - "
+msgid "Friends List - %s"
+msgstr "Listë Shokësh - %s"
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4531,8 +4531,8 @@ msgstr "Mesazh vetjak nga: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
-msgstr "I lidhur me %u rrjete dhe %u kanale - "
+msgid "Connected to %u networks and %u channels - %s"
+msgstr "I lidhur me %u rrjete dhe %u kanale - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4573,43 +4573,43 @@ msgstr "I _kthyer"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
-msgstr "Mesazh i theksuar prej: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
+msgstr "Mesazh i theksuar prej: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
-msgstr "%u mesazhe të theksuar, i fundit prej: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
+msgstr "%u mesazhe të theksuar, i fundit prej: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
-msgstr "Mesazh kanali nga: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
+msgstr "Mesazh kanali nga: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
-msgstr "mesazhe kanali %u. - "
+msgid "%u channel messages. - %s"
+msgstr "mesazhe kanali %u. - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
-msgstr "Mesazh vetjak prej: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
+msgstr "Mesazh vetjak prej: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
-msgstr "%u mesazhe vetjakë, i fundit prej: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
+msgstr "%u mesazhe vetjakë, i fundit prej: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
-msgstr "Ofertë kartele prej: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
+msgstr "Ofertë kartele prej: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
-msgstr "%u oferta kartelash, e fundit prej: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
+msgstr "%u oferta kartelash, e fundit prej: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4624,8 +4624,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Përzgjidhni Shtojcë ose Programth për t’u ngarkuar"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "Shtojca dhe Programthe - "
+msgid "Plugins and Scripts - %s"
+msgstr "Shtojca dhe Programthe - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4646,8 +4646,8 @@ msgstr "Ruajeni Si..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
-msgstr "Regjistër të Papërpunuarash (%s) - "
+msgid "Raw Log (%s) - %s"
+msgstr "Regjistër të Papërpunuarash (%s) - %s"
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4682,8 +4682,8 @@ msgstr "Mënyra se si identifikoni veten kundrejt shërbyesit. Për metoda të p
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "Përpuno %s - "
+msgid "Edit %s - %s"
+msgstr "Përpuno %s - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4774,8 +4774,8 @@ msgid "Character set:"
 msgstr "Shkronja:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "Listë Rrjetesh - "
+msgid "Network List - %s"
+msgstr "Listë Rrjetesh - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6139,8 +6139,8 @@ msgid ""
 msgstr "*KUJDES*\nVetëpranimi i DCC-së në drejtorinë tuaj shtëpi\nmund të jetë i rrezikshëm dhe është i shfrytëzueshëm. P.sh:\nDikush mund t’ju dërgojë një .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "Parapëlqime - "
+msgid "Preferences - %s"
+msgstr "Parapëlqime - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6204,8 +6204,8 @@ msgid "OK"
 msgstr "OK"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "Kopjues URL-sh - "
+msgid "URL Grabber - %s"
+msgstr "Kopjues URL-sh - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/sr.po
+++ b/po/sr.po
@@ -3240,8 +3240,8 @@ msgstr "Списак ућутканих се може отворити само 
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "Списак забрана (%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "Списак забрана (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3279,8 +3279,8 @@ msgstr "Копирај текст _теме"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr "списак канала (%s) - "
+msgid "Channel List (%s) - %s"
+msgstr "списак канала (%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3371,8 +3371,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Не може се наставити пренос исте датотеке од две различите особе."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "Отрпемања и преузимања - "
+msgid "Uploads and Downloads - %s"
+msgstr "Отрпемања и преузимања - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3429,8 +3429,8 @@ msgid "Open Folder..."
 msgstr "Отвори директоријум..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "DCC списак разговора - "
+msgid "DCC Chat List - %s"
+msgstr "DCC списак разговора - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3626,8 +3626,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "Скраћенице с тастатуре - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "Скраћенице с тастатуре - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3671,8 +3671,8 @@ msgid "Enter mask to ignore:"
 msgstr "Унеси шаблон за ућуткивање"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "Списак ућутканих - "
+msgid "Ignore list - %s"
+msgstr "Списак ућутканих - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3707,8 +3707,8 @@ msgid "Channel name too short, try again."
 msgstr "Име канала је прекратко, пробајте поново."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "Повезивање је успело - "
+msgid "Connection Complete - %s"
+msgstr "Повезивање је успело - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4034,8 +4034,8 @@ msgid "_Auto-Connect"
 msgstr "_Аутоматска конекција"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "Корисников мени - "
+msgid "User menu - %s"
+msgstr "Корисников мени - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4155,36 +4155,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "Корисникове команде - "
+msgid "User Defined Commands - %s"
+msgstr "Корисникове команде - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "Појавни мени из списка корисника - "
+msgid "Userlist Popup menu - %s"
+msgstr "Појавни мени из списка корисника - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Замени са"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "Замени - "
+msgid "Replace - %s"
+msgstr "Замени - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "Обрада URLова - "
+msgid "URL Handlers - %s"
+msgstr "Обрада URLова - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "Корисничка дугмета - "
+msgid "Userlist buttons - %s"
+msgstr "Корисничка дугмета - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "Дугмета у прозорчету - "
+msgid "Dialog buttons - %s"
+msgstr "Дугмета у прозорчету - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "Одговори на CTCP упите - "
+msgid "CTCP Replies - %s"
+msgstr "Одговори на CTCP упите - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4491,8 +4491,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Листа мрежа раздвојена зарезима је дозвољена."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
-msgstr "Листа пријатеља - "
+msgid "Friends List - %s"
+msgstr "Листа пријатеља - %s"
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4530,8 +4530,8 @@ msgstr "Приватна порука од: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
-msgstr "Повезани сте на %u мрежа и %u канала - "
+msgid "Connected to %u networks and %u channels - %s"
+msgstr "Повезани сте на %u мрежа и %u канала - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4572,43 +4572,43 @@ msgstr "_Назад"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
-msgstr "Истакнута порука од: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
+msgstr "Истакнута порука од: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
-msgstr "%u истакнутих порука, последња од: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
+msgstr "%u истакнутих порука, последња од: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
-msgstr "Порука на каналу од: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
+msgstr "Порука на каналу од: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
-msgstr "%u порука на каналу. - "
+msgid "%u channel messages. - %s"
+msgstr "%u порука на каналу. - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
-msgstr "Приватна порука од: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
+msgstr "Приватна порука од: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
-msgstr "%u приватних порука, последња од: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
+msgstr "%u приватних порука, последња од: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
-msgstr "Понуда датотека од: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
+msgstr "Понуда датотека од: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
-msgstr "%u понуда датотека, последња од: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
+msgstr "%u понуда датотека, последња од: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4623,8 +4623,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Избор додатка или скрипта за учитавање"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "Додаци и скриптови - "
+msgid "Plugins and Scripts - %s"
+msgstr "Додаци и скриптови - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4645,8 +4645,8 @@ msgstr "Сачувај као..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
-msgstr "Сирови дневник (%s) - "
+msgid "Raw Log (%s) - %s"
+msgstr "Сирови дневник (%s) - %s"
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4681,8 +4681,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "Уреди %s - "
+msgid "Edit %s - %s"
+msgstr "Уреди %s - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4773,8 +4773,8 @@ msgid "Character set:"
 msgstr "Скуп знакова:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "списак мрежа - "
+msgid "Network List - %s"
+msgstr "списак мрежа - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6138,8 +6138,8 @@ msgid ""
 msgstr "*УПОЗОРЕЊЕ*\nАутоматско прихватање DCC захтева у кућном\nдиректоријуму је опасно и може се искористити.\nНпр. неко може послати датотеку .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "Поставке - "
+msgid "Preferences - %s"
+msgstr "Поставке - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6203,8 +6203,8 @@ msgid "OK"
 msgstr "У реду"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "Преписивање URLова - "
+msgid "URL Grabber - %s"
+msgstr "Преписивање URLова - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/sr.po
+++ b/po/sr.po
@@ -3240,8 +3240,8 @@ msgstr "Списак ућутканих се може отворити само 
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr "Иксчет: Списак забрана (%s)"
+msgid "Ban List (%s) - "
+msgstr "Списак забрана (%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3279,8 +3279,8 @@ msgstr "Копирај текст _теме"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr "Иксчет: списак канала (%s)"
+msgid "Channel List (%s) - "
+msgstr "списак канала (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3371,8 +3371,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Не може се наставити пренос исте датотеке од две различите особе."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr ": Отрпемања и преузимања"
+msgid "Uploads and Downloads - "
+msgstr "Отрпемања и преузимања - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3429,8 +3429,8 @@ msgid "Open Folder..."
 msgstr "Отвори директоријум..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr "Иксчет: DCC списак разговора"
+msgid "DCC Chat List - "
+msgstr "DCC списак разговора - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3626,8 +3626,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr "Иксчет: Скраћенице с тастатуре"
+msgid "Keyboard Shortcuts - "
+msgstr "Скраћенице с тастатуре - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3671,8 +3671,8 @@ msgid "Enter mask to ignore:"
 msgstr "Унеси шаблон за ућуткивање"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr "Иксчет: Списак ућутканих"
+msgid "Ignore list - "
+msgstr "Списак ућутканих - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3707,8 +3707,8 @@ msgid "Channel name too short, try again."
 msgstr "Име канала је прекратко, пробајте поново."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr "Иксчет: Повезивање је успело"
+msgid "Connection Complete - "
+msgstr "Повезивање је успело - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4034,8 +4034,8 @@ msgid "_Auto-Connect"
 msgstr "_Аутоматска конекција"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr "Иксчет: Корисников мени"
+msgid "User menu - "
+msgstr "Корисников мени - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4155,36 +4155,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr "Иксчет: Корисникове команде"
+msgid "User Defined Commands - "
+msgstr "Корисникове команде - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr "Иксчет: Појавни мени из списка корисника"
+msgid "Userlist Popup menu - "
+msgstr "Појавни мени из списка корисника - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Замени са"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr "Иксчет: Замени"
+msgid "Replace - "
+msgstr "Замени - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr "Иксчет: Обрада URLова"
+msgid "URL Handlers - "
+msgstr "Обрада URLова - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr "Иксчет: Корисничка дугмета"
+msgid "Userlist buttons - "
+msgstr "Корисничка дугмета - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr "Иксчет: Дугмета у прозорчету"
+msgid "Dialog buttons - "
+msgstr "Дугмета у прозорчету - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr "Иксчет: Одговори на CTCP упите"
+msgid "CTCP Replies - "
+msgstr "Одговори на CTCP упите - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4491,8 +4491,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Листа мрежа раздвојена зарезима је дозвољена."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
-msgstr ": Листа пријатеља"
+msgid "Friends List - "
+msgstr "Листа пријатеља - "
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4530,8 +4530,8 @@ msgstr "Приватна порука од: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
-msgstr ": Повезани сте на %u мрежа и %u канала"
+msgid "Connected to %u networks and %u channels - "
+msgstr "Повезани сте на %u мрежа и %u канала - "
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4572,43 +4572,43 @@ msgstr "_Назад"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
-msgstr ": Истакнута порука од: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
+msgstr "Истакнута порука од: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
-msgstr ": %u истакнутих порука, последња од: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
+msgstr "%u истакнутих порука, последња од: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
-msgstr ": Порука на каналу од: %s (%s)"
+msgid "Channel message from: %s (%s) - "
+msgstr "Порука на каналу од: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
-msgstr ": %u порука на каналу."
+msgid "%u channel messages. - "
+msgstr "%u порука на каналу. - "
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
-msgstr ": Приватна порука од: %s (%s)"
+msgid "Private message from: %s (%s) - "
+msgstr "Приватна порука од: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
-msgstr ": %u приватних порука, последња од: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
+msgstr "%u приватних порука, последња од: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
-msgstr ": Понуда датотека од: %s (%s)"
+msgid "File offer from: %s (%s) - "
+msgstr "Понуда датотека од: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
-msgstr ": %u понуда датотека, последња од: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
+msgstr "%u понуда датотека, последња од: %s (%s) - "
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4623,8 +4623,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Избор додатка или скрипта за учитавање"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr "Иксчет: Додаци и скриптови"
+msgid "Plugins and Scripts - "
+msgstr "Додаци и скриптови - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4645,8 +4645,8 @@ msgstr "Сачувај као..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
-msgstr ": Сирови дневник (%s)"
+msgid "Raw Log (%s) - "
+msgstr "Сирови дневник (%s) - "
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4681,8 +4681,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr "Иксчет: Уреди %s"
+msgid "Edit %s - "
+msgstr "Уреди %s - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4773,8 +4773,8 @@ msgid "Character set:"
 msgstr "Скуп знакова:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr "Иксчет: списак мрежа"
+msgid "Network List - "
+msgstr "списак мрежа - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6138,8 +6138,8 @@ msgid ""
 msgstr "*УПОЗОРЕЊЕ*\nАутоматско прихватање DCC захтева у кућном\nдиректоријуму је опасно и може се искористити.\nНпр. неко може послати датотеку .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr "Иксчет: Поставке"
+msgid "Preferences - "
+msgstr "Поставке - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6203,8 +6203,8 @@ msgid "OK"
 msgstr "У реду"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr "Иксчет: Преписивање URLова"
+msgid "URL Grabber - "
+msgstr "Преписивање URLова - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -3240,8 +3240,8 @@ msgstr "Spisak ućutkanih se može otvoriti samo ako je otvoren jezičak za prik
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "Spisak zabrana (%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "Spisak zabrana (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3279,8 +3279,8 @@ msgstr "Kopiraj tekst _teme"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr "spisak kanala (%s) - "
+msgid "Channel List (%s) - %s"
+msgstr "spisak kanala (%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3371,8 +3371,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Ne može se nastaviti prenos iste datoteke od dve različite osobe."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "Otrpemanja i preuzimanja - "
+msgid "Uploads and Downloads - %s"
+msgstr "Otrpemanja i preuzimanja - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3429,8 +3429,8 @@ msgid "Open Folder..."
 msgstr "Otvori direktorijum..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr " DCC spisak razgovora - "
+msgid "DCC Chat List - %s"
+msgstr "DCC spisak razgovora - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3626,8 +3626,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "Skraćenice s tastature - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "Skraćenice s tastature - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3671,8 +3671,8 @@ msgid "Enter mask to ignore:"
 msgstr "Unesi šablon za ućutkivanje"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "Spisak ućutkanih - "
+msgid "Ignore list - %s"
+msgstr "Spisak ućutkanih - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3707,8 +3707,8 @@ msgid "Channel name too short, try again."
 msgstr "Ime kanala je prekratko, probajte ponovo."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "Povezivanje je uspelo - "
+msgid "Connection Complete - %s"
+msgstr "Povezivanje je uspelo - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4034,8 +4034,8 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "Korisnikov meni - "
+msgid "User menu - %s"
+msgstr "Korisnikov meni - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4155,36 +4155,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "Korisnikove komande - "
+msgid "User Defined Commands - %s"
+msgstr "Korisnikove komande - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "Pojavni meni iz spiska korisnika - "
+msgid "Userlist Popup menu - %s"
+msgstr "Pojavni meni iz spiska korisnika - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Zameni sa"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "Zameni - "
+msgid "Replace - %s"
+msgstr "Zameni - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "Obrada URLova - "
+msgid "URL Handlers - %s"
+msgstr "Obrada URLova - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "Korisnička dugmeta - "
+msgid "Userlist buttons - %s"
+msgstr "Korisnička dugmeta - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "Dugmeta u prozorčetu - "
+msgid "Dialog buttons - %s"
+msgstr "Dugmeta u prozorčetu - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "Odgovori na CTCP upite - "
+msgid "CTCP Replies - %s"
+msgstr "Odgovori na CTCP upite - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4491,8 +4491,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Lista mreža razdvojena zarezima je dozvoljena."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
-msgstr "Lista prijatelja - "
+msgid "Friends List - %s"
+msgstr "Lista prijatelja - %s"
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4530,8 +4530,8 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
-msgstr "Povezani ste na %u mreža i %u kanala - "
+msgid "Connected to %u networks and %u channels - %s"
+msgstr "Povezani ste na %u mreža i %u kanala - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4572,43 +4572,43 @@ msgstr "_Nazad"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
-msgstr "Istaknuta poruka od: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
+msgstr "Istaknuta poruka od: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
-msgstr "%u istaknutih poruka, poslednja od: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
+msgstr "%u istaknutih poruka, poslednja od: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
-msgstr "Privatna poruka od: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
+msgstr "Privatna poruka od: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
-msgstr "%u privatnih poruka, poslednja od: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
+msgstr "%u privatnih poruka, poslednja od: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
-msgstr "Ponuda datoteka od: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
+msgstr "Ponuda datoteka od: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
-msgstr "%u ponuda datoteka, poslednja od: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
+msgstr "%u ponuda datoteka, poslednja od: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4623,8 +4623,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Izbor dodatka ili skripta za učitavanje"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "Dodaci i skriptovi - "
+msgid "Plugins and Scripts - %s"
+msgstr "Dodaci i skriptovi - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4645,8 +4645,8 @@ msgstr "Sačuvaj kao..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
-msgstr "Sirovi dnevnik (%s) - "
+msgid "Raw Log (%s) - %s"
+msgstr "Sirovi dnevnik (%s) - %s"
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4681,8 +4681,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "Uredi %s - "
+msgid "Edit %s - %s"
+msgstr "Uredi %s - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4773,8 +4773,8 @@ msgid "Character set:"
 msgstr "Skup znakova:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "spisak mreža - "
+msgid "Network List - %s"
+msgstr "spisak mreža - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6138,8 +6138,8 @@ msgid ""
 msgstr "*UPOZORENJE*\nAutomatsko prihvatanje DCC zahteva u kućnom\ndirektorijumu je opasno i može se iskoristiti.\nNpr. neko može poslati datoteku .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "Postavke - "
+msgid "Preferences - %s"
+msgstr "Postavke - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6203,8 +6203,8 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "Prepisivanje URLova - "
+msgid "URL Grabber - %s"
+msgstr "Prepisivanje URLova - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -3240,8 +3240,8 @@ msgstr "Spisak ućutkanih se može otvoriti samo ako je otvoren jezičak za prik
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr "Iksčet: Spisak zabrana (%s)"
+msgid "Ban List (%s) - "
+msgstr "Spisak zabrana (%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3279,8 +3279,8 @@ msgstr "Kopiraj tekst _teme"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr "Iksčet: spisak kanala (%s)"
+msgid "Channel List (%s) - "
+msgstr "spisak kanala (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3371,8 +3371,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Ne može se nastaviti prenos iste datoteke od dve različite osobe."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr ": Otrpemanja i preuzimanja"
+msgid "Uploads and Downloads - "
+msgstr "Otrpemanja i preuzimanja - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3429,8 +3429,8 @@ msgid "Open Folder..."
 msgstr "Otvori direktorijum..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr "Iksčet: DCC spisak razgovora"
+msgid "DCC Chat List - "
+msgstr " DCC spisak razgovora - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3626,8 +3626,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr "Iksčet: Skraćenice s tastature"
+msgid "Keyboard Shortcuts - "
+msgstr "Skraćenice s tastature - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3671,8 +3671,8 @@ msgid "Enter mask to ignore:"
 msgstr "Unesi šablon za ućutkivanje"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr "Iksčet: Spisak ućutkanih"
+msgid "Ignore list - "
+msgstr "Spisak ućutkanih - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3707,8 +3707,8 @@ msgid "Channel name too short, try again."
 msgstr "Ime kanala je prekratko, probajte ponovo."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr "Iksčet: Povezivanje je uspelo"
+msgid "Connection Complete - "
+msgstr "Povezivanje je uspelo - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4034,8 +4034,8 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr "Iksčet: Korisnikov meni"
+msgid "User menu - "
+msgstr "Korisnikov meni - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4155,36 +4155,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr "Iksčet: Korisnikove komande"
+msgid "User Defined Commands - "
+msgstr "Korisnikove komande - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr "Iksčet: Pojavni meni iz spiska korisnika"
+msgid "Userlist Popup menu - "
+msgstr "Pojavni meni iz spiska korisnika - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Zameni sa"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr "Iksčet: Zameni"
+msgid "Replace - "
+msgstr "Zameni - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr "Iksčet: Obrada URLova"
+msgid "URL Handlers - "
+msgstr "Obrada URLova - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr "Iksčet: Korisnička dugmeta"
+msgid "Userlist buttons - "
+msgstr "Korisnička dugmeta - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr "Iksčet: Dugmeta u prozorčetu"
+msgid "Dialog buttons - "
+msgstr "Dugmeta u prozorčetu - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr "Iksčet: Odgovori na CTCP upite"
+msgid "CTCP Replies - "
+msgstr "Odgovori na CTCP upite - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4491,8 +4491,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Lista mreža razdvojena zarezima je dozvoljena."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
-msgstr ": Lista prijatelja"
+msgid "Friends List - "
+msgstr "Lista prijatelja - "
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4530,8 +4530,8 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
-msgstr ": Povezani ste na %u mreža i %u kanala"
+msgid "Connected to %u networks and %u channels - "
+msgstr "Povezani ste na %u mreža i %u kanala - "
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4572,43 +4572,43 @@ msgstr "_Nazad"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
-msgstr ": Istaknuta poruka od: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
+msgstr "Istaknuta poruka od: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
-msgstr ": %u istaknutih poruka, poslednja od: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
+msgstr "%u istaknutih poruka, poslednja od: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
-msgstr ": Privatna poruka od: %s (%s)"
+msgid "Private message from: %s (%s) - "
+msgstr "Privatna poruka od: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
-msgstr ": %u privatnih poruka, poslednja od: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
+msgstr "%u privatnih poruka, poslednja od: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
-msgstr ": Ponuda datoteka od: %s (%s)"
+msgid "File offer from: %s (%s) - "
+msgstr "Ponuda datoteka od: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
-msgstr ": %u ponuda datoteka, poslednja od: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
+msgstr "%u ponuda datoteka, poslednja od: %s (%s) - "
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4623,8 +4623,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Izbor dodatka ili skripta za učitavanje"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr "Iksčet: Dodaci i skriptovi"
+msgid "Plugins and Scripts - "
+msgstr "Dodaci i skriptovi - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4645,8 +4645,8 @@ msgstr "Sačuvaj kao..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
-msgstr ": Sirovi dnevnik (%s)"
+msgid "Raw Log (%s) - "
+msgstr "Sirovi dnevnik (%s) - "
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4681,8 +4681,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr "Iksčet: Uredi %s"
+msgid "Edit %s - "
+msgstr "Uredi %s - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4773,8 +4773,8 @@ msgid "Character set:"
 msgstr "Skup znakova:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr "Iksčet: spisak mreža"
+msgid "Network List - "
+msgstr "spisak mreža - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6138,8 +6138,8 @@ msgid ""
 msgstr "*UPOZORENJE*\nAutomatsko prihvatanje DCC zahteva u kućnom\ndirektorijumu je opasno i može se iskoristiti.\nNpr. neko može poslati datoteku .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr "Iksčet: Postavke"
+msgid "Preferences - "
+msgstr "Postavke - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6203,8 +6203,8 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr "Iksčet: Prepisivanje URLova"
+msgid "URL Grabber - "
+msgstr "Prepisivanje URLova - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/sv.po
+++ b/po/sv.po
@@ -3245,8 +3245,8 @@ msgstr "Du kan endast öppna bannlysningslistan inne i kanalfliken."
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "Bannlysningslista (%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "Bannlysningslista (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3284,8 +3284,8 @@ msgstr "Kopiera _ämnestext"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr " Kanallista (%s) - "
+msgid "Channel List (%s) - %s"
+msgstr " Kanallista (%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3376,8 +3376,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Kan inte återuppta samma fil från två personer."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "Sändningar och hämtningar - "
+msgid "Uploads and Downloads - %s"
+msgstr "Sändningar och hämtningar - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3434,8 +3434,8 @@ msgid "Open Folder..."
 msgstr "Öppna mapp..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "DCC Chat-lista - "
+msgid "DCC Chat List - %s"
+msgstr "DCC Chat-lista - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3631,8 +3631,8 @@ msgid "Select a row to get help information on its Action."
 msgstr "Välj en rad för att få hjälpinformation på dess åtgärd."
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "Tangentbordsgenvägar - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "Tangentbordsgenvägar - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3676,8 +3676,8 @@ msgid "Enter mask to ignore:"
 msgstr "Ange mask att ignorera:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "Ignoreringslista - "
+msgid "Ignore list - %s"
+msgstr "Ignoreringslista - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3712,8 +3712,8 @@ msgid "Channel name too short, try again."
 msgstr "Kanalnamn för kort, försök igen."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "Anslutningen klar - "
+msgid "Connection Complete - %s"
+msgstr "Anslutningen klar - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4039,8 +4039,8 @@ msgid "_Auto-Connect"
 msgstr "_Automatisk anslutning"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "Användarmeny - "
+msgid "User menu - %s"
+msgstr "Användarmeny - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4160,36 +4160,36 @@ msgid ""
 msgstr "URL-hanterare - Specialkoder:\n\n%s  =  URL-textsträng\n\nAngivelse av ett ! framför kommandot\nindikerar att det ska skickas till\nett skal istället för HexChat"
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "Användardefinierade kommandon - "
+msgid "User Defined Commands - %s"
+msgstr "Användardefinierade kommandon - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "Popupmeny i användarlista - "
+msgid "Userlist Popup menu - %s"
+msgstr "Popupmeny i användarlista - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Ersätt med"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "Ersätt - "
+msgid "Replace - %s"
+msgstr "Ersätt - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "URL-hanterare - "
+msgid "URL Handlers - %s"
+msgstr "URL-hanterare - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "Knappar i användarlista - "
+msgid "Userlist buttons - %s"
+msgstr "Knappar i användarlista - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "Dialogknappar - "
+msgid "Dialog buttons - %s"
+msgstr "Dialogknappar - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "CTCP-svar - "
+msgid "CTCP Replies - %s"
+msgstr "CTCP-svar - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4496,8 +4496,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Kommaseparerad lista över nätverken tillåts."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
-msgstr "Vännerlista - "
+msgid "Friends List - %s"
+msgstr "Vännerlista - %s"
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4535,8 +4535,8 @@ msgstr "Privat meddelande från: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
-msgstr "Ansluten till %u nätverk och %u kanaler - "
+msgid "Connected to %u networks and %u channels - %s"
+msgstr "Ansluten till %u nätverk och %u kanaler - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4577,43 +4577,43 @@ msgstr "_Bakåt"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
-msgstr "Färgmarkerat meddelande från: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
+msgstr "Färgmarkerat meddelande från: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
-msgstr "%u färgmarkerade meddelanden, senaste från: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
+msgstr "%u färgmarkerade meddelanden, senaste från: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
-msgstr "Kanalmeddelande från: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
+msgstr "Kanalmeddelande från: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
-msgstr "%u kanalmeddelanden. - "
+msgid "%u channel messages. - %s"
+msgstr "%u kanalmeddelanden. - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
-msgstr "Privat meddelande från: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
+msgstr "Privat meddelande från: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
-msgstr "%u privata meddelanden, senaste från: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
+msgstr "%u privata meddelanden, senaste från: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
-msgstr "Filerbjudande från: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
+msgstr "Filerbjudande från: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
-msgstr "%u filerbjudanden, senaste från: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
+msgstr "%u filerbjudanden, senaste från: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4628,8 +4628,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Välj en insticksmodul eller ett skript att läsa in"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "Insticksmoduler och skript - "
+msgid "Plugins and Scripts - %s"
+msgstr "Insticksmoduler och skript - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4650,8 +4650,8 @@ msgstr "Spara som..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
-msgstr "Rålogg (%s) - "
+msgid "Raw Log (%s) - %s"
+msgstr "Rålogg (%s) - %s"
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4686,8 +4686,8 @@ msgstr "Sättet du identifierar dig på gentemot servern. För anpassad login-me
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "Redigera %s - "
+msgid "Edit %s - %s"
+msgstr "Redigera %s - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4778,8 +4778,8 @@ msgid "Character set:"
 msgstr "Teckentabell:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "Nätverkslista - "
+msgid "Network List - %s"
+msgstr "Nätverkslista - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6143,8 +6143,8 @@ msgid ""
 msgstr "*VARNING*\nAtt automatiskt acceptera DCC till din\nhemkatalog kan vara farligt och utnyttjas\nav andra. Någon kan till exempel skicka\ndig en .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "Inställningar - "
+msgid "Preferences - %s"
+msgstr "Inställningar - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6208,8 +6208,8 @@ msgid "OK"
 msgstr "OK"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "URL-fångare - "
+msgid "URL Grabber - %s"
+msgstr "URL-fångare - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/sv.po
+++ b/po/sv.po
@@ -3245,8 +3245,8 @@ msgstr "Du kan endast öppna bannlysningslistan inne i kanalfliken."
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr ": Bannlysningslista (%s)"
+msgid "Ban List (%s) - "
+msgstr "Bannlysningslista (%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3284,8 +3284,8 @@ msgstr "Kopiera _ämnestext"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr ": Kanallista (%s)"
+msgid "Channel List (%s) - "
+msgstr " Kanallista (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3376,8 +3376,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Kan inte återuppta samma fil från två personer."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr ": Sändningar och hämtningar"
+msgid "Uploads and Downloads - "
+msgstr "Sändningar och hämtningar - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3434,8 +3434,8 @@ msgid "Open Folder..."
 msgstr "Öppna mapp..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr ": DCC Chat-lista"
+msgid "DCC Chat List - "
+msgstr "DCC Chat-lista - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3631,8 +3631,8 @@ msgid "Select a row to get help information on its Action."
 msgstr "Välj en rad för att få hjälpinformation på dess åtgärd."
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr ": Tangentbordsgenvägar"
+msgid "Keyboard Shortcuts - "
+msgstr "Tangentbordsgenvägar - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3676,8 +3676,8 @@ msgid "Enter mask to ignore:"
 msgstr "Ange mask att ignorera:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr ": Ignoreringslista"
+msgid "Ignore list - "
+msgstr "Ignoreringslista - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3712,8 +3712,8 @@ msgid "Channel name too short, try again."
 msgstr "Kanalnamn för kort, försök igen."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr ": Anslutningen klar"
+msgid "Connection Complete - "
+msgstr "Anslutningen klar - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4039,8 +4039,8 @@ msgid "_Auto-Connect"
 msgstr "_Automatisk anslutning"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr ": Användarmeny"
+msgid "User menu - "
+msgstr "Användarmeny - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4160,36 +4160,36 @@ msgid ""
 msgstr "URL-hanterare - Specialkoder:\n\n%s  =  URL-textsträng\n\nAngivelse av ett ! framför kommandot\nindikerar att det ska skickas till\nett skal istället för HexChat"
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr ": Användardefinierade kommandon"
+msgid "User Defined Commands - "
+msgstr "Användardefinierade kommandon - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr ": Popupmeny i användarlista"
+msgid "Userlist Popup menu - "
+msgstr "Popupmeny i användarlista - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Ersätt med"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr ": Ersätt"
+msgid "Replace - "
+msgstr "Ersätt - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr ": URL-hanterare"
+msgid "URL Handlers - "
+msgstr "URL-hanterare - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr ": Knappar i användarlista"
+msgid "Userlist buttons - "
+msgstr "Knappar i användarlista - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr ": Dialogknappar"
+msgid "Dialog buttons - "
+msgstr "Dialogknappar - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr ": CTCP-svar"
+msgid "CTCP Replies - "
+msgstr "CTCP-svar - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4496,8 +4496,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Kommaseparerad lista över nätverken tillåts."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
-msgstr ": Vännerlista"
+msgid "Friends List - "
+msgstr "Vännerlista - "
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4535,8 +4535,8 @@ msgstr "Privat meddelande från: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
-msgstr ": Ansluten till %u nätverk och %u kanaler"
+msgid "Connected to %u networks and %u channels - "
+msgstr "Ansluten till %u nätverk och %u kanaler - "
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4577,43 +4577,43 @@ msgstr "_Bakåt"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
-msgstr ": Färgmarkerat meddelande från: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
+msgstr "Färgmarkerat meddelande från: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
-msgstr ": %u färgmarkerade meddelanden, senaste från: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
+msgstr "%u färgmarkerade meddelanden, senaste från: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
-msgstr ": Kanalmeddelande från: %s (%s)"
+msgid "Channel message from: %s (%s) - "
+msgstr "Kanalmeddelande från: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
-msgstr ": %u kanalmeddelanden."
+msgid "%u channel messages. - "
+msgstr "%u kanalmeddelanden. - "
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
-msgstr ": Privat meddelande från: %s (%s)"
+msgid "Private message from: %s (%s) - "
+msgstr "Privat meddelande från: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
-msgstr ": %u privata meddelanden, senaste från: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
+msgstr "%u privata meddelanden, senaste från: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
-msgstr ": Filerbjudande från: %s (%s)"
+msgid "File offer from: %s (%s) - "
+msgstr "Filerbjudande från: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
-msgstr ": %u filerbjudanden, senaste från: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
+msgstr "%u filerbjudanden, senaste från: %s (%s) - "
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4628,8 +4628,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Välj en insticksmodul eller ett skript att läsa in"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr ": Insticksmoduler och skript"
+msgid "Plugins and Scripts - "
+msgstr "Insticksmoduler och skript - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4650,8 +4650,8 @@ msgstr "Spara som..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
-msgstr ": Rålogg (%s)"
+msgid "Raw Log (%s) - "
+msgstr "Rålogg (%s) - "
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4686,8 +4686,8 @@ msgstr "Sättet du identifierar dig på gentemot servern. För anpassad login-me
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr ": Redigera %s"
+msgid "Edit %s - "
+msgstr "Redigera %s - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4778,8 +4778,8 @@ msgid "Character set:"
 msgstr "Teckentabell:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr ": Nätverkslista"
+msgid "Network List - "
+msgstr "Nätverkslista - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6143,8 +6143,8 @@ msgid ""
 msgstr "*VARNING*\nAtt automatiskt acceptera DCC till din\nhemkatalog kan vara farligt och utnyttjas\nav andra. Någon kan till exempel skicka\ndig en .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr ": Inställningar"
+msgid "Preferences - "
+msgstr "Inställningar - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6208,8 +6208,8 @@ msgid "OK"
 msgstr "OK"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr ": URL-fångare"
+msgid "URL Grabber - "
+msgstr "URL-fångare - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/th.po
+++ b/po/th.po
@@ -3239,8 +3239,8 @@ msgstr "คุณสามารถเปิดหน้าต่างราย
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr ": รายการแบน (%s)"
+msgid "Ban List (%s) - "
+msgstr "รายการแบน (%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3278,8 +3278,8 @@ msgstr "คัดลอกข้อความหัวข้อ"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr ": รายการแชนแนล (%s)"
+msgid "Channel List (%s) - "
+msgstr ":รายการแชนแนล (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3370,8 +3370,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "ไม่สามารถเริ่มต่อสำหรับไฟล์เดียวกันจากคนสองคน."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr ": อัพโหลดและดาวน์โหลด"
+msgid "Uploads and Downloads - "
+msgstr "อัพโหลดและดาวน์โหลด - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3428,8 +3428,8 @@ msgid "Open Folder..."
 msgstr "เปิดโฟลเดอร์..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr ": รายการคุยเล่น DCC"
+msgid "DCC Chat List - "
+msgstr "รายการคุยเล่น DCC - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3625,8 +3625,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr ": แป้นพิมพ์ลัด"
+msgid "Keyboard Shortcuts - "
+msgstr "แป้นพิมพ์ลัด - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3670,8 +3670,8 @@ msgid "Enter mask to ignore:"
 msgstr "ป้อนมาสก์เพื่อเพิกเฉย"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr ": รายการเพิกเฉย"
+msgid "Ignore list - "
+msgstr "รายการเพิกเฉย - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3706,8 +3706,8 @@ msgid "Channel name too short, try again."
 msgstr "ชื่อแชนแนลสั้นเกินไป, ลองใหม่อีกครั้ง."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr ": การเชื่อมต่อเสร็จสมบูรณ์"
+msgid "Connection Complete - "
+msgstr "การเชื่อมต่อเสร็จสมบูรณ์ - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4033,8 +4033,8 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr ": เมนูผู้ใช้"
+msgid "User menu - "
+msgstr "เมนูผู้ใช้ - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4154,36 +4154,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr ": คำสั่งที่ผู้ใช้นิยามขึ้น"
+msgid "User Defined Commands - "
+msgstr "คำสั่งที่ผู้ใช้นิยามขึ้น - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr ": เมนูป็อบอัพรายชื่อผู้ใช้"
+msgid "Userlist Popup menu - "
+msgstr "เมนูป็อบอัพรายชื่อผู้ใช้ - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "แทนที่ด้วย"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr ": แทนที่"
+msgid "Replace - "
+msgstr "แทนที่ - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr ": ตัวจัดการ URL"
+msgid "URL Handlers - "
+msgstr "ตัวจัดการ URL - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr ": ปุ่มรายการผู้ใช้"
+msgid "Userlist buttons - "
+msgstr "ปุ่มรายการผู้ใช้ - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr ": ปุ่มสนทนา"
+msgid "Dialog buttons - "
+msgstr "ปุ่มสนทนา - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr ": การตอบรับ CTCP"
+msgid "CTCP Replies - "
+msgstr "การตอบรับ CTCP - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4490,7 +4490,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr "ยอมรับรายการเครือข่ายที่แยกด้วยจุลภาค."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
+msgid "Friends List - "
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4529,8 +4529,8 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
-msgstr ": เชื่อมต่อไปยังเครือข่าย %u และแชนแนล %u "
+msgid "Connected to %u networks and %u channels - "
+msgstr "เชื่อมต่อไปยังเครือข่าย %u และแชนแนล %u  - "
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4571,43 +4571,43 @@ msgstr "กลับมา"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
-msgstr ": ข้อความที่ถูกเน้นจาก: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
+msgstr "ข้อความที่ถูกเน้นจาก: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
-msgstr ": %u ข้อความที่ถูกเน้น, ล่าสุดจาก: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
+msgstr "%u ข้อความที่ถูกเน้น, ล่าสุดจาก: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
-msgstr ": ข้อความส่วนตัวจาก: %s (%s)"
+msgid "Private message from: %s (%s) - "
+msgstr "ข้อความส่วนตัวจาก: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
-msgstr ": %u ข้อความส่วนตัว, ล่าสุดจาก: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
+msgstr "%u ข้อความส่วนตัว, ล่าสุดจาก: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
-msgstr ": เสนอไฟล์จาก: %s (%s)"
+msgid "File offer from: %s (%s) - "
+msgstr "เสนอไฟล์จาก: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
-msgstr ": %u เสนอไฟล์, ล่าสุดจาก: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
+msgstr "%u เสนอไฟล์, ล่าสุดจาก: %s (%s) - "
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4622,8 +4622,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "เลือกปลั๊กอินหรือสคริปที่จะโหลด"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr ": ปลั๊กอินและสคริป"
+msgid "Plugins and Scripts - "
+msgstr "ปลั๊กอินและสคริป - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4644,7 +4644,7 @@ msgstr "บันทึกเป็น..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4680,8 +4680,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr ": แก้ไข %s"
+msgid "Edit %s - "
+msgstr "แก้ไข %s - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4772,8 +4772,8 @@ msgid "Character set:"
 msgstr "ชุดอักขระ:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr ": รายการเครือข่าย"
+msgid "Network List - "
+msgstr "รายการเครือข่าย - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6137,8 +6137,8 @@ msgid ""
 msgstr "*คำเตือน*\nการรับ DCC อัตโนมัติไปยังไดเร็กทอรีบ้านของคุณ\nอาจจะอันตรายและสร้างความเสียหายได้. เช่น:\nบางคนอาจจะสามารถส่ง .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr ": ปรับแต่งค่า"
+msgid "Preferences - "
+msgstr "ปรับแต่งค่า - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6202,8 +6202,8 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr ": ตัวดักจับ URL"
+msgid "URL Grabber - "
+msgstr "ตัวดักจับ URL - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/th.po
+++ b/po/th.po
@@ -3239,8 +3239,8 @@ msgstr "คุณสามารถเปิดหน้าต่างราย
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "รายการแบน (%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "รายการแบน (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3278,8 +3278,8 @@ msgstr "คัดลอกข้อความหัวข้อ"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr ":รายการแชนแนล (%s) - "
+msgid "Channel List (%s) - %s"
+msgstr ":รายการแชนแนล (%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3370,8 +3370,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "ไม่สามารถเริ่มต่อสำหรับไฟล์เดียวกันจากคนสองคน."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "อัพโหลดและดาวน์โหลด - "
+msgid "Uploads and Downloads - %s"
+msgstr "อัพโหลดและดาวน์โหลด - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3428,8 +3428,8 @@ msgid "Open Folder..."
 msgstr "เปิดโฟลเดอร์..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "รายการคุยเล่น DCC - "
+msgid "DCC Chat List - %s"
+msgstr "รายการคุยเล่น DCC - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3625,8 +3625,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "แป้นพิมพ์ลัด - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "แป้นพิมพ์ลัด - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3670,8 +3670,8 @@ msgid "Enter mask to ignore:"
 msgstr "ป้อนมาสก์เพื่อเพิกเฉย"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "รายการเพิกเฉย - "
+msgid "Ignore list - %s"
+msgstr "รายการเพิกเฉย - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3706,8 +3706,8 @@ msgid "Channel name too short, try again."
 msgstr "ชื่อแชนแนลสั้นเกินไป, ลองใหม่อีกครั้ง."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "การเชื่อมต่อเสร็จสมบูรณ์ - "
+msgid "Connection Complete - %s"
+msgstr "การเชื่อมต่อเสร็จสมบูรณ์ - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4033,8 +4033,8 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "เมนูผู้ใช้ - "
+msgid "User menu - %s"
+msgstr "เมนูผู้ใช้ - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4154,36 +4154,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "คำสั่งที่ผู้ใช้นิยามขึ้น - "
+msgid "User Defined Commands - %s"
+msgstr "คำสั่งที่ผู้ใช้นิยามขึ้น - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "เมนูป็อบอัพรายชื่อผู้ใช้ - "
+msgid "Userlist Popup menu - %s"
+msgstr "เมนูป็อบอัพรายชื่อผู้ใช้ - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "แทนที่ด้วย"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "แทนที่ - "
+msgid "Replace - %s"
+msgstr "แทนที่ - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "ตัวจัดการ URL - "
+msgid "URL Handlers - %s"
+msgstr "ตัวจัดการ URL - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "ปุ่มรายการผู้ใช้ - "
+msgid "Userlist buttons - %s"
+msgstr "ปุ่มรายการผู้ใช้ - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "ปุ่มสนทนา - "
+msgid "Dialog buttons - %s"
+msgstr "ปุ่มสนทนา - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "การตอบรับ CTCP - "
+msgid "CTCP Replies - %s"
+msgstr "การตอบรับ CTCP - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4490,7 +4490,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr "ยอมรับรายการเครือข่ายที่แยกด้วยจุลภาค."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
+msgid "Friends List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4529,8 +4529,8 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
-msgstr "เชื่อมต่อไปยังเครือข่าย %u และแชนแนล %u  - "
+msgid "Connected to %u networks and %u channels - %s"
+msgstr "เชื่อมต่อไปยังเครือข่าย %u และแชนแนล %u  - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4571,43 +4571,43 @@ msgstr "กลับมา"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
-msgstr "ข้อความที่ถูกเน้นจาก: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
+msgstr "ข้อความที่ถูกเน้นจาก: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
-msgstr "%u ข้อความที่ถูกเน้น, ล่าสุดจาก: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
+msgstr "%u ข้อความที่ถูกเน้น, ล่าสุดจาก: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
-msgstr "ข้อความส่วนตัวจาก: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
+msgstr "ข้อความส่วนตัวจาก: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
-msgstr "%u ข้อความส่วนตัว, ล่าสุดจาก: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
+msgstr "%u ข้อความส่วนตัว, ล่าสุดจาก: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
-msgstr "เสนอไฟล์จาก: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
+msgstr "เสนอไฟล์จาก: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
-msgstr "%u เสนอไฟล์, ล่าสุดจาก: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
+msgstr "%u เสนอไฟล์, ล่าสุดจาก: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4622,8 +4622,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "เลือกปลั๊กอินหรือสคริปที่จะโหลด"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "ปลั๊กอินและสคริป - "
+msgid "Plugins and Scripts - %s"
+msgstr "ปลั๊กอินและสคริป - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4644,7 +4644,7 @@ msgstr "บันทึกเป็น..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4680,8 +4680,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "แก้ไข %s - "
+msgid "Edit %s - %s"
+msgstr "แก้ไข %s - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4772,8 +4772,8 @@ msgid "Character set:"
 msgstr "ชุดอักขระ:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "รายการเครือข่าย - "
+msgid "Network List - %s"
+msgstr "รายการเครือข่าย - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6137,8 +6137,8 @@ msgid ""
 msgstr "*คำเตือน*\nการรับ DCC อัตโนมัติไปยังไดเร็กทอรีบ้านของคุณ\nอาจจะอันตรายและสร้างความเสียหายได้. เช่น:\nบางคนอาจจะสามารถส่ง .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "ปรับแต่งค่า - "
+msgid "Preferences - %s"
+msgstr "ปรับแต่งค่า - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6202,8 +6202,8 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "ตัวดักจับ URL - "
+msgid "URL Grabber - %s"
+msgstr "ตัวดักจับ URL - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/tr.po
+++ b/po/tr.po
@@ -3250,7 +3250,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
+msgid "Ban List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3289,7 +3289,7 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
+msgid "Channel List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3381,7 +3381,7 @@ msgid "Cannot resume the same file from two people."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
+msgid "Uploads and Downloads - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3439,7 +3439,7 @@ msgid "Open Folder..."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
+msgid "DCC Chat List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3636,8 +3636,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "Klavye Kısayolları - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "Klavye Kısayolları - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3681,7 +3681,7 @@ msgid "Enter mask to ignore:"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
+msgid "Ignore list - %s"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3717,7 +3717,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
+msgid "Connection Complete - %s"
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4044,7 +4044,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
+msgid "User menu - %s"
 msgstr ""
 
 #. sep
@@ -4165,11 +4165,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
+msgid "User Defined Commands - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
+msgid "Userlist Popup menu - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4177,23 +4177,23 @@ msgid "Replace with"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
+msgid "Replace - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
+msgid "URL Handlers - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
+msgid "Userlist buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
+msgid "Dialog buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
+msgid "CTCP Replies - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4501,7 +4501,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
+msgid "Friends List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4540,7 +4540,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
+msgid "Connected to %u networks and %u channels - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4582,42 +4582,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4633,8 +4633,8 @@ msgid "Select a Plugin or Script to load"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "Eklenti ve Betikler - "
+msgid "Plugins and Scripts - %s"
+msgstr "Eklenti ve Betikler - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4655,7 +4655,7 @@ msgstr "Farklı Kaydet..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4691,7 +4691,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
+msgid "Edit %s - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4783,7 +4783,7 @@ msgid "Character set:"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
+msgid "Network List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6148,7 +6148,7 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
+msgid "Preferences - %s"
 msgstr ""
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6213,7 +6213,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
+msgid "URL Grabber - %s"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/tr.po
+++ b/po/tr.po
@@ -3250,7 +3250,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
+msgid "Ban List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3289,7 +3289,7 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
+msgid "Channel List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3381,7 +3381,7 @@ msgid "Cannot resume the same file from two people."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
+msgid "Uploads and Downloads - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3439,7 +3439,7 @@ msgid "Open Folder..."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
+msgid "DCC Chat List - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3636,8 +3636,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr ": Klavye Kısayolları"
+msgid "Keyboard Shortcuts - "
+msgstr "Klavye Kısayolları - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3681,7 +3681,7 @@ msgid "Enter mask to ignore:"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
+msgid "Ignore list - "
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3717,7 +3717,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
+msgid "Connection Complete - "
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4044,7 +4044,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
+msgid "User menu - "
 msgstr ""
 
 #. sep
@@ -4165,11 +4165,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
+msgid "User Defined Commands - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
+msgid "Userlist Popup menu - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4177,23 +4177,23 @@ msgid "Replace with"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
+msgid "Replace - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
+msgid "URL Handlers - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
+msgid "Userlist buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
+msgid "Dialog buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
+msgid "CTCP Replies - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4501,7 +4501,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
+msgid "Friends List - "
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4540,7 +4540,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
+msgid "Connected to %u networks and %u channels - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4582,42 +4582,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
+msgid "Private message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
+msgid "File offer from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4633,8 +4633,8 @@ msgid "Select a Plugin or Script to load"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr ": Eklenti ve Betikler"
+msgid "Plugins and Scripts - "
+msgstr "Eklenti ve Betikler - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4655,7 +4655,7 @@ msgstr "Farklı Kaydet..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4691,7 +4691,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
+msgid "Edit %s - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4783,7 +4783,7 @@ msgid "Character set:"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
+msgid "Network List - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6148,7 +6148,7 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
+msgid "Preferences - "
 msgstr ""
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6213,7 +6213,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
+msgid "URL Grabber - "
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/uk.po
+++ b/po/uk.po
@@ -3240,8 +3240,8 @@ msgstr "Можете відкрити лише вікно Список бані�
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr "X-Chat: Список банів (%s)"
+msgid "Ban List (%s) - "
+msgstr "Список банів (%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3279,8 +3279,8 @@ msgstr "Копіювати _текст теми"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr "XChat: Список каналів (%s)"
+msgid "Channel List (%s) - "
+msgstr "Список каналів (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3371,8 +3371,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Не можна продовжувати однаковий файл від 2-х користувачів."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr "XChat: Завантаження та відвантаження"
+msgid "Uploads and Downloads - "
+msgstr "Завантаження та відвантаження - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3429,8 +3429,8 @@ msgid "Open Folder..."
 msgstr "Відкрити теку..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr "XChat: список розмов по DCC"
+msgid "DCC Chat List - "
+msgstr "список розмов по DCC - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3626,8 +3626,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr "XChat: Комбінації клавіш"
+msgid "Keyboard Shortcuts - "
+msgstr "Комбінації клавіш - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3671,8 +3671,8 @@ msgid "Enter mask to ignore:"
 msgstr "Введіть маску для ігнорування:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr "XChat: список ігнорувань"
+msgid "Ignore list - "
+msgstr "список ігнорувань - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3707,8 +3707,8 @@ msgid "Channel name too short, try again."
 msgstr "Назва каналу надто коротка, спробуйте ще раз."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr "XChat: з'єднання завершено"
+msgid "Connection Complete - "
+msgstr "з'єднання завершено - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4034,8 +4034,8 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr "XChat: Меню користувача"
+msgid "User menu - "
+msgstr "Меню користувача - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4155,36 +4155,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr "XChat: Визначені користувачем команди"
+msgid "User Defined Commands - "
+msgstr "Визначені користувачем команди - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr "XChat: Контекстне меню списку користувачів"
+msgid "Userlist Popup menu - "
+msgstr "Контекстне меню списку користувачів - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Замінити на"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr "X-Chat: Заміни"
+msgid "Replace - "
+msgstr "Заміни - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr "XChat: Обробка URL посилань"
+msgid "URL Handlers - "
+msgstr "Обробка URL посилань - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr "XChat: Кнопки списку користувачів"
+msgid "Userlist buttons - "
+msgstr "Кнопки списку користувачів - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr "XChat: Діалогові кнопки"
+msgid "Dialog buttons - "
+msgstr "Діалогові кнопки - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr "XChat: Відповіді CTCP"
+msgid "CTCP Replies - "
+msgstr "Відповіді CTCP - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4491,8 +4491,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Список допустимих мереж (елементи розділяються комами)."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
-msgstr "XChat: Список друзів"
+msgid "Friends List - "
+msgstr "Список друзів - "
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4530,8 +4530,8 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
-msgstr "XChat: З'єднання з %u мережами та %u каналами"
+msgid "Connected to %u networks and %u channels - "
+msgstr "З'єднання з %u мережами та %u каналами - "
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4572,43 +4572,43 @@ msgstr "_Назад"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
-msgstr "XChat: Виділені повідомлення від: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
+msgstr "Виділені повідомлення від: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
-msgstr "XChat: %u виділених повідомлень, останнє від: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
+msgstr "%u виділених повідомлень, останнє від: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
-msgstr "XChat: Приватне повідомлення від: %s (%s)"
+msgid "Private message from: %s (%s) - "
+msgstr "Приватне повідомлення від: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
-msgstr "XChat: %u приватних повідомленнь, останнє від: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
+msgstr "%u приватних повідомленнь, останнє від: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
-msgstr "XChat: Передача файлу від: %s (%s)"
+msgid "File offer from: %s (%s) - "
+msgstr "Передача файлу від: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
-msgstr "XChat: %u передач файлів, остання від: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
+msgstr "%u передач файлів, остання від: %s (%s) - "
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4623,8 +4623,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Виберіть модуль або скрипт для завантаження"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr "XChat: модулі та скрипти"
+msgid "Plugins and Scripts - "
+msgstr "модулі та скрипти - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4645,7 +4645,7 @@ msgstr "Зберегти як..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4681,8 +4681,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr "XChat: Редагування %s"
+msgid "Edit %s - "
+msgstr "Редагування %s - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4773,8 +4773,8 @@ msgid "Character set:"
 msgstr "Набір символів:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr "XChat: Список мереж"
+msgid "Network List - "
+msgstr "Список мереж - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6138,8 +6138,8 @@ msgid ""
 msgstr "*ПОПЕРЕДЖЕННЯ*\nАвтоматичне приймання DCC до вашої домашньої теки\nможе бути небезпечним. Наприклад:\nхтось може надіслати вам .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr "XChat: Параметри"
+msgid "Preferences - "
+msgstr "Параметри - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6203,8 +6203,8 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr "XChat: Захоплювач URL"
+msgid "URL Grabber - "
+msgstr "Захоплювач URL - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/uk.po
+++ b/po/uk.po
@@ -3240,8 +3240,8 @@ msgstr "Можете відкрити лише вікно Список бані�
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "Список банів (%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "Список банів (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3279,8 +3279,8 @@ msgstr "Копіювати _текст теми"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr "Список каналів (%s) - "
+msgid "Channel List (%s) - %s"
+msgstr "Список каналів (%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3371,8 +3371,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Не можна продовжувати однаковий файл від 2-х користувачів."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "Завантаження та відвантаження - "
+msgid "Uploads and Downloads - %s"
+msgstr "Завантаження та відвантаження - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3429,8 +3429,8 @@ msgid "Open Folder..."
 msgstr "Відкрити теку..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "список розмов по DCC - "
+msgid "DCC Chat List - %s"
+msgstr "список розмов по DCC - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3626,8 +3626,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "Комбінації клавіш - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "Комбінації клавіш - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3671,8 +3671,8 @@ msgid "Enter mask to ignore:"
 msgstr "Введіть маску для ігнорування:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "список ігнорувань - "
+msgid "Ignore list - %s"
+msgstr "список ігнорувань - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3707,8 +3707,8 @@ msgid "Channel name too short, try again."
 msgstr "Назва каналу надто коротка, спробуйте ще раз."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "з'єднання завершено - "
+msgid "Connection Complete - %s"
+msgstr "з'єднання завершено - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4034,8 +4034,8 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "Меню користувача - "
+msgid "User menu - %s"
+msgstr "Меню користувача - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4155,36 +4155,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "Визначені користувачем команди - "
+msgid "User Defined Commands - %s"
+msgstr "Визначені користувачем команди - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "Контекстне меню списку користувачів - "
+msgid "Userlist Popup menu - %s"
+msgstr "Контекстне меню списку користувачів - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Замінити на"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "Заміни - "
+msgid "Replace - %s"
+msgstr "Заміни - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "Обробка URL посилань - "
+msgid "URL Handlers - %s"
+msgstr "Обробка URL посилань - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "Кнопки списку користувачів - "
+msgid "Userlist buttons - %s"
+msgstr "Кнопки списку користувачів - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "Діалогові кнопки - "
+msgid "Dialog buttons - %s"
+msgstr "Діалогові кнопки - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "Відповіді CTCP - "
+msgid "CTCP Replies - %s"
+msgstr "Відповіді CTCP - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4491,8 +4491,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Список допустимих мереж (елементи розділяються комами)."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
-msgstr "Список друзів - "
+msgid "Friends List - %s"
+msgstr "Список друзів - %s"
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4530,8 +4530,8 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
-msgstr "З'єднання з %u мережами та %u каналами - "
+msgid "Connected to %u networks and %u channels - %s"
+msgstr "З'єднання з %u мережами та %u каналами - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4572,43 +4572,43 @@ msgstr "_Назад"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
-msgstr "Виділені повідомлення від: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
+msgstr "Виділені повідомлення від: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
-msgstr "%u виділених повідомлень, останнє від: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
+msgstr "%u виділених повідомлень, останнє від: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
-msgstr "Приватне повідомлення від: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
+msgstr "Приватне повідомлення від: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
-msgstr "%u приватних повідомленнь, останнє від: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
+msgstr "%u приватних повідомленнь, останнє від: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
-msgstr "Передача файлу від: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
+msgstr "Передача файлу від: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
-msgstr "%u передач файлів, остання від: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
+msgstr "%u передач файлів, остання від: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4623,8 +4623,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Виберіть модуль або скрипт для завантаження"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "модулі та скрипти - "
+msgid "Plugins and Scripts - %s"
+msgstr "модулі та скрипти - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4645,7 +4645,7 @@ msgstr "Зберегти як..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4681,8 +4681,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "Редагування %s - "
+msgid "Edit %s - %s"
+msgstr "Редагування %s - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4773,8 +4773,8 @@ msgid "Character set:"
 msgstr "Набір символів:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "Список мереж - "
+msgid "Network List - %s"
+msgstr "Список мереж - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6138,8 +6138,8 @@ msgid ""
 msgstr "*ПОПЕРЕДЖЕННЯ*\nАвтоматичне приймання DCC до вашої домашньої теки\nможе бути небезпечним. Наприклад:\nхтось може надіслати вам .bash_profile"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "Параметри - "
+msgid "Preferences - %s"
+msgstr "Параметри - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6203,8 +6203,8 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "Захоплювач URL - "
+msgid "URL Grabber - %s"
+msgstr "Захоплювач URL - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/vi.po
+++ b/po/vi.po
@@ -3237,8 +3237,8 @@ msgstr "Bạn có thể mở cửa sổ Danh Sách Đuổi Ra chỉ khi trong m�
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr "X-Chat: Danh Sách Đuổi Ra (%s)"
+msgid "Ban List (%s) - "
+msgstr "Danh Sách Đuổi Ra (%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3276,8 +3276,8 @@ msgstr "Chép c_hủ đề"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr "XChat: Danh Sách Kênh (%s)"
+msgid "Channel List (%s) - "
+msgstr "Danh Sách Kênh (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3368,8 +3368,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Không thể tiếp tục lại cùng một tập tin từ hai người khác."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr "XChat: Tải lên/về"
+msgid "Uploads and Downloads - "
+msgstr "Tải lên/về - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3426,8 +3426,8 @@ msgid "Open Folder..."
 msgstr "Mở thư mục..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr "XChat: Danh Sách Trò Chuyện Trực Tiếp (DCC)"
+msgid "DCC Chat List - "
+msgstr "Danh Sách Trò Chuyện Trực Tiếp (DCC) - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3623,8 +3623,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr "XChat: Phím tắt"
+msgid "Keyboard Shortcuts - "
+msgstr "Phím tắt - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3668,8 +3668,8 @@ msgid "Enter mask to ignore:"
 msgstr "Hãy nhập bộ lọc cần bỏ qua:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr "XChat: Danh Sách Bỏ Qua"
+msgid "Ignore list - "
+msgstr "Danh Sách Bỏ Qua - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3704,8 +3704,8 @@ msgid "Channel name too short, try again."
 msgstr "Tên kênh quá ngắn nên hãy thử lại."
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr "XChat: Kết nối hoàn tất"
+msgid "Connection Complete - "
+msgstr "Kết nối hoàn tất - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4031,8 +4031,8 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr "XChat: Trình đơn người dùng"
+msgid "User menu - "
+msgstr "Trình đơn người dùng - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4152,36 +4152,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr "XChat: Lệnh định nghĩa riêng"
+msgid "User Defined Commands - "
+msgstr "Lệnh định nghĩa riêng - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr "XChat: Trình đơn bât lên danh sách người dùng"
+msgid "Userlist Popup menu - "
+msgstr "Trình đơn bât lên danh sách người dùng - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Thay thế bằng"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr "XChat: Thay thế"
+msgid "Replace - "
+msgstr "Thay thế - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr "XChat: Quản lý URL"
+msgid "URL Handlers - "
+msgstr "Quản lý URL - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr "XChat: Nút danh sách người dùng"
+msgid "Userlist buttons - "
+msgstr "Nút danh sách người dùng - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr "XChat: Nút đối thoại"
+msgid "Dialog buttons - "
+msgstr "Nút đối thoại - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr "XChat: Trả lời CTCP"
+msgid "CTCP Replies - "
+msgstr "Trả lời CTCP - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4488,7 +4488,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Cho phép tạo danh sách các mạng định giới bằng dấu phẩy."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
+msgid "Friends List - "
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4527,8 +4527,8 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
-msgstr "XChat: đang kết nối với %u mạng và %u kênh"
+msgid "Connected to %u networks and %u channels - "
+msgstr "đang kết nối với %u mạng và %u kênh - "
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4569,43 +4569,43 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
-msgstr "XChat: nhận được tin nhẳn đã tô sáng từ : %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
+msgstr "nhận được tin nhẳn đã tô sáng từ : %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
-msgstr "XChat: Nhận %u tin nhẳn đã tô sáng, mới nhất từ : %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
+msgstr "Nhận %u tin nhẳn đã tô sáng, mới nhất từ : %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
-msgstr "XChat: Nhận tin nhẳn riêng từ : %s (%s)"
+msgid "Private message from: %s (%s) - "
+msgstr "Nhận tin nhẳn riêng từ : %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
-msgstr "XChat: Nhận %u tin nhẳn riêng, mới nhất từ : %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
+msgstr "Nhận %u tin nhẳn riêng, mới nhất từ : %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
-msgstr "XChat: Nhận lời mời gởi tập tin từ : %s (%s)"
+msgid "File offer from: %s (%s) - "
+msgstr "Nhận lời mời gởi tập tin từ : %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
-msgstr "XChat: Nhận %u lời mời gởi tập tin, mới nhất từ : %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
+msgstr "Nhận %u lời mời gởi tập tin, mới nhất từ : %s (%s) - "
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4620,8 +4620,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Chọn bổ sung hay văn lệnh cần nạp"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr "XChat: Bổ sung và Văn lệnh"
+msgid "Plugins and Scripts - "
+msgstr "Bổ sung và Văn lệnh - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4642,7 +4642,7 @@ msgstr "Lưu dạng..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4678,8 +4678,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr "XChat: Sửa %s"
+msgid "Edit %s - "
+msgstr "Sửa %s - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4770,8 +4770,8 @@ msgid "Character set:"
 msgstr "Bộ ký tự :"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr "XChat: Danh sách mạng"
+msgid "Network List - "
+msgstr "Danh sách mạng - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6135,8 +6135,8 @@ msgid ""
 msgstr "•• CẢNH BÁO ••\nViệc tự động chấp nhận DCC vào thư mục\nchính của bạn có lẽ nguy hiểm và cho phép\nngười khác tấn công hệ thống của bạn.\nV.d. người khác có thể gởi cho bạn\nmột « .bash_profile »."
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr "XChat: Tùy thích"
+msgid "Preferences - "
+msgstr "Tùy thích - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6200,8 +6200,8 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr "XChat: Lấy URL"
+msgid "URL Grabber - "
+msgstr "Lấy URL - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/vi.po
+++ b/po/vi.po
@@ -3237,8 +3237,8 @@ msgstr "Bạn có thể mở cửa sổ Danh Sách Đuổi Ra chỉ khi trong m�
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "Danh Sách Đuổi Ra (%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "Danh Sách Đuổi Ra (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3276,8 +3276,8 @@ msgstr "Chép c_hủ đề"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr "Danh Sách Kênh (%s) - "
+msgid "Channel List (%s) - %s"
+msgstr "Danh Sách Kênh (%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3368,8 +3368,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "Không thể tiếp tục lại cùng một tập tin từ hai người khác."
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "Tải lên/về - "
+msgid "Uploads and Downloads - %s"
+msgstr "Tải lên/về - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3426,8 +3426,8 @@ msgid "Open Folder..."
 msgstr "Mở thư mục..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "Danh Sách Trò Chuyện Trực Tiếp (DCC) - "
+msgid "DCC Chat List - %s"
+msgstr "Danh Sách Trò Chuyện Trực Tiếp (DCC) - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3623,8 +3623,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "Phím tắt - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "Phím tắt - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3668,8 +3668,8 @@ msgid "Enter mask to ignore:"
 msgstr "Hãy nhập bộ lọc cần bỏ qua:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "Danh Sách Bỏ Qua - "
+msgid "Ignore list - %s"
+msgstr "Danh Sách Bỏ Qua - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3704,8 +3704,8 @@ msgid "Channel name too short, try again."
 msgstr "Tên kênh quá ngắn nên hãy thử lại."
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "Kết nối hoàn tất - "
+msgid "Connection Complete - %s"
+msgstr "Kết nối hoàn tất - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4031,8 +4031,8 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "Trình đơn người dùng - "
+msgid "User menu - %s"
+msgstr "Trình đơn người dùng - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4152,36 +4152,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "Lệnh định nghĩa riêng - "
+msgid "User Defined Commands - %s"
+msgstr "Lệnh định nghĩa riêng - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "Trình đơn bât lên danh sách người dùng - "
+msgid "Userlist Popup menu - %s"
+msgstr "Trình đơn bât lên danh sách người dùng - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "Thay thế bằng"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "Thay thế - "
+msgid "Replace - %s"
+msgstr "Thay thế - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "Quản lý URL - "
+msgid "URL Handlers - %s"
+msgstr "Quản lý URL - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "Nút danh sách người dùng - "
+msgid "Userlist buttons - %s"
+msgstr "Nút danh sách người dùng - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "Nút đối thoại - "
+msgid "Dialog buttons - %s"
+msgstr "Nút đối thoại - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "Trả lời CTCP - "
+msgid "CTCP Replies - %s"
+msgstr "Trả lời CTCP - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4488,7 +4488,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr "Cho phép tạo danh sách các mạng định giới bằng dấu phẩy."
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
+msgid "Friends List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4527,8 +4527,8 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
-msgstr "đang kết nối với %u mạng và %u kênh - "
+msgid "Connected to %u networks and %u channels - %s"
+msgstr "đang kết nối với %u mạng và %u kênh - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4569,43 +4569,43 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
-msgstr "nhận được tin nhẳn đã tô sáng từ : %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
+msgstr "nhận được tin nhẳn đã tô sáng từ : %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
-msgstr "Nhận %u tin nhẳn đã tô sáng, mới nhất từ : %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
+msgstr "Nhận %u tin nhẳn đã tô sáng, mới nhất từ : %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
-msgstr "Nhận tin nhẳn riêng từ : %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
+msgstr "Nhận tin nhẳn riêng từ : %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
-msgstr "Nhận %u tin nhẳn riêng, mới nhất từ : %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
+msgstr "Nhận %u tin nhẳn riêng, mới nhất từ : %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
-msgstr "Nhận lời mời gởi tập tin từ : %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
+msgstr "Nhận lời mời gởi tập tin từ : %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
-msgstr "Nhận %u lời mời gởi tập tin, mới nhất từ : %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
+msgstr "Nhận %u lời mời gởi tập tin, mới nhất từ : %s (%s) - %s"
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4620,8 +4620,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "Chọn bổ sung hay văn lệnh cần nạp"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "Bổ sung và Văn lệnh - "
+msgid "Plugins and Scripts - %s"
+msgstr "Bổ sung và Văn lệnh - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4642,7 +4642,7 @@ msgstr "Lưu dạng..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4678,8 +4678,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "Sửa %s - "
+msgid "Edit %s - %s"
+msgstr "Sửa %s - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4770,8 +4770,8 @@ msgid "Character set:"
 msgstr "Bộ ký tự :"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "Danh sách mạng - "
+msgid "Network List - %s"
+msgstr "Danh sách mạng - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6135,8 +6135,8 @@ msgid ""
 msgstr "•• CẢNH BÁO ••\nViệc tự động chấp nhận DCC vào thư mục\nchính của bạn có lẽ nguy hiểm và cho phép\nngười khác tấn công hệ thống của bạn.\nV.d. người khác có thể gởi cho bạn\nmột « .bash_profile »."
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "Tùy thích - "
+msgid "Preferences - %s"
+msgstr "Tùy thích - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6200,8 +6200,8 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "Lấy URL - "
+msgid "URL Grabber - %s"
+msgstr "Lấy URL - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/wa.po
+++ b/po/wa.po
@@ -3238,7 +3238,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
+msgid "Ban List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3277,7 +3277,7 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
+msgid "Channel List (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3369,7 +3369,7 @@ msgid "Cannot resume the same file from two people."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
+msgid "Uploads and Downloads - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3427,7 +3427,7 @@ msgid "Open Folder..."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
+msgid "DCC Chat List - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3624,7 +3624,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
+msgid "Keyboard Shortcuts - "
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3669,7 +3669,7 @@ msgid "Enter mask to ignore:"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
+msgid "Ignore list - "
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3705,7 +3705,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
+msgid "Connection Complete - "
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4032,7 +4032,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
+msgid "User menu - "
 msgstr ""
 
 #. sep
@@ -4153,11 +4153,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
+msgid "User Defined Commands - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
+msgid "Userlist Popup menu - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4165,23 +4165,23 @@ msgid "Replace with"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
+msgid "Replace - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
+msgid "URL Handlers - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
+msgid "Userlist buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
+msgid "Dialog buttons - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
+msgid "CTCP Replies - "
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4489,7 +4489,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
+msgid "Friends List - "
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4528,7 +4528,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
+msgid "Connected to %u networks and %u channels - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4570,42 +4570,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
+msgid "Private message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
+msgid "File offer from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4621,7 +4621,7 @@ msgid "Select a Plugin or Script to load"
 msgstr "Tchoezixhoz on tchôke-divins ou on scripe a tcherdjî"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
+msgid "Plugins and Scripts - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4643,7 +4643,7 @@ msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4679,7 +4679,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
+msgid "Edit %s - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4771,7 +4771,7 @@ msgid "Character set:"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
+msgid "Network List - "
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6136,7 +6136,7 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
+msgid "Preferences - "
 msgstr ""
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6201,7 +6201,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
+msgid "URL Grabber - "
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/wa.po
+++ b/po/wa.po
@@ -3238,7 +3238,7 @@ msgstr ""
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
+msgid "Ban List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
@@ -3277,7 +3277,7 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
+msgid "Channel List (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:794
@@ -3369,7 +3369,7 @@ msgid "Cannot resume the same file from two people."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
+msgid "Uploads and Downloads - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3427,7 +3427,7 @@ msgid "Open Folder..."
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
+msgid "DCC Chat List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:1062
@@ -3624,7 +3624,7 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
+msgid "Keyboard Shortcuts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/gtkutil.c:126
@@ -3669,7 +3669,7 @@ msgid "Enter mask to ignore:"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
+msgid "Ignore list - %s"
 msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:358
@@ -3705,7 +3705,7 @@ msgid "Channel name too short, try again."
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
+msgid "Connection Complete - %s"
 msgstr ""
 
 #: ../src/fe-gtk/joind.c:161
@@ -4032,7 +4032,7 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
+msgid "User menu - %s"
 msgstr ""
 
 #. sep
@@ -4153,11 +4153,11 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
+msgid "User Defined Commands - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
+msgid "Userlist Popup menu - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
@@ -4165,23 +4165,23 @@ msgid "Replace with"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
+msgid "Replace - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
+msgid "URL Handlers - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
+msgid "Userlist buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
+msgid "Dialog buttons - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
+msgid "CTCP Replies - %s"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1747
@@ -4489,7 +4489,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
+msgid "Friends List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4528,7 +4528,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
+msgid "Connected to %u networks and %u channels - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4570,42 +4570,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4621,7 +4621,7 @@ msgid "Select a Plugin or Script to load"
 msgstr "Tchoezixhoz on tchôke-divins ou on scripe a tcherdjî"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
+msgid "Plugins and Scripts - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:255
@@ -4643,7 +4643,7 @@ msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4679,7 +4679,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
+msgid "Edit %s - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1731
@@ -4771,7 +4771,7 @@ msgid "Character set:"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
+msgid "Network List - %s"
 msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6136,7 +6136,7 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
+msgid "Preferences - %s"
 msgstr ""
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
@@ -6201,7 +6201,7 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
+msgid "URL Grabber - %s"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:212

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -236,7 +236,7 @@ msgstr "进入频道..."
 
 #: ../src/common/hexchat.c:918 ../src/fe-gtk/menu.c:1410
 msgid "Enter Channel to Join:"
-msgstr "输入要进入的频道："
+msgstr "输入要进入的频道:"
 
 #: ../src/common/hexchat.c:919
 msgid "Server Links"
@@ -344,7 +344,7 @@ msgstr "找不到"
 
 #: ../src/common/inbound.c:1302
 msgid "Resolved to:"
-msgstr "解析到："
+msgstr "解析到:"
 
 #: ../src/common/inbound.c:1332
 #, c-format
@@ -382,7 +382,7 @@ msgstr "已将服务器 %s 添加到网络 %s 中。\n"
 #: ../src/common/outbound.c:368
 #, c-format
 msgid "Already marked away: %s\n"
-msgstr "已标记为离开：%s\n"
+msgstr "已标记为离开:%s\n"
 
 #: ../src/common/outbound.c:405
 msgid "Already marked back.\n"
@@ -394,15 +394,15 @@ msgstr "使用 /bin/sh 才能执行本程序！\n"
 
 #: ../src/common/outbound.c:2195
 msgid "Commands Available:"
-msgstr "可用命令："
+msgstr "可用命令:"
 
 #: ../src/common/outbound.c:2209
 msgid "User defined commands:"
-msgstr "用户自定义命令："
+msgstr "用户自定义命令:"
 
 #: ../src/common/outbound.c:2225
 msgid "Plugin defined commands:"
-msgstr "可用插件命令："
+msgstr "可用插件命令:"
 
 #: ../src/common/outbound.c:2236
 msgid "Type /HELP <command> for more information, or /HELP -l"
@@ -603,7 +603,7 @@ msgid ""
 "    types - types of data to ignore, one or all of:\n"
 "            PRIV, CHAN, NOTI, CTCP, DCC, INVI, ALL\n"
 "    options - NOSAVE, QUIET"
-msgstr "IGNORE <掩码> <类型..> <选项..>\n    掩码 - 要忽略的主机掩码，比如 *!*@*.aol.com\n    类型 - 要忽略数据的类型，应以下选项之一或全部：\n            PRIV，CHAN，NOTI，CTCP，INVI，ALL\n    选项 - 忽略选项：NOSAVE，QUIET"
+msgstr "IGNORE <掩码> <类型..> <选项..>\n    掩码 - 要忽略的主机掩码，比如 *!*@*.aol.com\n    类型 - 要忽略数据的类型，应以下选项之一或全部:\n            PRIV，CHAN，NOTI，CTCP，INVI，ALL\n    选项 - 忽略选项:NOSAVE，QUIET"
 
 #: ../src/common/outbound.c:3947
 msgid ""
@@ -860,12 +860,12 @@ msgstr "WALLCHOP <消息>，给当前频道中所有管理员发送消息"
 #: ../src/common/outbound.c:4093
 #, c-format
 msgid "User Command for: %s\n"
-msgstr "用户命令：%s\n"
+msgstr "用户命令:%s\n"
 
 #: ../src/common/outbound.c:4120
 #, c-format
 msgid "Usage: %s\n"
-msgstr "用法：%s\n"
+msgstr "用法:%s\n"
 
 #: ../src/common/outbound.c:4125
 msgid ""
@@ -902,7 +902,7 @@ msgstr "*\t服务器识别需要从 %s 作为 %s"
 #: ../src/common/plugin-identd.c:238
 #, c-format
 msgid "*\tError starting identd server: %s"
-msgstr "*\t开始 identd 服务器错误： %s"
+msgstr "*\t开始 identd 服务器错误: %s"
 
 #: ../src/common/plugin-identd.c:262
 msgid "IDENTD <port> <username>"
@@ -972,7 +972,7 @@ msgstr "%C22*%O$t 不能加入 %C22$1 %O(%C20您已被拦截%O)。"
 
 #: ../src/common/textevents.h:18
 msgid "%C29*%O$tCapabilities acknowledged: %C29$2%O"
-msgstr "%C29*%O$t 已知能力： %C29$2%O"
+msgstr "%C29*%O$t 已知能力: %C29$2%O"
 
 #: ../src/common/textevents.h:21
 msgid "%C29*%O$tCapabilities removed: %C29$2%O"
@@ -980,11 +980,11 @@ msgstr "%C29*%O$t能力移除: %C29$2%O"
 
 #: ../src/common/textevents.h:24
 msgid "%C23*%O$tCapabilities supported: %C29$2%O"
-msgstr "%C23*%O$t 支持能力： %C29$2%O"
+msgstr "%C23*%O$t 支持能力: %C29$2%O"
 
 #: ../src/common/textevents.h:27
 msgid "%C23*%O$tCapabilities requested: %C29$1%O"
-msgstr "%C23*%O$t 请求能力：%C29$1%O"
+msgstr "%C23*%O$t 请求能力:%C29$1%O"
 
 #: ../src/common/textevents.h:30
 msgid "%C24*%O$t%C28$1%O is now known as %C18$2%O"
@@ -1032,7 +1032,7 @@ msgstr "%C22*%O$t%C26$1%O 在上 %C22$4%O 设置了 %C24$2$3%O 模式"
 
 #: ../src/common/textevents.h:72
 msgid "%C22*%O$tChannel %C22$1%O modes: %C24$2"
-msgstr "%C22*%O$t 频道 %C22$1%O 模式： %C24$2"
+msgstr "%C22*%O$t 频道 %C22$1%O 模式: %C24$2"
 
 #: ../src/common/textevents.h:81
 msgid "%C22*%O$t%C26$1%O gives channel operator status to %C18$2%O"
@@ -1182,7 +1182,7 @@ msgstr "%C20*%O$t 来自于 %C18$3%O 的 DCC RECV 连接 '%C23$1%O' 失败 (%C20
 
 #: ../src/common/textevents.h:189
 msgid "%C20*%O$tDCC RECV: Cannot open '%C23$1%C' for writing (%C20$2%O)"
-msgstr "%C20*%O$t DCC RECV：无法打开 %C23$1%C 进行写入(%C20$2%O)。 "
+msgstr "%C20*%O$t DCC RECV:无法打开 %C23$1%C 进行写入(%C20$2%O)。 "
 
 #: ../src/common/textevents.h:192
 msgid ""
@@ -1335,7 +1335,7 @@ msgstr "通知列表中有 %C23*%O$t%C23$1%O 位用户。"
 
 #: ../src/common/textevents.h:312
 msgid "%C23*%O$tNotify: %C18$1%C is offline (%C29$3%O)"
-msgstr "%C23*%O$t 通知：%C18$1%C 下线了(%C29$3%O)。"
+msgstr "%C23*%O$t 通知:%C18$1%C 下线了(%C29$3%O)。"
 
 #: ../src/common/textevents.h:315
 msgid "%C23*%O$tNotify: %C18$1%C is online (%C29$3%O)"
@@ -1353,7 +1353,7 @@ msgstr "%C24*$t$1 ($2%C24) 已离开 ($4)"
 
 #: ../src/common/textevents.h:327
 msgid "%C24*%O$tPing reply from %C18$1%C: %C24$2%O second(s)"
-msgstr "%C24*%O$t 从 %C18$1%C 处得到 Ping 回应时间：%C24$2%O 秒"
+msgstr "%C24*%O$t 从 %C18$1%C 处得到 Ping 回应时间:%C24$2%O 秒"
 
 #: ../src/common/textevents.h:330
 msgid "%C20*%O$tNo ping reply for %C24$1%O seconds, disconnecting."
@@ -1398,11 +1398,11 @@ msgstr "%C23*%O$t 前次连接尝试停止(%C24$1%O)"
 
 #: ../src/common/textevents.h:387
 msgid "%C22*%O$tTopic for %C22$1%C is: $2%O"
-msgstr "%C22*%O$t %C22$1%C的主题是：$2%O"
+msgstr "%C22*%O$t %C22$1%C的主题是:$2%O"
 
 #: ../src/common/textevents.h:390
 msgid "%C22*%O$t%C26$1%C has changed the topic to: $2%O"
-msgstr "%C22*%O$t%C26$1%C 已将主题更改为：$2%O"
+msgstr "%C22*%O$t%C26$1%C 已将主题更改为:$2%O"
 
 #: ../src/common/textevents.h:393
 msgid "%C22*%O$tTopic for %C22$1%C set by %C26$2%C (%C24$3%O)"
@@ -1434,7 +1434,7 @@ msgstr "%C23*%O$t%C28[%C18$1%C28]%O 发呆 %C23$2%O"
 
 #: ../src/common/textevents.h:423
 msgid "%C23*%O$t%C28[%C18$1%C28]%O idle %C23$2%O, signon: %C23$3%O"
-msgstr "%C23*%O$t%C28[%C18$1%C28]%O 发呆 %C23$2%O，登录时间：%C23$3%O"
+msgstr "%C23*%O$t%C28[%C18$1%C28]%O 发呆 %C23$2%O，登录时间:%C23$3%O"
 
 #: ../src/common/textevents.h:429
 msgid ""
@@ -2009,7 +2009,7 @@ msgstr "解析事件 %s 出错。\n正在载入默认值。"
 msgid ""
 "Cannot read sound file:\n"
 "%s"
-msgstr "无法读取声音文件：\n%s"
+msgstr "无法读取声音文件:\n%s"
 
 #: ../src/common/util.c:119
 msgid "Remote host closed socket"
@@ -3162,12 +3162,12 @@ msgstr "用 DBUS 远程访问的插件"
 #: ../src/common/dbus/dbus-plugin.c:900
 #, c-format
 msgid "Couldn't connect to session bus: %s\n"
-msgstr "无法连接到会话 bus：%s\n"
+msgstr "无法连接到会话 bus:%s\n"
 
 #: ../src/common/dbus/dbus-plugin.c:917
 #, c-format
 msgid "Failed to acquire %s: %s\n"
-msgstr "获取 %s 失败：%s\n"
+msgstr "获取 %s 失败:%s\n"
 
 #: ../src/fe-gtk/ascii.c:126
 msgid "Character Chart"
@@ -3251,8 +3251,8 @@ msgstr "您只能在一个频道的标签页下打开屏蔽列表窗口。"
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr "：屏蔽列表(%s)"
+msgid "Ban List (%s) - "
+msgstr ":屏蔽列表(%s)"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3290,8 +3290,8 @@ msgstr "复制频道主题(_T)"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr "：频道列表(%s)"
+msgid "Channel List (%s) - "
+msgstr "频道列表(%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3308,7 +3308,7 @@ msgstr "保存列表(_L)..."
 #. =============================================================
 #: ../src/fe-gtk/chanlist.c:819
 msgid "Show only:"
-msgstr "只显示："
+msgstr "只显示:"
 
 #: ../src/fe-gtk/chanlist.c:831
 msgid "channels with"
@@ -3325,7 +3325,7 @@ msgstr "位用户。"
 #. =============================================================
 #: ../src/fe-gtk/chanlist.c:862
 msgid "Look in:"
-msgstr "按照："
+msgstr "按照:"
 
 #: ../src/fe-gtk/chanlist.c:874
 msgid "Channel name"
@@ -3334,7 +3334,7 @@ msgstr "频道名称"
 #. =============================================================
 #: ../src/fe-gtk/chanlist.c:894
 msgid "Search type:"
-msgstr "搜索类型："
+msgstr "搜索类型:"
 
 #: ../src/fe-gtk/chanlist.c:901
 msgid "Simple Search"
@@ -3351,7 +3351,7 @@ msgstr "正则表达式"
 #. =============================================================
 #: ../src/fe-gtk/chanlist.c:913 ../src/fe-gtk/maingui.c:2902
 msgid "Find:"
-msgstr "查找："
+msgstr "查找:"
 
 #: ../src/fe-gtk/dccgui.c:141
 #, c-format
@@ -3369,7 +3369,7 @@ msgid ""
 "Cannot access file: %s\n"
 "%s.\n"
 "Resuming not possible."
-msgstr "不能访问文件：%s\n%s。\n无法续传。"
+msgstr "不能访问文件:%s\n%s。\n无法续传。"
 
 #: ../src/fe-gtk/dccgui.c:536
 msgid ""
@@ -3382,8 +3382,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "不能续传来自两个人的同一文件"
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
-msgstr "：文件传输列表"
+msgid "Uploads and Downloads - "
+msgstr "文件传输列表 - "
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3417,11 +3417,11 @@ msgstr "详细信息"
 
 #: ../src/fe-gtk/dccgui.c:878
 msgid "File:"
-msgstr "文件："
+msgstr "文件:"
 
 #: ../src/fe-gtk/dccgui.c:879
 msgid "Address:"
-msgstr "地址："
+msgstr "地址:"
 
 #: ../src/fe-gtk/dccgui.c:885 ../src/fe-gtk/dccgui.c:1084
 msgid "Abort"
@@ -3440,8 +3440,8 @@ msgid "Open Folder..."
 msgstr "打开目录..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr "：DCC 直连聊天列表"
+msgid "DCC Chat List - "
+msgstr "DCC 直连聊天列表 - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3499,7 +3499,7 @@ msgstr "打开一个 irc://server:port/channel?key URL"
 
 #: ../src/fe-gtk/fe-gtk.c:87 ../src/fe-gtk/setup.c:268
 msgid "Execute command:"
-msgstr "执行命令："
+msgstr "执行命令:"
 
 #: ../src/fe-gtk/fe-gtk.c:89
 msgid "Open URL or execute command in an existing HexChat"
@@ -3523,7 +3523,7 @@ msgid ""
 "Failed to open font:\n"
 "\n"
 "%s"
-msgstr "打开字体失败：\n\n%s"
+msgstr "打开字体失败:\n\n%s"
 
 #: ../src/fe-gtk/fe-gtk.c:714
 msgid "Search buffer is empty.\n"
@@ -3537,7 +3537,7 @@ msgstr "%d 字节"
 #: ../src/fe-gtk/fe-gtk.c:826
 #, c-format
 msgid "Network send queue: %d bytes"
-msgstr "网络发送队列：%d 字节"
+msgstr "网络发送队列:%d 字节"
 
 #: ../src/fe-gtk/fkeys.c:141
 msgid ""
@@ -3637,8 +3637,8 @@ msgid "Select a row to get help information on its Action."
 msgstr "选择一行查看对应动作的信息。"
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr "：键盘快捷键"
+msgid "Keyboard Shortcuts - "
+msgstr "键盘快捷键 - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3679,35 +3679,35 @@ msgstr "您确定要删除 %s 中的全部忽略项吗？"
 
 #: ../src/fe-gtk/ignoregui.c:303
 msgid "Enter mask to ignore:"
-msgstr "输入要忽略的掩码："
+msgstr "输入要忽略的掩码:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr "：忽略列表"
+msgid "Ignore list - "
+msgstr "忽略列表 - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
-msgstr "忽略统计："
+msgstr "忽略统计:"
 
 #: ../src/fe-gtk/ignoregui.c:366
 msgid "Channel:"
-msgstr "频道："
+msgstr "频道:"
 
 #: ../src/fe-gtk/ignoregui.c:367
 msgid "Private:"
-msgstr "私聊："
+msgstr "私聊:"
 
 #: ../src/fe-gtk/ignoregui.c:368
 msgid "Notice:"
-msgstr "通知："
+msgstr "通知:"
 
 #: ../src/fe-gtk/ignoregui.c:369
 msgid "CTCP:"
-msgstr "CTCP："
+msgstr "CTCP:"
 
 #: ../src/fe-gtk/ignoregui.c:370
 msgid "Invite:"
-msgstr "邀请："
+msgstr "邀请:"
 
 #: ../src/fe-gtk/ignoregui.c:381 ../src/fe-gtk/notifygui.c:423
 msgid "Add..."
@@ -3718,8 +3718,8 @@ msgid "Channel name too short, try again."
 msgstr "频道名称过短，请重新尝试。"
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr "：连接完毕"
+msgid "Connection Complete - "
+msgstr "连接完毕 - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -3742,7 +3742,7 @@ msgstr "我稍后自行进入频道。(_N)"
 
 #: ../src/fe-gtk/joind.c:190
 msgid "_Join this channel:"
-msgstr "进入以下频道(_J)："
+msgstr "进入以下频道(_J):"
 
 #: ../src/fe-gtk/joind.c:202
 msgid "If you know the name of the channel you want to join, enter it here."
@@ -3750,7 +3750,7 @@ msgstr "如果您知道想要进入的频道的名称，请在此输入。"
 
 #: ../src/fe-gtk/joind.c:209
 msgid "O_pen the Channel-List window."
-msgstr "打开频道列表窗口(_P)："
+msgstr "打开频道列表窗口(_P):"
 
 #: ../src/fe-gtk/joind.c:215
 msgid "Retrieving the Channel-List may take a minute or two."
@@ -3767,7 +3767,7 @@ msgstr "与以下用户对话"
 #: ../src/fe-gtk/maingui.c:696
 #, c-format
 msgid "Topic for %s is: %s"
-msgstr "%s 的主题：%s"
+msgstr "%s 的主题:%s"
 
 #: ../src/fe-gtk/maingui.c:701
 msgid "No topic is set"
@@ -3916,7 +3916,7 @@ msgstr "用户限制"
 
 #: ../src/fe-gtk/maingui.c:2593
 msgid "Enter new nickname:"
-msgstr "输入新昵称："
+msgstr "输入新昵称:"
 
 #: ../src/fe-gtk/maingui.c:2816
 msgid "No results found."
@@ -3970,23 +3970,23 @@ msgstr "未知"
 
 #: ../src/fe-gtk/menu.c:620 ../src/fe-gtk/menu.c:624
 msgid "Real Name:"
-msgstr "真实姓名："
+msgstr "真实姓名:"
 
 #: ../src/fe-gtk/menu.c:631
 msgid "User:"
-msgstr "用户："
+msgstr "用户:"
 
 #: ../src/fe-gtk/menu.c:638
 msgid "Account:"
-msgstr "账户："
+msgstr "账户:"
 
 #: ../src/fe-gtk/menu.c:648
 msgid "Country:"
-msgstr "国家："
+msgstr "国家:"
 
 #: ../src/fe-gtk/menu.c:654
 msgid "Server:"
-msgstr "服务器："
+msgstr "服务器:"
 
 #: ../src/fe-gtk/menu.c:665
 #, c-format
@@ -3995,11 +3995,11 @@ msgstr "%u 分钟之前"
 
 #: ../src/fe-gtk/menu.c:667 ../src/fe-gtk/menu.c:670
 msgid "Last Msg:"
-msgstr "最后发言："
+msgstr "最后发言:"
 
 #: ../src/fe-gtk/menu.c:680
 msgid "Away Msg:"
-msgstr "离开信息："
+msgstr "离开信息:"
 
 #: ../src/fe-gtk/menu.c:737
 #, c-format
@@ -4045,8 +4045,8 @@ msgid "_Auto-Connect"
 msgstr "自动连接(_A)"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr "：用户菜单"
+msgid "User menu - "
+msgstr "用户菜单 - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4105,7 +4105,7 @@ msgid ""
 "\n"
 "%2 would be \"john\"\n"
 "&2 would be \"john hello\"."
-msgstr "用户命令 - 特殊代码：\n\n%c  =  当前频道\n%e  =  当前网络名称\n%m  =  机器信息\n%n  =  你的昵称\n%t  =  时间/日期\n%v  =  HexChat 版本\n%2  =  第 2 个词\n%3  =  第 3 个词\n&2  =  从第 2 个词到行末\n&3  =  从第 3 个词到行末\n\n如:\n/cmd john hello\n\n%2 是“john”\n&2 是“john hello”。"
+msgstr "用户命令 - 特殊代码:\n\n%c  =  当前频道\n%e  =  当前网络名称\n%m  =  机器信息\n%n  =  你的昵称\n%t  =  时间/日期\n%v  =  HexChat 版本\n%2  =  第 2 个词\n%3  =  第 3 个词\n&2  =  从第 2 个词到行末\n&3  =  从第 3 个词到行末\n\n如:\n/cmd john hello\n\n%2 是“john”\n&2 是“john hello”。"
 
 #: ../src/fe-gtk/menu.c:1485
 msgid ""
@@ -4120,7 +4120,7 @@ msgid ""
 "%s  =  selected nick\n"
 "%t  =  time/date\n"
 "%u  =  selected users account"
-msgstr "用户列表按钮 - 特殊代码：\n\n%a  =  所有选取的用户\n%c  =  当前频道\n%e  =  当前网络名称\n%h  =  选取昵称的主机名\n%m  =  机器信息\n%n  =  您的昵称\n%s  =  选取的昵称\n%t  =  时间/日期\n%u = 选取的用户账号"
+msgstr "用户列表按钮 - 特殊代码:\n\n%a  =  所有选取的用户\n%c  =  当前频道\n%e  =  当前网络名称\n%h  =  选取昵称的主机名\n%m  =  机器信息\n%n  =  您的昵称\n%s  =  选取的昵称\n%t  =  时间/日期\n%u = 选取的用户账号"
 
 #: ../src/fe-gtk/menu.c:1496
 msgid ""
@@ -4166,36 +4166,36 @@ msgid ""
 msgstr "URL 处理程序 - 特殊代码:\n\n%s  =  URL 字符串\n\n在命令前加一个 “!” 表示\n该命令应被发送到 shell 而\n非 HexChat"
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr "：用户自定义命令"
+msgid "User Defined Commands - "
+msgstr "用户自定义命令 - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr "：用户列表弹出菜单"
+msgid "Userlist Popup menu - "
+msgstr "用户列表弹出菜单 - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "使用以下替换"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr "：替换"
+msgid "Replace - "
+msgstr "替换 - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr "：URL 处理程序"
+msgid "URL Handlers - "
+msgstr "URL 处理程序 - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr "：用户列表按钮"
+msgid "Userlist buttons - "
+msgstr "用户列表按钮 - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr "：对话按钮"
+msgid "Dialog buttons - "
+msgstr "对话按钮 - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr "：CTCP 回应"
+msgid "CTCP Replies - "
+msgstr "CTCP 回应 - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4491,19 +4491,19 @@ msgstr "上线"
 
 #: ../src/fe-gtk/notifygui.c:343
 msgid "Enter nickname to add:"
-msgstr "输入要添加的昵称："
+msgstr "输入要添加的昵称:"
 
 #: ../src/fe-gtk/notifygui.c:372
 msgid "Notify on these networks:"
-msgstr "在这些网络中进行通知："
+msgstr "在这些网络中进行通知:"
 
 #: ../src/fe-gtk/notifygui.c:383
 msgid "Comma separated list of networks is accepted."
 msgstr "此处允许使用逗号分隔多个网络。"
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
-msgstr "：好友列表"
+msgid "Friends List - "
+msgstr "好友列表 - "
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4512,7 +4512,7 @@ msgstr "打开对话框"
 #: ../src/fe-gtk/plugin-notification.c:111
 #, c-format
 msgid "Highlighted message from: %s (%s)"
-msgstr "高亮消息来自于：%s (%s)"
+msgstr "高亮消息来自于:%s (%s)"
 
 #: ../src/fe-gtk/plugin-notification.c:123
 #, c-format
@@ -4537,12 +4537,12 @@ msgstr "%s  (%s) 发的通知"
 #: ../src/fe-gtk/plugin-notification.c:158
 #, c-format
 msgid "Private message from: %s (%s)"
-msgstr "私聊消息来自于：%s (%s)"
+msgstr "私聊消息来自于:%s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
-msgstr "：已连接到 %u 个网络和 %u 个频道"
+msgid "Connected to %u networks and %u channels - "
+msgstr ":已连接到 %u 个网络和 %u 个频道"
 
 #: ../src/fe-gtk/plugin-tray.c:545
 msgid "_Restore Window"
@@ -4583,43 +4583,43 @@ msgstr "返回(_B)"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
-msgstr "：高亮消息来自于：%s (%s)"
+msgid "Highlighted message from: %s (%s) - "
+msgstr ":高亮消息来自于:%s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
-msgstr "：%u 条高亮消息，最近一条来自于：%s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
+msgstr ":%u 条高亮消息，最近一条来自于:%s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
-msgstr ": 频道消息来自于: %s (%s)"
+msgid "Channel message from: %s (%s) - "
+msgstr "频道消息来自于: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
-msgstr ": %u 频道消息。"
+msgid "%u channel messages. - "
+msgstr "%u 频道消息。 - "
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
-msgstr "：私聊消息来自于：%s (%s)"
+msgid "Private message from: %s (%s) - "
+msgstr ":私聊消息来自于:%s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
-msgstr "：%u 条私聊消息，最近的一个来自于: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
+msgstr ":%u 条私聊消息，最近的一个来自于: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
-msgstr "XChat: 文件传输来自于: %s (%s)"
+msgid "File offer from: %s (%s) - "
+msgstr "文件传输来自于: %s (%s) - "
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
-msgstr "Xchat: %u 个文件传输,最近的一个来自于：%s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
+msgstr "%u 个文件传输,最近的一个来自于:%s (%s) - "
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4634,8 +4634,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "选择要载入的插件或脚本"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr "：插件和脚本"
+msgid "Plugins and Scripts - "
+msgstr "插件和脚本 - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4656,8 +4656,8 @@ msgstr "另存为..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
-msgstr "：原始聊天记录 (%s)"
+msgid "Raw Log (%s) - "
+msgstr ":原始聊天记录 (%s)"
 
 #: ../src/fe-gtk/rawlog.c:133
 msgid "Clear Raw Log"
@@ -4692,8 +4692,8 @@ msgstr "您向服务器发送的个人身份识别信息。如果需要自定义
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr "：编辑 %s"
+msgid "Edit %s - "
+msgstr "编辑 %s - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4753,27 +4753,27 @@ msgstr "使用全局用户信息"
 
 #: ../src/fe-gtk/servlistgui.c:1880 ../src/fe-gtk/servlistgui.c:1997
 msgid "_Nick name:"
-msgstr "昵称(_N)："
+msgstr "昵称(_N):"
 
 #: ../src/fe-gtk/servlistgui.c:1881 ../src/fe-gtk/servlistgui.c:2004
 msgid "Second choice:"
-msgstr "第二选择："
+msgstr "第二选择:"
 
 #: ../src/fe-gtk/servlistgui.c:1882
 msgid "Rea_l name:"
-msgstr "真实姓名(_L)："
+msgstr "真实姓名(_L):"
 
 #: ../src/fe-gtk/servlistgui.c:1883 ../src/fe-gtk/servlistgui.c:2018
 msgid "_User name:"
-msgstr "用户名(_U)："
+msgstr "用户名(_U):"
 
 #: ../src/fe-gtk/servlistgui.c:1885
 msgid "Login method:"
-msgstr "登录方法："
+msgstr "登录方法:"
 
 #: ../src/fe-gtk/servlistgui.c:1891 ../src/fe-gtk/setup.c:655
 msgid "Password:"
-msgstr "密码："
+msgstr "密码:"
 
 #: ../src/fe-gtk/servlistgui.c:1891
 msgid "Password used for login. If in doubt, leave blank."
@@ -4781,11 +4781,11 @@ msgstr "登录时使用的密码。如果不确定请留空。"
 
 #: ../src/fe-gtk/servlistgui.c:1896
 msgid "Character set:"
-msgstr "字符集："
+msgstr "字符集:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr "：网络列表"
+msgid "Network List - "
+msgstr ":网络列表"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -4793,7 +4793,7 @@ msgstr "用户信息"
 
 #: ../src/fe-gtk/servlistgui.c:2011
 msgid "Third choice:"
-msgstr "第三选择："
+msgstr "第三选择:"
 
 #: ../src/fe-gtk/servlistgui.c:2071
 msgid "Networks"
@@ -5047,15 +5047,15 @@ msgstr "一般"
 
 #: ../src/fe-gtk/setup.c:151
 msgid "Language:"
-msgstr "语言："
+msgstr "语言:"
 
 #: ../src/fe-gtk/setup.c:152
 msgid "Main font:"
-msgstr "主要字体："
+msgstr "主要字体:"
 
 #: ../src/fe-gtk/setup.c:154
 msgid "Font:"
-msgstr "字体："
+msgstr "字体:"
 
 #: ../src/fe-gtk/setup.c:157
 msgid "Text Box"
@@ -5087,7 +5087,7 @@ msgstr "在最后读取的文本后添加一条红线。"
 
 #: ../src/fe-gtk/setup.c:161
 msgid "Background image:"
-msgstr "背景图像："
+msgstr "背景图像:"
 
 #: ../src/fe-gtk/setup.c:163
 msgid "Transparency Settings"
@@ -5095,7 +5095,7 @@ msgstr "透明度设置"
 
 #: ../src/fe-gtk/setup.c:164
 msgid "Window Opacity:"
-msgstr "窗口透明度："
+msgstr "窗口透明度:"
 
 #: ../src/fe-gtk/setup.c:166 ../src/fe-gtk/setup.c:593
 msgid "Time Stamps"
@@ -5107,7 +5107,7 @@ msgstr "启用时间戳"
 
 #: ../src/fe-gtk/setup.c:168
 msgid "Time stamp format:"
-msgstr "时间戳格式："
+msgstr "时间戳格式:"
 
 #: ../src/fe-gtk/setup.c:170 ../src/fe-gtk/setup.c:597
 msgid "See the strftime MSDN article for details."
@@ -5163,7 +5163,7 @@ msgstr "拼写检查"
 
 #: ../src/fe-gtk/setup.c:197
 msgid "Dictionaries to use:"
-msgstr "要使用的字典："
+msgstr "要使用的字典:"
 
 #: ../src/fe-gtk/setup.c:199
 msgid ""
@@ -5181,15 +5181,15 @@ msgstr "昵称自动补全"
 
 #: ../src/fe-gtk/setup.c:205
 msgid "Nick completion suffix:"
-msgstr "昵称自动补全后缀："
+msgstr "昵称自动补全后缀:"
 
 #: ../src/fe-gtk/setup.c:206
 msgid "Nick completion sorted:"
-msgstr "昵称排序："
+msgstr "昵称排序:"
 
 #: ../src/fe-gtk/setup.c:207
 msgid "Nick completion amount:"
-msgstr "昵称自动补全量："
+msgstr "昵称自动补全量:"
 
 #: ../src/fe-gtk/setup.c:207
 msgid "Threshold of nicks to start listing instead of completing"
@@ -5277,11 +5277,11 @@ msgstr "显示当前频道用户数"
 
 #: ../src/fe-gtk/setup.c:260
 msgid "User list sorted by:"
-msgstr "用户列表排列方式："
+msgstr "用户列表排列方式:"
 
 #: ../src/fe-gtk/setup.c:261
 msgid "Show user list at:"
-msgstr "显示用户列表于："
+msgstr "显示用户列表于:"
 
 #: ../src/fe-gtk/setup.c:263
 msgid "Away Tracking"
@@ -5293,7 +5293,7 @@ msgstr "追踪用户的离开状态并且以不同颜色标记"
 
 #: ../src/fe-gtk/setup.c:265
 msgid "On channels smaller than:"
-msgstr "在小于此值的频道里："
+msgstr "在小于此值的频道里:"
 
 #: ../src/fe-gtk/setup.c:267
 msgid "Action Upon Double Click"
@@ -5305,7 +5305,7 @@ msgstr "附加小程序"
 
 #: ../src/fe-gtk/setup.c:271
 msgid "Lag meter:"
-msgstr "延时表："
+msgstr "延时表:"
 
 #: ../src/fe-gtk/setup.c:272
 msgid "Throttle meter:"
@@ -5348,7 +5348,7 @@ msgstr "树状图"
 #. {ST_HEADER,	N_("Channel Switcher"),0,0,0},
 #: ../src/fe-gtk/setup.c:311
 msgid "Switcher type:"
-msgstr "转换器类型："
+msgstr "转换器类型:"
 
 #: ../src/fe-gtk/setup.c:312
 msgid "Open an extra tab for server messages"
@@ -5384,19 +5384,19 @@ msgstr "小字"
 
 #: ../src/fe-gtk/setup.c:320
 msgid "Focus new tabs:"
-msgstr "聚焦到新标签页："
+msgstr "聚焦到新标签页:"
 
 #: ../src/fe-gtk/setup.c:321
 msgid "Placement of notices:"
-msgstr "放置通知："
+msgstr "放置通知:"
 
 #: ../src/fe-gtk/setup.c:322
 msgid "Show channel switcher at:"
-msgstr "显示频道转换器于："
+msgstr "显示频道转换器于:"
 
 #: ../src/fe-gtk/setup.c:323
 msgid "Shorten tab labels to:"
-msgstr "缩短标签页标签页至："
+msgstr "缩短标签页标签页至:"
 
 #: ../src/fe-gtk/setup.c:323
 msgid "letters."
@@ -5408,15 +5408,15 @@ msgstr "标签页或窗口"
 
 #: ../src/fe-gtk/setup.c:326
 msgid "Open channels in:"
-msgstr "打开频道于："
+msgstr "打开频道于:"
 
 #: ../src/fe-gtk/setup.c:327
 msgid "Open dialogs in:"
-msgstr "打开对话框于："
+msgstr "打开对话框于:"
 
 #: ../src/fe-gtk/setup.c:328
 msgid "Open utilities in:"
-msgstr "打开工具于："
+msgstr "打开工具于:"
 
 #: ../src/fe-gtk/setup.c:328
 msgid "Open DCC, Ignore, Notify etc, in tabs or windows?"
@@ -5448,15 +5448,15 @@ msgstr "文件和目录"
 
 #: ../src/fe-gtk/setup.c:353
 msgid "Auto accept file offers:"
-msgstr "自动接受文件传输："
+msgstr "自动接受文件传输:"
 
 #: ../src/fe-gtk/setup.c:354
 msgid "Download files to:"
-msgstr "把文件下载到："
+msgstr "把文件下载到:"
 
 #: ../src/fe-gtk/setup.c:355
 msgid "Move completed files to:"
-msgstr "将完成下载的文件移动到："
+msgstr "将完成下载的文件移动到:"
 
 #: ../src/fe-gtk/setup.c:356
 msgid "Save nick name in filenames"
@@ -5484,7 +5484,7 @@ msgstr "最大文件传输速度(字节每秒)"
 
 #: ../src/fe-gtk/setup.c:364
 msgid "One upload:"
-msgstr "每个上传任务："
+msgstr "每个上传任务:"
 
 #: ../src/fe-gtk/setup.c:365 ../src/fe-gtk/setup.c:367
 msgid "Maximum speed for one transfer"
@@ -5492,11 +5492,11 @@ msgstr "一个传送进程的最大速度"
 
 #: ../src/fe-gtk/setup.c:366
 msgid "One download:"
-msgstr "每个下载任务："
+msgstr "每个下载任务:"
 
 #: ../src/fe-gtk/setup.c:368
 msgid "All uploads combined:"
-msgstr "所有上传："
+msgstr "所有上传:"
 
 #: ../src/fe-gtk/setup.c:369 ../src/fe-gtk/setup.c:371
 msgid "Maximum speed for all files"
@@ -5514,23 +5514,23 @@ msgstr "提示"
 
 #: ../src/fe-gtk/setup.c:403 ../src/fe-gtk/setup.c:485
 msgid "Show notifications on:"
-msgstr "显示通知于："
+msgstr "显示通知于:"
 
 #: ../src/fe-gtk/setup.c:404 ../src/fe-gtk/setup.c:442
 msgid "Blink tray icon on:"
-msgstr "托盘图标闪烁于："
+msgstr "托盘图标闪烁于:"
 
 #: ../src/fe-gtk/setup.c:405 ../src/fe-gtk/setup.c:447
 #: ../src/fe-gtk/setup.c:486 ../src/fe-gtk/setup.c:508
 msgid "Blink task bar on:"
-msgstr "任务栏图标闪烁于："
+msgstr "任务栏图标闪烁于:"
 
 #: ../src/fe-gtk/setup.c:407 ../src/fe-gtk/setup.c:410
 #: ../src/fe-gtk/setup.c:412 ../src/fe-gtk/setup.c:451
 #: ../src/fe-gtk/setup.c:454 ../src/fe-gtk/setup.c:456
 #: ../src/fe-gtk/setup.c:487 ../src/fe-gtk/setup.c:509
 msgid "Make a beep sound on:"
-msgstr "响铃于："
+msgstr "响铃于:"
 
 #: ../src/fe-gtk/setup.c:407 ../src/fe-gtk/setup.c:451
 msgid ""
@@ -5595,22 +5595,22 @@ msgstr "高亮显示消息"
 #: ../src/fe-gtk/setup.c:493 ../src/fe-gtk/setup.c:515
 msgid ""
 "Highlighted messages are ones where your nickname is mentioned, but also:"
-msgstr "高亮消息是当您的昵称被提到时所显示的消息，同时还显示："
+msgstr "高亮消息是当您的昵称被提到时所显示的消息，同时还显示:"
 
 #: ../src/fe-gtk/setup.c:429 ../src/fe-gtk/setup.c:472
 #: ../src/fe-gtk/setup.c:495 ../src/fe-gtk/setup.c:517
 msgid "Extra words to highlight:"
-msgstr "需要高亮显示的其他单词："
+msgstr "需要高亮显示的其他单词:"
 
 #: ../src/fe-gtk/setup.c:430 ../src/fe-gtk/setup.c:473
 #: ../src/fe-gtk/setup.c:496 ../src/fe-gtk/setup.c:518
 msgid "Nick names not to highlight:"
-msgstr "不高亮显示的昵称："
+msgstr "不高亮显示的昵称:"
 
 #: ../src/fe-gtk/setup.c:431 ../src/fe-gtk/setup.c:474
 #: ../src/fe-gtk/setup.c:497 ../src/fe-gtk/setup.c:519
 msgid "Nick names to always highlight:"
-msgstr "总是高亮显示的昵称："
+msgstr "总是高亮显示的昵称:"
 
 #: ../src/fe-gtk/setup.c:432 ../src/fe-gtk/setup.c:475
 #: ../src/fe-gtk/setup.c:498 ../src/fe-gtk/setup.c:520
@@ -5629,15 +5629,15 @@ msgstr "默认信息"
 
 #: ../src/fe-gtk/setup.c:528
 msgid "Quit:"
-msgstr "退出："
+msgstr "退出:"
 
 #: ../src/fe-gtk/setup.c:529
 msgid "Leave channel:"
-msgstr "离开频道："
+msgstr "离开频道:"
 
 #: ../src/fe-gtk/setup.c:530
 msgid "Away:"
-msgstr "离开："
+msgstr "离开:"
 
 #: ../src/fe-gtk/setup.c:532
 msgid "Away"
@@ -5739,11 +5739,11 @@ msgstr "自动在复制的每行文本中加上颜色信息，否则，在选择
 
 #: ../src/fe-gtk/setup.c:570
 msgid "Real name:"
-msgstr "真实姓名："
+msgstr "真实姓名:"
 
 #: ../src/fe-gtk/setup.c:572
 msgid "Alternative fonts:"
-msgstr "备用字体："
+msgstr "备用字体:"
 
 #: ../src/fe-gtk/setup.c:572
 msgid "Separate multiple entries with commas without spaces before or after."
@@ -5773,15 +5773,15 @@ msgstr "断线重连"
 
 #: ../src/fe-gtk/setup.c:577
 msgid "Auto reconnect delay:"
-msgstr "自动重连间隔："
+msgstr "自动重连间隔:"
 
 #: ../src/fe-gtk/setup.c:578
 msgid "Auto join delay:"
-msgstr "自动重连间隔："
+msgstr "自动重连间隔:"
 
 #: ../src/fe-gtk/setup.c:579
 msgid "Ban Type:"
-msgstr "屏蔽类型："
+msgstr "屏蔽类型:"
 
 #: ../src/fe-gtk/setup.c:579
 msgid ""
@@ -5799,7 +5799,7 @@ msgstr "显示上一会话时的信息回滚"
 
 #: ../src/fe-gtk/setup.c:588
 msgid "Scrollback lines:"
-msgstr "往回滚动的行数："
+msgstr "往回滚动的行数:"
 
 #: ../src/fe-gtk/setup.c:589
 msgid "Enable logging of conversations to disk"
@@ -5807,7 +5807,7 @@ msgstr "允许对话记录写入磁盘"
 
 #: ../src/fe-gtk/setup.c:590
 msgid "Log filename:"
-msgstr "聊天记录文件名称："
+msgstr "聊天记录文件名称:"
 
 #: ../src/fe-gtk/setup.c:591
 #, c-format
@@ -5820,7 +5820,7 @@ msgstr "在聊天记录中插入时间戳"
 
 #: ../src/fe-gtk/setup.c:595
 msgid "Log timestamp format:"
-msgstr "聊天记录时间戳格式："
+msgstr "聊天记录时间戳格式:"
 
 #: ../src/fe-gtk/setup.c:602
 msgid "URLs"
@@ -5836,7 +5836,7 @@ msgstr "开启 URL 抓取程序"
 
 #: ../src/fe-gtk/setup.c:605
 msgid "Maximum number of URLs to grab:"
-msgstr "抓取最多的 URL 条目数："
+msgstr "抓取最多的 URL 条目数:"
 
 #: ../src/fe-gtk/setup.c:612
 msgid "(Disabled)"
@@ -5880,7 +5880,7 @@ msgstr "您的地址"
 
 #: ../src/fe-gtk/setup.c:634
 msgid "Bind to:"
-msgstr "绑定到："
+msgstr "绑定到:"
 
 #: ../src/fe-gtk/setup.c:635
 msgid "Only useful for computers with multiple addresses."
@@ -5902,7 +5902,7 @@ msgstr "向 IRC 服务器查询您的真实地址。如果您有 192.168.*.* 这
 
 #: ../src/fe-gtk/setup.c:640
 msgid "DCC IP address:"
-msgstr "DCC IP 地址："
+msgstr "DCC IP 地址:"
 
 #: ../src/fe-gtk/setup.c:641
 msgid "Claim you are at this address when offering files."
@@ -5910,11 +5910,11 @@ msgstr "发送文件时声称您使用此地址。"
 
 #: ../src/fe-gtk/setup.c:642
 msgid "First DCC send port:"
-msgstr "第一个 DCC 文件发送端口："
+msgstr "第一个 DCC 文件发送端口:"
 
 #: ../src/fe-gtk/setup.c:643
 msgid "Last DCC send port:"
-msgstr "最后一个 DCC 文件传送端口："
+msgstr "最后一个 DCC 文件传送端口:"
 
 #: ../src/fe-gtk/setup.c:644
 msgid "!Leave ports at zero for full range."
@@ -5926,19 +5926,19 @@ msgstr "代理服务器"
 
 #: ../src/fe-gtk/setup.c:647
 msgid "Hostname:"
-msgstr "主机名："
+msgstr "主机名:"
 
 #: ../src/fe-gtk/setup.c:648 ../src/fe-gtk/setup.c:664
 msgid "Port:"
-msgstr "端口号："
+msgstr "端口号:"
 
 #: ../src/fe-gtk/setup.c:649
 msgid "Type:"
-msgstr "类型："
+msgstr "类型:"
 
 #: ../src/fe-gtk/setup.c:650
 msgid "Use proxy for:"
-msgstr "应用代理于："
+msgstr "应用代理于:"
 
 #: ../src/fe-gtk/setup.c:652
 msgid "Proxy Authentication"
@@ -5950,7 +5950,7 @@ msgstr "使用验证(仅支持 HTTP 或 Socks5 代理服务器)"
 
 #: ../src/fe-gtk/setup.c:654
 msgid "Username:"
-msgstr "用户名："
+msgstr "用户名:"
 
 #: ../src/fe-gtk/setup.c:662
 msgid "Identd Server"
@@ -6000,19 +6000,19 @@ msgstr "文本颜色"
 
 #: ../src/fe-gtk/setup.c:1536
 msgid "mIRC colors:"
-msgstr "mIRC 颜色："
+msgstr "mIRC 颜色:"
 
 #: ../src/fe-gtk/setup.c:1544
 msgid "Local colors:"
-msgstr "本地颜色："
+msgstr "本地颜色:"
 
 #: ../src/fe-gtk/setup.c:1552 ../src/fe-gtk/setup.c:1557
 msgid "Foreground:"
-msgstr "前景："
+msgstr "前景:"
 
 #: ../src/fe-gtk/setup.c:1553 ../src/fe-gtk/setup.c:1558
 msgid "Background:"
-msgstr "背景："
+msgstr "背景:"
 
 #: ../src/fe-gtk/setup.c:1555
 msgid "Selected Text"
@@ -6024,27 +6024,27 @@ msgstr "界面颜色"
 
 #: ../src/fe-gtk/setup.c:1562
 msgid "New data:"
-msgstr "新数据："
+msgstr "新数据:"
 
 #: ../src/fe-gtk/setup.c:1563
 msgid "Marker line:"
-msgstr "标记线："
+msgstr "标记线:"
 
 #: ../src/fe-gtk/setup.c:1564
 msgid "New message:"
-msgstr "新信息："
+msgstr "新信息:"
 
 #: ../src/fe-gtk/setup.c:1565
 msgid "Away user:"
-msgstr "离开的用户："
+msgstr "离开的用户:"
 
 #: ../src/fe-gtk/setup.c:1566
 msgid "Highlight:"
-msgstr "高亮显示："
+msgstr "高亮显示:"
 
 #: ../src/fe-gtk/setup.c:1567
 msgid "Spell checker:"
-msgstr "拼写检查程序："
+msgstr "拼写检查程序:"
 
 #: ../src/fe-gtk/setup.c:1569
 msgid "Color Stripping"
@@ -6146,11 +6146,11 @@ msgid ""
 "Auto accepting DCC to your home directory\n"
 "can be dangerous and is exploitable. Eg:\n"
 "Someone could send you a .bash_profile"
-msgstr "*警告*\n自动接收 DCC 到您的主目录中是危险之举，\n且有被盗用的可能性。例如：\n某人可能会给您发送一份 .bash_profile 文件"
+msgstr "*警告*\n自动接收 DCC 到您的主目录中是危险之举，\n且有被盗用的可能性。例如:\n某人可能会给您发送一份 .bash_profile 文件"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr "：首选项"
+msgid "Preferences - "
+msgstr ":首选项"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6178,7 +6178,7 @@ msgstr "拼写建议"
 #: ../src/fe-gtk/sexy-spell-entry.c:1293
 #, c-format
 msgid "enchant error for language: %s"
-msgstr "enchant 在以下语言中出错：%s"
+msgstr "enchant 在以下语言中出错:%s"
 
 #: ../src/fe-gtk/textgui.c:171
 msgid "There was an error parsing the string"
@@ -6214,8 +6214,8 @@ msgid "OK"
 msgstr "确认"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr "：URL 抓取程序"
+msgid "URL Grabber - "
+msgstr ":URL 抓取程序"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"
@@ -6244,32 +6244,32 @@ msgstr "打开一个 irc://server:port/channel URL"
 
 #: ../plugins/sysinfo/sysinfo.c:128
 msgid "Sysinfo: Failed to get info. Either not supported or error."
-msgstr "系统信息：获取信息失败。可能是不支持也可能是错误。"
+msgstr "系统信息:获取信息失败。可能是不支持也可能是错误。"
 
 #: ../plugins/sysinfo/sysinfo.c:133
 msgid "Sysinfo: No info by that name\n"
-msgstr "系统信息：没有以此名字的信息\n"
+msgstr "系统信息:没有以此名字的信息\n"
 
 #: ../plugins/sysinfo/sysinfo.c:164 ../plugins/sysinfo/sysinfo.c:168
 #, c-format
 msgid "Sysinfo: %s is set to: %d\n"
-msgstr "系统信息：%s 被设置为：%d\n"
+msgstr "系统信息:%s 被设置为:%d\n"
 
 #: ../plugins/sysinfo/sysinfo.c:178
 msgid ""
 "Sysinfo: Valid settings are: announce and hide_* for each piece of "
 "information. e.g. hide_os. Without a value it will show current (or default)"
 " setting.\n"
-msgstr "系统信息：有效的信息是：通知并为每一条信息加前缀 hide_* 。比如 hide_os。若没有值的话将会显示当前 (或默认) 设置。\n"
+msgstr "系统信息:有效的信息是:通知并为每一条信息加前缀 hide_* 。比如 hide_os。若没有值的话将会显示当前 (或默认) 设置。\n"
 
 #: ../plugins/sysinfo/sysinfo.c:193 ../plugins/sysinfo/sysinfo.c:200
 #, c-format
 msgid "Sysinfo: pciids is set to: %s\n"
-msgstr "系统信息：pciids 被设置为：%s\n"
+msgstr "系统信息:pciids 被设置为:%s\n"
 
 #: ../plugins/sysinfo/sysinfo.c:218
 msgid "Sysinfo: Invalid variable name\n"
-msgstr "系统信息：无效的变量名\n"
+msgstr "系统信息:无效的变量名\n"
 
 #: ../plugins/sysinfo/sysinfo.c:267
 #, c-format

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -3251,8 +3251,8 @@ msgstr "您只能在一个频道的标签页下打开屏蔽列表窗口。"
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr ":屏蔽列表(%s)"
+msgid "Ban List (%s) - %s"
+msgstr "屏蔽列表(%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3290,8 +3290,8 @@ msgstr "复制频道主题(_T)"
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr "频道列表(%s) - "
+msgid "Channel List (%s) - %s"
+msgstr "频道列表(%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3382,8 +3382,8 @@ msgid "Cannot resume the same file from two people."
 msgstr "不能续传来自两个人的同一文件"
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
-msgstr "文件传输列表 - "
+msgid "Uploads and Downloads - %s"
+msgstr "文件传输列表 - %s"
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
 #: ../src/fe-gtk/notifygui.c:124
@@ -3440,8 +3440,8 @@ msgid "Open Folder..."
 msgstr "打开目录..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "DCC 直连聊天列表 - "
+msgid "DCC Chat List - %s"
+msgstr "DCC 直连聊天列表 - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3637,8 +3637,8 @@ msgid "Select a row to get help information on its Action."
 msgstr "选择一行查看对应动作的信息。"
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "键盘快捷键 - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "键盘快捷键 - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3682,8 +3682,8 @@ msgid "Enter mask to ignore:"
 msgstr "输入要忽略的掩码:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "忽略列表 - "
+msgid "Ignore list - %s"
+msgstr "忽略列表 - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3718,8 +3718,8 @@ msgid "Channel name too short, try again."
 msgstr "频道名称过短，请重新尝试。"
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "连接完毕 - "
+msgid "Connection Complete - %s"
+msgstr "连接完毕 - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4045,8 +4045,8 @@ msgid "_Auto-Connect"
 msgstr "自动连接(_A)"
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "用户菜单 - "
+msgid "User menu - %s"
+msgstr "用户菜单 - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4166,36 +4166,36 @@ msgid ""
 msgstr "URL 处理程序 - 特殊代码:\n\n%s  =  URL 字符串\n\n在命令前加一个 “!” 表示\n该命令应被发送到 shell 而\n非 HexChat"
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "用户自定义命令 - "
+msgid "User Defined Commands - %s"
+msgstr "用户自定义命令 - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "用户列表弹出菜单 - "
+msgid "Userlist Popup menu - %s"
+msgstr "用户列表弹出菜单 - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "使用以下替换"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "替换 - "
+msgid "Replace - %s"
+msgstr "替换 - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "URL 处理程序 - "
+msgid "URL Handlers - %s"
+msgstr "URL 处理程序 - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "用户列表按钮 - "
+msgid "Userlist buttons - %s"
+msgstr "用户列表按钮 - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "对话按钮 - "
+msgid "Dialog buttons - %s"
+msgstr "对话按钮 - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "CTCP 回应 - "
+msgid "CTCP Replies - %s"
+msgstr "CTCP 回应 - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4502,8 +4502,8 @@ msgid "Comma separated list of networks is accepted."
 msgstr "此处允许使用逗号分隔多个网络。"
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
-msgstr "好友列表 - "
+msgid "Friends List - %s"
+msgstr "好友列表 - %s"
 
 #: ../src/fe-gtk/notifygui.c:431
 msgid "Open Dialog"
@@ -4541,7 +4541,7 @@ msgstr "私聊消息来自于:%s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
+msgid "Connected to %u networks and %u channels - %s"
 msgstr ":已连接到 %u 个网络和 %u 个频道"
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4583,43 +4583,43 @@ msgstr "返回(_B)"
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
 msgstr ":高亮消息来自于:%s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
 msgstr ":%u 条高亮消息，最近一条来自于:%s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
-msgstr "频道消息来自于: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
+msgstr "频道消息来自于: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
-msgstr "%u 频道消息。 - "
+msgid "%u channel messages. - %s"
+msgstr "%u 频道消息。 - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
 msgstr ":私聊消息来自于:%s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
 msgstr ":%u 条私聊消息，最近的一个来自于: %s (%s)"
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
-msgstr "文件传输来自于: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
+msgstr "文件传输来自于: %s (%s) - %s"
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
-msgstr "%u 个文件传输,最近的一个来自于:%s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
+msgstr "%u 个文件传输,最近的一个来自于:%s (%s) - %s"
 
 #: ../src/fe-gtk/plugingui.c:65
 msgid "Version"
@@ -4634,8 +4634,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "选择要载入的插件或脚本"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "插件和脚本 - "
+msgid "Plugins and Scripts - %s"
+msgstr "插件和脚本 - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4656,7 +4656,7 @@ msgstr "另存为..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ":原始聊天记录 (%s)"
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4692,8 +4692,8 @@ msgstr "您向服务器发送的个人身份识别信息。如果需要自定义
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "编辑 %s - "
+msgid "Edit %s - %s"
+msgstr "编辑 %s - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4784,7 +4784,7 @@ msgid "Character set:"
 msgstr "字符集:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
+msgid "Network List - %s"
 msgstr ":网络列表"
 
 #: ../src/fe-gtk/servlistgui.c:1987
@@ -6149,8 +6149,8 @@ msgid ""
 msgstr "*警告*\n自动接收 DCC 到您的主目录中是危险之举，\n且有被盗用的可能性。例如:\n某人可能会给您发送一份 .bash_profile 文件"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr ":首选项"
+msgid "Preferences - %s"
+msgstr "首选项 - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6214,8 +6214,8 @@ msgid "OK"
 msgstr "确认"
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr ":URL 抓取程序"
+msgid "URL Grabber - %s"
+msgstr "URL 抓取程序 - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -231,7 +231,7 @@ msgstr "加入聊天室..."
 
 #: ../src/common/hexchat.c:918 ../src/fe-gtk/menu.c:1410
 msgid "Enter Channel to Join:"
-msgstr "輸入要加入的聊天室："
+msgstr "輸入要加入的聊天室:"
 
 #: ../src/common/hexchat.c:919
 msgid "Server Links"
@@ -260,7 +260,7 @@ msgstr "道別"
 #: ../src/common/hexchat.c:936
 #, c-format
 msgid "Enter reason to kick %s:"
-msgstr "輸入踢出 %s 的原因："
+msgstr "輸入踢出 %s 的原因:"
 
 #: ../src/common/hexchat.c:937
 msgid "Sendfile"
@@ -389,15 +389,15 @@ msgstr "使用 /bin/sh 才能執行本程式！\n"
 
 #: ../src/common/outbound.c:2195
 msgid "Commands Available:"
-msgstr "可用命令："
+msgstr "可用命令:"
 
 #: ../src/common/outbound.c:2209
 msgid "User defined commands:"
-msgstr "使用者自訂命令："
+msgstr "使用者自訂命令:"
 
 #: ../src/common/outbound.c:2225
 msgid "Plugin defined commands:"
-msgstr "使用者自訂命令："
+msgstr "使用者自訂命令:"
 
 #: ../src/common/outbound.c:2236
 msgid "Type /HELP <command> for more information, or /HELP -l"
@@ -482,7 +482,7 @@ msgstr ""
 
 #: ../src/common/outbound.c:3880
 msgid "COUNTRY [-s] <code|wildcard>, finds a country code, eg: au = australia"
-msgstr "COUNTRY [-s] <code|wildcard>，查看國家代碼對應的國家名，比如：tw = 臺灣"
+msgstr "COUNTRY [-s] <code|wildcard>，查看國家代碼對應的國家名，比如:tw = 臺灣"
 
 #: ../src/common/outbound.c:3882
 msgid ""
@@ -507,7 +507,7 @@ msgid ""
 "DCC PCHAT <nick>                    - offer DCC CHAT using passive mode\n"
 "DCC CLOSE <type> <nick> <file>         example:\n"
 "         /dcc close send johnsmith file.tar.gz"
-msgstr "\nDCC GET <nick>                     - 接收暱稱為 <nick> 者發送給您的檔案\nDCC SEND [-maxcps=#] <nick> [file] - 發送檔案給某人\nDCC PSEND [-maxcps=#] <nick> [file] - 使用被動模式發送檔案給某人\nDCC LIST                           - 顯示 DCC 清單\nDCC CHAT <nick>                    - 與某人密談\nDCC PCHAT <nick>                    - 使用被動模式與某人密談\nDCC CLOSE <type> <nick> <file>         例如：\n         /dcc close send johnsmith file.tar.gz"
+msgstr "\nDCC GET <nick>                     - 接收暱稱為 <nick> 者發送給您的檔案\nDCC SEND [-maxcps=#] <nick> [file] - 發送檔案給某人\nDCC PSEND [-maxcps=#] <nick> [file] - 使用被動模式發送檔案給某人\nDCC LIST                           - 顯示 DCC 清單\nDCC CHAT <nick>                    - 與某人密談\nDCC PCHAT <nick>                    - 使用被動模式與某人密談\nDCC CLOSE <type> <nick> <file>         例如:\n         /dcc close send johnsmith file.tar.gz"
 
 #: ../src/common/outbound.c:3898
 msgid ""
@@ -598,7 +598,7 @@ msgid ""
 "    types - types of data to ignore, one or all of:\n"
 "            PRIV, CHAN, NOTI, CTCP, DCC, INVI, ALL\n"
 "    options - NOSAVE, QUIET"
-msgstr "IGNORE <mask> <types..> <options..>\n    mask - 欲忽略的主機遮罩，比如 *!*@*.aol.com\n    types - 欲忽略資料的類型，以下選項之一或全部：\n            PRIV，CHAN，NOTI，CTCP，INVI，ALL\n    options - NOSAVE, QUIET"
+msgstr "IGNORE <mask> <types..> <options..>\n    mask - 欲忽略的主機遮罩，比如 *!*@*.aol.com\n    types - 欲忽略資料的類型，以下選項之一或全部:\n            PRIV，CHAN，NOTI，CTCP，INVI，ALL\n    options - NOSAVE, QUIET"
 
 #: ../src/common/outbound.c:3947
 msgid ""
@@ -860,7 +860,7 @@ msgstr ""
 #: ../src/common/outbound.c:4120
 #, c-format
 msgid "Usage: %s\n"
-msgstr "用法：%s\n"
+msgstr "用法:%s\n"
 
 #: ../src/common/outbound.c:4125
 msgid ""
@@ -951,7 +951,7 @@ msgstr "輪跳至 %s 的下一個伺服器中...\n"
 msgid ""
 "Warning: \"%s\" character set is unknown. No conversion will be applied for "
 "network %s."
-msgstr "警告：未知的字元設定「%s」。對網路 %s 將不應用字元轉換。"
+msgstr "警告:未知的字元設定「%s」。對網路 %s 將不應用字元轉換。"
 
 #: ../src/common/textevents.h:6
 msgid "%C18*%O$t%C18$1%O added to notify list."
@@ -2004,7 +2004,7 @@ msgstr "解析事件 %s 時出錯。\n載入預設值。"
 msgid ""
 "Cannot read sound file:\n"
 "%s"
-msgstr "無法讀取聲音檔案：\n%s"
+msgstr "無法讀取聲音檔案:\n%s"
 
 #: ../src/common/util.c:119
 msgid "Remote host closed socket"
@@ -3246,8 +3246,8 @@ msgstr "在聊天室分頁中您只能開啟封禁清單視窗。"
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid ": Ban List (%s)"
-msgstr "： 封禁清單 (%s)"
+msgid "Ban List (%s) - "
+msgstr "封禁清單 (%s) - "
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3285,8 +3285,8 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid ": Channel List (%s)"
-msgstr "：聊天室清單 (%s)"
+msgid "Channel List (%s) - "
+msgstr "聊天室清單 (%s) - "
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3346,7 +3346,7 @@ msgstr ""
 #. =============================================================
 #: ../src/fe-gtk/chanlist.c:913 ../src/fe-gtk/maingui.c:2902
 msgid "Find:"
-msgstr "尋找："
+msgstr "尋找:"
 
 #: ../src/fe-gtk/dccgui.c:141
 #, c-format
@@ -3364,7 +3364,7 @@ msgid ""
 "Cannot access file: %s\n"
 "%s.\n"
 "Resuming not possible."
-msgstr "不能存取檔案：%s\n%s。\n無法續傳。"
+msgstr "不能存取檔案:%s\n%s。\n無法續傳。"
 
 #: ../src/fe-gtk/dccgui.c:536
 msgid ""
@@ -3377,7 +3377,7 @@ msgid "Cannot resume the same file from two people."
 msgstr "不能從兩人那裡續傳同一檔案"
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid ": Uploads and Downloads"
+msgid "Uploads and Downloads - "
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3412,7 +3412,7 @@ msgstr "詳細資訊"
 
 #: ../src/fe-gtk/dccgui.c:878
 msgid "File:"
-msgstr "檔案："
+msgstr "檔案:"
 
 #: ../src/fe-gtk/dccgui.c:879
 msgid "Address:"
@@ -3435,8 +3435,8 @@ msgid "Open Folder..."
 msgstr "開啟文件夾..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid ": DCC Chat List"
-msgstr "： DCC 交談清單"
+msgid "DCC Chat List - "
+msgstr "DCC 交談清單 - "
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3494,7 +3494,7 @@ msgstr ""
 
 #: ../src/fe-gtk/fe-gtk.c:87 ../src/fe-gtk/setup.c:268
 msgid "Execute command:"
-msgstr "執行命令："
+msgstr "執行命令:"
 
 #: ../src/fe-gtk/fe-gtk.c:89
 msgid "Open URL or execute command in an existing HexChat"
@@ -3518,7 +3518,7 @@ msgid ""
 "Failed to open font:\n"
 "\n"
 "%s"
-msgstr "開啟字型失敗：\n\n%s"
+msgstr "開啟字型失敗:\n\n%s"
 
 #: ../src/fe-gtk/fe-gtk.c:714
 msgid "Search buffer is empty.\n"
@@ -3632,8 +3632,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid ": Keyboard Shortcuts"
-msgstr "： 鍵盤快捷鍵"
+msgid "Keyboard Shortcuts - "
+msgstr "鍵盤快捷鍵 - "
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3674,35 +3674,35 @@ msgstr ""
 
 #: ../src/fe-gtk/ignoregui.c:303
 msgid "Enter mask to ignore:"
-msgstr "輸入要忽略的遮罩："
+msgstr "輸入要忽略的遮罩:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid ": Ignore list"
-msgstr "： 忽略清單"
+msgid "Ignore list - "
+msgstr "忽略清單 - "
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
-msgstr "忽略統計："
+msgstr "忽略統計:"
 
 #: ../src/fe-gtk/ignoregui.c:366
 msgid "Channel:"
-msgstr "聊天室："
+msgstr "聊天室:"
 
 #: ../src/fe-gtk/ignoregui.c:367
 msgid "Private:"
-msgstr "私人："
+msgstr "私人:"
 
 #: ../src/fe-gtk/ignoregui.c:368
 msgid "Notice:"
-msgstr "通知："
+msgstr "通知:"
 
 #: ../src/fe-gtk/ignoregui.c:369
 msgid "CTCP:"
-msgstr "CTCP："
+msgstr "CTCP:"
 
 #: ../src/fe-gtk/ignoregui.c:370
 msgid "Invite:"
-msgstr "邀請："
+msgstr "邀請:"
 
 #: ../src/fe-gtk/ignoregui.c:381 ../src/fe-gtk/notifygui.c:423
 msgid "Add..."
@@ -3713,8 +3713,8 @@ msgid "Channel name too short, try again."
 msgstr "聊天室名稱太短，再試一次。"
 
 #: ../src/fe-gtk/joind.c:133
-msgid ": Connection Complete"
-msgstr "XChat: 連線完成"
+msgid "Connection Complete - "
+msgstr "連線完成 - "
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -3762,7 +3762,7 @@ msgstr "交談與"
 #: ../src/fe-gtk/maingui.c:696
 #, c-format
 msgid "Topic for %s is: %s"
-msgstr "%s 的話題是：%s"
+msgstr "%s 的話題是:%s"
 
 #: ../src/fe-gtk/maingui.c:701
 msgid "No topic is set"
@@ -3911,7 +3911,7 @@ msgstr "使用者限額"
 
 #: ../src/fe-gtk/maingui.c:2593
 msgid "Enter new nickname:"
-msgstr "輸入新暱稱："
+msgstr "輸入新暱稱:"
 
 #: ../src/fe-gtk/maingui.c:2816
 msgid "No results found."
@@ -3965,11 +3965,11 @@ msgstr "未知"
 
 #: ../src/fe-gtk/menu.c:620 ../src/fe-gtk/menu.c:624
 msgid "Real Name:"
-msgstr "真實名稱："
+msgstr "真實名稱:"
 
 #: ../src/fe-gtk/menu.c:631
 msgid "User:"
-msgstr "使用者："
+msgstr "使用者:"
 
 #: ../src/fe-gtk/menu.c:638
 msgid "Account:"
@@ -3977,11 +3977,11 @@ msgstr ""
 
 #: ../src/fe-gtk/menu.c:648
 msgid "Country:"
-msgstr "國家："
+msgstr "國家:"
 
 #: ../src/fe-gtk/menu.c:654
 msgid "Server:"
-msgstr "伺服器："
+msgstr "伺服器:"
 
 #: ../src/fe-gtk/menu.c:665
 #, c-format
@@ -3990,11 +3990,11 @@ msgstr "%u 分鐘之前"
 
 #: ../src/fe-gtk/menu.c:667 ../src/fe-gtk/menu.c:670
 msgid "Last Msg:"
-msgstr "最後訊息："
+msgstr "最後訊息:"
 
 #: ../src/fe-gtk/menu.c:680
 msgid "Away Msg:"
-msgstr "離開訊息："
+msgstr "離開訊息:"
 
 #: ../src/fe-gtk/menu.c:737
 #, c-format
@@ -4040,8 +4040,8 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid ": User menu"
-msgstr "：使用者選單"
+msgid "User menu - "
+msgstr "使用者選單 - "
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4161,36 +4161,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid ": User Defined Commands"
-msgstr "： 使用者自訂命令"
+msgid "User Defined Commands - "
+msgstr "使用者自訂命令 - "
 
 #: ../src/fe-gtk/menu.c:1534
-msgid ": Userlist Popup menu"
-msgstr "： 使用者清單彈出選單"
+msgid "Userlist Popup menu - "
+msgstr "使用者清單彈出選單 - "
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "以...替換"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid ": Replace"
-msgstr "： 替換"
+msgid "Replace - "
+msgstr "替換 - "
 
 #: ../src/fe-gtk/menu.c:1548
-msgid ": URL Handlers"
-msgstr "： URL 處理程式"
+msgid "URL Handlers - "
+msgstr "URL 處理程式 - "
 
 #: ../src/fe-gtk/menu.c:1567
-msgid ": Userlist buttons"
-msgstr "： 使用者清單按鈕"
+msgid "Userlist buttons - "
+msgstr "使用者清單按鈕 - "
 
 #: ../src/fe-gtk/menu.c:1574
-msgid ": Dialog buttons"
-msgstr "： 對話框按鈕"
+msgid "Dialog buttons - "
+msgstr "對話框按鈕 - "
 
 #: ../src/fe-gtk/menu.c:1581
-msgid ": CTCP Replies"
-msgstr "： CTCP 回應"
+msgid "CTCP Replies - "
+msgstr "CTCP 回應 - "
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4486,7 +4486,7 @@ msgstr "上線"
 
 #: ../src/fe-gtk/notifygui.c:343
 msgid "Enter nickname to add:"
-msgstr "輸入要新增的暱稱："
+msgstr "輸入要新增的暱稱:"
 
 #: ../src/fe-gtk/notifygui.c:372
 msgid "Notify on these networks:"
@@ -4497,7 +4497,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid ": Friends List"
+msgid "Friends List - "
 msgstr "好友清單"
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4536,7 +4536,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid ": Connected to %u networks and %u channels"
+msgid "Connected to %u networks and %u channels - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4578,42 +4578,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid ": Highlighted message from: %s (%s)"
+msgid "Highlighted message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid ": %u highlighted messages, latest from: %s (%s)"
+msgid "%u highlighted messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid ": Channel message from: %s (%s)"
+msgid "Channel message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid ": %u channel messages."
+msgid "%u channel messages. - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid ": Private message from: %s (%s)"
+msgid "Private message from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid ": %u private messages, latest from: %s (%s)"
+msgid "%u private messages, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid ": File offer from: %s (%s)"
+msgid "File offer from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid ": %u file offers, latest from: %s (%s)"
+msgid "%u file offers, latest from: %s (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4629,8 +4629,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "選擇要載入的外掛程式或命令稿"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid ": Plugins and Scripts"
-msgstr "： 外掛程式和命令稿"
+msgid "Plugins and Scripts - "
+msgstr "外掛程式和命令稿 - "
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4651,7 +4651,7 @@ msgstr "另存為..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid ": Raw Log (%s)"
+msgid "Raw Log (%s) - "
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4687,8 +4687,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid ": Edit %s"
-msgstr "： 編輯 %s"
+msgid "Edit %s - "
+msgstr "編輯 %s - "
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4748,19 +4748,19 @@ msgstr "使用廣域使用者資訊"
 
 #: ../src/fe-gtk/servlistgui.c:1880 ../src/fe-gtk/servlistgui.c:1997
 msgid "_Nick name:"
-msgstr "暱稱(_N)："
+msgstr "暱稱(_N):"
 
 #: ../src/fe-gtk/servlistgui.c:1881 ../src/fe-gtk/servlistgui.c:2004
 msgid "Second choice:"
-msgstr "第二選擇："
+msgstr "第二選擇:"
 
 #: ../src/fe-gtk/servlistgui.c:1882
 msgid "Rea_l name:"
-msgstr "真實名稱(_L)："
+msgstr "真實名稱(_L):"
 
 #: ../src/fe-gtk/servlistgui.c:1883 ../src/fe-gtk/servlistgui.c:2018
 msgid "_User name:"
-msgstr "使用者名(_U)："
+msgstr "使用者名(_U):"
 
 #: ../src/fe-gtk/servlistgui.c:1885
 msgid "Login method:"
@@ -4768,7 +4768,7 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1891 ../src/fe-gtk/setup.c:655
 msgid "Password:"
-msgstr "密碼："
+msgstr "密碼:"
 
 #: ../src/fe-gtk/servlistgui.c:1891
 msgid "Password used for login. If in doubt, leave blank."
@@ -4776,11 +4776,11 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1896
 msgid "Character set:"
-msgstr "字元設定："
+msgstr "字元設定:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid ": Network List"
-msgstr "： 網路清單"
+msgid "Network List - "
+msgstr "網路清單 - "
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -4788,7 +4788,7 @@ msgstr "使用者資訊"
 
 #: ../src/fe-gtk/servlistgui.c:2011
 msgid "Third choice:"
-msgstr "第三選擇："
+msgstr "第三選擇:"
 
 #: ../src/fe-gtk/servlistgui.c:2071
 msgid "Networks"
@@ -5050,7 +5050,7 @@ msgstr ""
 
 #: ../src/fe-gtk/setup.c:154
 msgid "Font:"
-msgstr "字型："
+msgstr "字型:"
 
 #: ../src/fe-gtk/setup.c:157
 msgid "Text Box"
@@ -5082,7 +5082,7 @@ msgstr "在最後讀取的文字後添加一條紅線。"
 
 #: ../src/fe-gtk/setup.c:161
 msgid "Background image:"
-msgstr "背景圖像："
+msgstr "背景圖像:"
 
 #: ../src/fe-gtk/setup.c:163
 msgid "Transparency Settings"
@@ -5102,7 +5102,7 @@ msgstr "打開時間戳記"
 
 #: ../src/fe-gtk/setup.c:168
 msgid "Time stamp format:"
-msgstr "時間戳記格式："
+msgstr "時間戳記格式:"
 
 #: ../src/fe-gtk/setup.c:170 ../src/fe-gtk/setup.c:597
 msgid "See the strftime MSDN article for details."
@@ -5176,7 +5176,7 @@ msgstr "暱稱自動補齊"
 
 #: ../src/fe-gtk/setup.c:205
 msgid "Nick completion suffix:"
-msgstr "暱稱自動補齊後綴："
+msgstr "暱稱自動補齊後綴:"
 
 #: ../src/fe-gtk/setup.c:206
 msgid "Nick completion sorted:"
@@ -5272,7 +5272,7 @@ msgstr ""
 
 #: ../src/fe-gtk/setup.c:260
 msgid "User list sorted by:"
-msgstr "使用者清單排列方式："
+msgstr "使用者清單排列方式:"
 
 #: ../src/fe-gtk/setup.c:261
 msgid "Show user list at:"
@@ -5288,7 +5288,7 @@ msgstr "追蹤使用者的離開狀態並且以不同顏色標記它們"
 
 #: ../src/fe-gtk/setup.c:265
 msgid "On channels smaller than:"
-msgstr "在小於此值的聊天室裡："
+msgstr "在小於此值的聊天室裡:"
 
 #: ../src/fe-gtk/setup.c:267
 msgid "Action Upon Double Click"
@@ -5379,7 +5379,7 @@ msgstr ""
 
 #: ../src/fe-gtk/setup.c:320
 msgid "Focus new tabs:"
-msgstr "聚焦到新分頁："
+msgstr "聚焦到新分頁:"
 
 #: ../src/fe-gtk/setup.c:321
 msgid "Placement of notices:"
@@ -5391,7 +5391,7 @@ msgstr ""
 
 #: ../src/fe-gtk/setup.c:323
 msgid "Shorten tab labels to:"
-msgstr "縮短分頁標籤至："
+msgstr "縮短分頁標籤至:"
 
 #: ../src/fe-gtk/setup.c:323
 msgid "letters."
@@ -5403,15 +5403,15 @@ msgstr "分頁或視窗"
 
 #: ../src/fe-gtk/setup.c:326
 msgid "Open channels in:"
-msgstr "打開聊天室於："
+msgstr "打開聊天室於:"
 
 #: ../src/fe-gtk/setup.c:327
 msgid "Open dialogs in:"
-msgstr "打開對話框於："
+msgstr "打開對話框於:"
 
 #: ../src/fe-gtk/setup.c:328
 msgid "Open utilities in:"
-msgstr "打開工具於："
+msgstr "打開工具於:"
 
 #: ../src/fe-gtk/setup.c:328
 msgid "Open DCC, Ignore, Notify etc, in tabs or windows?"
@@ -5443,15 +5443,15 @@ msgstr "檔案和目錄"
 
 #: ../src/fe-gtk/setup.c:353
 msgid "Auto accept file offers:"
-msgstr "自動接受所提供的檔案："
+msgstr "自動接受所提供的檔案:"
 
 #: ../src/fe-gtk/setup.c:354
 msgid "Download files to:"
-msgstr "把檔案下載到："
+msgstr "把檔案下載到:"
 
 #: ../src/fe-gtk/setup.c:355
 msgid "Move completed files to:"
-msgstr "移動完成下載的檔案到："
+msgstr "移動完成下載的檔案到:"
 
 #: ../src/fe-gtk/setup.c:356
 msgid "Save nick name in filenames"
@@ -5487,11 +5487,11 @@ msgstr "一個傳送行程的最大速度"
 
 #: ../src/fe-gtk/setup.c:366
 msgid "One download:"
-msgstr "一次下載："
+msgstr "一次下載:"
 
 #: ../src/fe-gtk/setup.c:368
 msgid "All uploads combined:"
-msgstr "所有上傳："
+msgstr "所有上傳:"
 
 #: ../src/fe-gtk/setup.c:369 ../src/fe-gtk/setup.c:371
 msgid "Maximum speed for all files"
@@ -5624,15 +5624,15 @@ msgstr "預設訊息"
 
 #: ../src/fe-gtk/setup.c:528
 msgid "Quit:"
-msgstr "離開："
+msgstr "離開:"
 
 #: ../src/fe-gtk/setup.c:529
 msgid "Leave channel:"
-msgstr "離開聊天室："
+msgstr "離開聊天室:"
 
 #: ../src/fe-gtk/setup.c:530
 msgid "Away:"
-msgstr "離開："
+msgstr "離開:"
 
 #: ../src/fe-gtk/setup.c:532
 msgid "Away"
@@ -5768,7 +5768,7 @@ msgstr ""
 
 #: ../src/fe-gtk/setup.c:577
 msgid "Auto reconnect delay:"
-msgstr "自動重連間隔："
+msgstr "自動重連間隔:"
 
 #: ../src/fe-gtk/setup.c:578
 msgid "Auto join delay:"
@@ -5794,7 +5794,7 @@ msgstr ""
 
 #: ../src/fe-gtk/setup.c:588
 msgid "Scrollback lines:"
-msgstr "回滾列數："
+msgstr "回滾列數:"
 
 #: ../src/fe-gtk/setup.c:589
 msgid "Enable logging of conversations to disk"
@@ -5815,7 +5815,7 @@ msgstr "在日誌中加入時間戳記"
 
 #: ../src/fe-gtk/setup.c:595
 msgid "Log timestamp format:"
-msgstr "日誌時間戳記格式："
+msgstr "日誌時間戳記格式:"
 
 #: ../src/fe-gtk/setup.c:602
 msgid "URLs"
@@ -5875,7 +5875,7 @@ msgstr "您的位址"
 
 #: ../src/fe-gtk/setup.c:634
 msgid "Bind to:"
-msgstr "綁定於："
+msgstr "綁定於:"
 
 #: ../src/fe-gtk/setup.c:635
 msgid "Only useful for computers with multiple addresses."
@@ -5897,7 +5897,7 @@ msgstr "向 IRC 伺服器查詢您的真實位址。如果您具有 192.168.*.* 
 
 #: ../src/fe-gtk/setup.c:640
 msgid "DCC IP address:"
-msgstr "DCC IP 位址："
+msgstr "DCC IP 位址:"
 
 #: ../src/fe-gtk/setup.c:641
 msgid "Claim you are at this address when offering files."
@@ -5905,11 +5905,11 @@ msgstr "發送檔案時聲稱您是這個位址。"
 
 #: ../src/fe-gtk/setup.c:642
 msgid "First DCC send port:"
-msgstr "第一個 DCC 檔案發送輸出入埠："
+msgstr "第一個 DCC 檔案發送輸出入埠:"
 
 #: ../src/fe-gtk/setup.c:643
 msgid "Last DCC send port:"
-msgstr "最後一個 DCC 檔案傳送輸出入埠："
+msgstr "最後一個 DCC 檔案傳送輸出入埠:"
 
 #: ../src/fe-gtk/setup.c:644
 msgid "!Leave ports at zero for full range."
@@ -5921,19 +5921,19 @@ msgstr "代理伺服器"
 
 #: ../src/fe-gtk/setup.c:647
 msgid "Hostname:"
-msgstr "主機名："
+msgstr "主機名:"
 
 #: ../src/fe-gtk/setup.c:648 ../src/fe-gtk/setup.c:664
 msgid "Port:"
-msgstr "輸出入埠："
+msgstr "輸出入埠:"
 
 #: ../src/fe-gtk/setup.c:649
 msgid "Type:"
-msgstr "類型："
+msgstr "類型:"
 
 #: ../src/fe-gtk/setup.c:650
 msgid "Use proxy for:"
-msgstr "使用代理伺服器於："
+msgstr "使用代理伺服器於:"
 
 #: ../src/fe-gtk/setup.c:652
 msgid "Proxy Authentication"
@@ -5945,7 +5945,7 @@ msgstr "使用驗證(HTTP 或僅有 Socks5)"
 
 #: ../src/fe-gtk/setup.c:654
 msgid "Username:"
-msgstr "使用者名："
+msgstr "使用者名:"
 
 #: ../src/fe-gtk/setup.c:662
 msgid "Identd Server"
@@ -5995,19 +5995,19 @@ msgstr "文字顏色"
 
 #: ../src/fe-gtk/setup.c:1536
 msgid "mIRC colors:"
-msgstr "mIRC 顏色："
+msgstr "mIRC 顏色:"
 
 #: ../src/fe-gtk/setup.c:1544
 msgid "Local colors:"
-msgstr "本地的顏色："
+msgstr "本地的顏色:"
 
 #: ../src/fe-gtk/setup.c:1552 ../src/fe-gtk/setup.c:1557
 msgid "Foreground:"
-msgstr "前景："
+msgstr "前景:"
 
 #: ../src/fe-gtk/setup.c:1553 ../src/fe-gtk/setup.c:1558
 msgid "Background:"
-msgstr "背景："
+msgstr "背景:"
 
 #: ../src/fe-gtk/setup.c:1555
 msgid "Selected Text"
@@ -6019,23 +6019,23 @@ msgstr "介面顏色"
 
 #: ../src/fe-gtk/setup.c:1562
 msgid "New data:"
-msgstr "新資料："
+msgstr "新資料:"
 
 #: ../src/fe-gtk/setup.c:1563
 msgid "Marker line:"
-msgstr "標記線："
+msgstr "標記線:"
 
 #: ../src/fe-gtk/setup.c:1564
 msgid "New message:"
-msgstr "新訊息："
+msgstr "新訊息:"
 
 #: ../src/fe-gtk/setup.c:1565
 msgid "Away user:"
-msgstr "離開的使用者："
+msgstr "離開的使用者:"
 
 #: ../src/fe-gtk/setup.c:1566
 msgid "Highlight:"
-msgstr "高亮度顯示："
+msgstr "高亮度顯示:"
 
 #: ../src/fe-gtk/setup.c:1567
 msgid "Spell checker:"
@@ -6059,7 +6059,7 @@ msgstr "選擇聲音檔案"
 
 #: ../src/fe-gtk/setup.c:1800
 msgid "Sound file:"
-msgstr "音效檔案："
+msgstr "音效檔案:"
 
 #: ../src/fe-gtk/setup.c:1815
 msgid "_Browse..."
@@ -6141,11 +6141,11 @@ msgid ""
 "Auto accepting DCC to your home directory\n"
 "can be dangerous and is exploitable. Eg:\n"
 "Someone could send you a .bash_profile"
-msgstr "*警告*\n自動接收 DCC 到您的主目錄中是危險之舉，\n且有被盜用的可能性。例如：\n某人可能會給您發送一份 .bash_profile 檔案"
+msgstr "*警告*\n自動接收 DCC 到您的主目錄中是危險之舉，\n且有被盜用的可能性。例如:\n某人可能會給您發送一份 .bash_profile 檔案"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid ": Preferences"
-msgstr "： 偏好設定"
+msgid "Preferences - "
+msgstr "偏好設定 - "
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6209,8 +6209,8 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid ": URL Grabber"
-msgstr "： URL 擷取程式"
+msgid "URL Grabber - "
+msgstr "URL 擷取程式 - "
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -3246,8 +3246,8 @@ msgstr "在聊天室分頁中您只能開啟封禁清單視窗。"
 
 #: ../src/fe-gtk/banlist.c:808
 #, c-format
-msgid "Ban List (%s) - "
-msgstr "封禁清單 (%s) - "
+msgid "Ban List (%s) - %s"
+msgstr "封禁清單 (%s) - %s"
 
 #: ../src/fe-gtk/banlist.c:843 ../src/fe-gtk/notifygui.c:427
 msgid "Remove"
@@ -3285,8 +3285,8 @@ msgstr ""
 
 #: ../src/fe-gtk/chanlist.c:720
 #, c-format
-msgid "Channel List (%s) - "
-msgstr "聊天室清單 (%s) - "
+msgid "Channel List (%s) - %s"
+msgstr "聊天室清單 (%s) - %s"
 
 #: ../src/fe-gtk/chanlist.c:794
 msgid "_Search"
@@ -3377,7 +3377,7 @@ msgid "Cannot resume the same file from two people."
 msgstr "不能從兩人那裡續傳同一檔案"
 
 #: ../src/fe-gtk/dccgui.c:802
-msgid "Uploads and Downloads - "
+msgid "Uploads and Downloads - %s"
 msgstr ""
 
 #: ../src/fe-gtk/dccgui.c:819 ../src/fe-gtk/dccgui.c:1060
@@ -3435,8 +3435,8 @@ msgid "Open Folder..."
 msgstr "開啟文件夾..."
 
 #: ../src/fe-gtk/dccgui.c:1049
-msgid "DCC Chat List - "
-msgstr "DCC 交談清單 - "
+msgid "DCC Chat List - %s"
+msgstr "DCC 交談清單 - %s"
 
 #: ../src/fe-gtk/dccgui.c:1062
 msgid "Recv"
@@ -3632,8 +3632,8 @@ msgid "Select a row to get help information on its Action."
 msgstr ""
 
 #: ../src/fe-gtk/fkeys.c:811
-msgid "Keyboard Shortcuts - "
-msgstr "鍵盤快捷鍵 - "
+msgid "Keyboard Shortcuts - %s"
+msgstr "鍵盤快捷鍵 - %s"
 
 #: ../src/fe-gtk/gtkutil.c:126
 msgid "Cannot write to that file."
@@ -3677,8 +3677,8 @@ msgid "Enter mask to ignore:"
 msgstr "輸入要忽略的遮罩:"
 
 #: ../src/fe-gtk/ignoregui.c:350
-msgid "Ignore list - "
-msgstr "忽略清單 - "
+msgid "Ignore list - %s"
+msgstr "忽略清單 - %s"
 
 #: ../src/fe-gtk/ignoregui.c:358
 msgid "Ignore Stats:"
@@ -3713,8 +3713,8 @@ msgid "Channel name too short, try again."
 msgstr "聊天室名稱太短，再試一次。"
 
 #: ../src/fe-gtk/joind.c:133
-msgid "Connection Complete - "
-msgstr "連線完成 - "
+msgid "Connection Complete - %s"
+msgstr "連線完成 - %s"
 
 #: ../src/fe-gtk/joind.c:161
 #, c-format
@@ -4040,8 +4040,8 @@ msgid "_Auto-Connect"
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1137
-msgid "User menu - "
-msgstr "使用者選單 - "
+msgid "User menu - %s"
+msgstr "使用者選單 - %s"
 
 #. sep
 #: ../src/fe-gtk/menu.c:1146
@@ -4161,36 +4161,36 @@ msgid ""
 msgstr ""
 
 #: ../src/fe-gtk/menu.c:1527
-msgid "User Defined Commands - "
-msgstr "使用者自訂命令 - "
+msgid "User Defined Commands - %s"
+msgstr "使用者自訂命令 - %s"
 
 #: ../src/fe-gtk/menu.c:1534
-msgid "Userlist Popup menu - "
-msgstr "使用者清單彈出選單 - "
+msgid "Userlist Popup menu - %s"
+msgstr "使用者清單彈出選單 - %s"
 
 #: ../src/fe-gtk/menu.c:1541
 msgid "Replace with"
 msgstr "以...替換"
 
 #: ../src/fe-gtk/menu.c:1541
-msgid "Replace - "
-msgstr "替換 - "
+msgid "Replace - %s"
+msgstr "替換 - %s"
 
 #: ../src/fe-gtk/menu.c:1548
-msgid "URL Handlers - "
-msgstr "URL 處理程式 - "
+msgid "URL Handlers - %s"
+msgstr "URL 處理程式 - %s"
 
 #: ../src/fe-gtk/menu.c:1567
-msgid "Userlist buttons - "
-msgstr "使用者清單按鈕 - "
+msgid "Userlist buttons - %s"
+msgstr "使用者清單按鈕 - %s"
 
 #: ../src/fe-gtk/menu.c:1574
-msgid "Dialog buttons - "
-msgstr "對話框按鈕 - "
+msgid "Dialog buttons - %s"
+msgstr "對話框按鈕 - %s"
 
 #: ../src/fe-gtk/menu.c:1581
-msgid "CTCP Replies - "
-msgstr "CTCP 回應 - "
+msgid "CTCP Replies - %s"
+msgstr "CTCP 回應 - %s"
 
 #: ../src/fe-gtk/menu.c:1747
 msgid "He_xChat"
@@ -4497,7 +4497,7 @@ msgid "Comma separated list of networks is accepted."
 msgstr ""
 
 #: ../src/fe-gtk/notifygui.c:409
-msgid "Friends List - "
+msgid "Friends List - %s"
 msgstr "好友清單"
 
 #: ../src/fe-gtk/notifygui.c:431
@@ -4536,7 +4536,7 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:176
 #, c-format
-msgid "Connected to %u networks and %u channels - "
+msgid "Connected to %u networks and %u channels - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:545
@@ -4578,42 +4578,42 @@ msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:630
 #, c-format
-msgid "Highlighted message from: %s (%s) - "
+msgid "Highlighted message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:633
 #, c-format
-msgid "%u highlighted messages, latest from: %s (%s) - "
+msgid "%u highlighted messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:652
 #, c-format
-msgid "Channel message from: %s (%s) - "
+msgid "Channel message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:655
 #, c-format
-msgid "%u channel messages. - "
+msgid "%u channel messages. - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:679
 #, c-format
-msgid "Private message from: %s (%s) - "
+msgid "Private message from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:682
 #, c-format
-msgid "%u private messages, latest from: %s (%s) - "
+msgid "%u private messages, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:722
 #, c-format
-msgid "File offer from: %s (%s) - "
+msgid "File offer from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugin-tray.c:725
 #, c-format
-msgid "%u file offers, latest from: %s (%s) - "
+msgid "%u file offers, latest from: %s (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/plugingui.c:65
@@ -4629,8 +4629,8 @@ msgid "Select a Plugin or Script to load"
 msgstr "選擇要載入的外掛程式或命令稿"
 
 #: ../src/fe-gtk/plugingui.c:240
-msgid "Plugins and Scripts - "
-msgstr "外掛程式和命令稿 - "
+msgid "Plugins and Scripts - %s"
+msgstr "外掛程式和命令稿 - %s"
 
 #: ../src/fe-gtk/plugingui.c:255
 msgid "_Load..."
@@ -4651,7 +4651,7 @@ msgstr "另存為..."
 
 #: ../src/fe-gtk/rawlog.c:112
 #, c-format
-msgid "Raw Log (%s) - "
+msgid "Raw Log (%s) - %s"
 msgstr ""
 
 #: ../src/fe-gtk/rawlog.c:133
@@ -4687,8 +4687,8 @@ msgstr ""
 
 #: ../src/fe-gtk/servlistgui.c:1710
 #, c-format
-msgid "Edit %s - "
-msgstr "編輯 %s - "
+msgid "Edit %s - %s"
+msgstr "編輯 %s - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1731
 msgid "Servers"
@@ -4779,8 +4779,8 @@ msgid "Character set:"
 msgstr "字元設定:"
 
 #: ../src/fe-gtk/servlistgui.c:1976
-msgid "Network List - "
-msgstr "網路清單 - "
+msgid "Network List - %s"
+msgstr "網路清單 - %s"
 
 #: ../src/fe-gtk/servlistgui.c:1987
 msgid "User Information"
@@ -6144,8 +6144,8 @@ msgid ""
 msgstr "*警告*\n自動接收 DCC 到您的主目錄中是危險之舉，\n且有被盜用的可能性。例如:\n某人可能會給您發送一份 .bash_profile 檔案"
 
 #: ../src/fe-gtk/setup.c:2282
-msgid "Preferences - "
-msgstr "偏好設定 - "
+msgid "Preferences - %s"
+msgstr "偏好設定 - %s"
 
 #: ../src/fe-gtk/sexy-spell-entry.c:554
 msgid "<i>(no suggestions)</i>"
@@ -6209,8 +6209,8 @@ msgid "OK"
 msgstr ""
 
 #: ../src/fe-gtk/urlgrab.c:198
-msgid "URL Grabber - "
-msgstr "URL 擷取程式 - "
+msgid "URL Grabber - %s"
+msgstr "URL 擷取程式 - %s"
 
 #: ../src/fe-gtk/urlgrab.c:212
 msgid "Clear list"

--- a/src/fe-gtk/banlist.c
+++ b/src/fe-gtk/banlist.c
@@ -436,7 +436,7 @@ banlist_do_refresh (banlist_info *banl)
 	{
 		GtkListStore *store;
 
-		g_snprintf (tbuf, sizeof tbuf, DISPLAY_NAME": Ban List (%s, %s)",
+		g_snprintf (tbuf, sizeof tbuf, "Ban List (%s, %s) - ",
 						sess->channel, sess->server->servername);
 		mg_set_title (banl->window, tbuf);
 
@@ -805,7 +805,7 @@ banlist_opengui (struct session *sess)
 	/* Force on the checkmark in the "Bans" box */
 	banl->checked = 1<<MODE_BAN;
 
-	g_snprintf (tbuf, sizeof tbuf, _(DISPLAY_NAME": Ban List (%s)"),
+	g_snprintf (tbuf, sizeof tbuf, _("Ban List (%s) - "DISPLAY_NAME),
 					sess->server->servername);
 
 	banl->window = mg_create_generic_tab ("BanList", tbuf, FALSE,

--- a/src/fe-gtk/banlist.c
+++ b/src/fe-gtk/banlist.c
@@ -436,8 +436,8 @@ banlist_do_refresh (banlist_info *banl)
 	{
 		GtkListStore *store;
 
-		g_snprintf (tbuf, sizeof tbuf, "Ban List (%s, %s) - ",
-						sess->channel, sess->server->servername);
+		g_snprintf (tbuf, sizeof tbuf, "Ban List (%s, %s) - %s",
+						sess->channel, sess->server->servername, _(DISPLAY_NAME));
 		mg_set_title (banl->window, tbuf);
 
 		store = get_store (sess);
@@ -805,8 +805,8 @@ banlist_opengui (struct session *sess)
 	/* Force on the checkmark in the "Bans" box */
 	banl->checked = 1<<MODE_BAN;
 
-	g_snprintf (tbuf, sizeof tbuf, _("Ban List (%s) - "DISPLAY_NAME),
-					sess->server->servername);
+	g_snprintf (tbuf, sizeof tbuf, _("Ban List (%s) - %s"),
+					sess->server->servername, _(DISPLAY_NAME));
 
 	banl->window = mg_create_generic_tab ("BanList", tbuf, FALSE,
 					TRUE, banlist_closegui, banl, 700, 300, &vbox, sess->server);

--- a/src/fe-gtk/chanlist.c
+++ b/src/fe-gtk/chanlist.c
@@ -717,8 +717,8 @@ chanlist_opengui (server *serv, int do_refresh)
 		return;
 	}
 
-	g_snprintf (tbuf, sizeof tbuf, _("Channel List (%s) - "DISPLAY_NAME),
-				 server_get_network (serv, TRUE));
+	g_snprintf (tbuf, sizeof tbuf, _("Channel List (%s) - %s"),
+				 server_get_network (serv, TRUE), _(DISPLAY_NAME));
 
 	serv->gui->chanlist_pending_rows = NULL;
 	serv->gui->chanlist_tag = 0;

--- a/src/fe-gtk/chanlist.c
+++ b/src/fe-gtk/chanlist.c
@@ -717,7 +717,7 @@ chanlist_opengui (server *serv, int do_refresh)
 		return;
 	}
 
-	g_snprintf (tbuf, sizeof tbuf, _(DISPLAY_NAME": Channel List (%s)"),
+	g_snprintf (tbuf, sizeof tbuf, _("Channel List (%s) - "DISPLAY_NAME),
 				 server_get_network (serv, TRUE));
 
 	serv->gui->chanlist_pending_rows = NULL;

--- a/src/fe-gtk/dccgui.c
+++ b/src/fe-gtk/dccgui.c
@@ -792,6 +792,7 @@ fe_dcc_open_recv_win (int passive)
 	GtkWidget *radio, *table, *vbox, *bbox, *view, *exp, *detailbox;
 	GtkListStore *store;
 	GSList *group;
+	char buf[128];
 
 	if (dccfwin.window)
 	{
@@ -799,9 +800,9 @@ fe_dcc_open_recv_win (int passive)
 			mg_bring_tofront (dccfwin.window);
 		return TRUE;
 	}
-	dccfwin.window = mg_create_generic_tab ("Transfers", _("Uploads and Downloads - "DISPLAY_NAME),
-														 FALSE, TRUE, close_dcc_file_window, NULL,
-														 win_width, win_height, &vbox, 0);
+	g_snprintf(buf, sizeof(buf), _("Uploads and Downloads - %s"), _(DISPLAY_NAME));
+	dccfwin.window = mg_create_generic_tab ("Transfers", buf, FALSE, TRUE, close_dcc_file_window,
+														 NULL, win_width, win_height, &vbox, 0);
 	gtkutil_destroy_on_esc (dccfwin.window);
 	gtk_container_set_border_width (GTK_CONTAINER (dccfwin.window), 3);
 	gtk_box_set_spacing (GTK_BOX (vbox), 3);
@@ -1037,6 +1038,7 @@ fe_dcc_open_chat_win (int passive)
 {
 	GtkWidget *view, *vbox, *bbox;
 	GtkListStore *store;
+	char buf[128];
 
 	if (dcccwin.window)
 	{
@@ -1045,9 +1047,10 @@ fe_dcc_open_chat_win (int passive)
 		return TRUE;
 	}
 
+	g_snprintf(buf, sizeof(buf), _("DCC Chat List - %s"), _(DISPLAY_NAME));
 	dcccwin.window =
-			  mg_create_generic_tab ("DCCChat", _("DCC Chat List - "DISPLAY_NAME),
-						FALSE, TRUE, dcc_chat_close_cb, NULL, 550, 180, &vbox, 0);
+			  mg_create_generic_tab ("DCCChat", buf, FALSE, TRUE, dcc_chat_close_cb,
+						NULL, 550, 180, &vbox, 0);
 	gtkutil_destroy_on_esc (dcccwin.window);
 	gtk_container_set_border_width (GTK_CONTAINER (dcccwin.window), 3);
 	gtk_box_set_spacing (GTK_BOX (vbox), 3);

--- a/src/fe-gtk/dccgui.c
+++ b/src/fe-gtk/dccgui.c
@@ -799,7 +799,7 @@ fe_dcc_open_recv_win (int passive)
 			mg_bring_tofront (dccfwin.window);
 		return TRUE;
 	}
-	dccfwin.window = mg_create_generic_tab ("Transfers", _(DISPLAY_NAME": Uploads and Downloads"),
+	dccfwin.window = mg_create_generic_tab ("Transfers", _("Uploads and Downloads - "DISPLAY_NAME),
 														 FALSE, TRUE, close_dcc_file_window, NULL,
 														 win_width, win_height, &vbox, 0);
 	gtkutil_destroy_on_esc (dccfwin.window);
@@ -1046,7 +1046,7 @@ fe_dcc_open_chat_win (int passive)
 	}
 
 	dcccwin.window =
-			  mg_create_generic_tab ("DCCChat", _(DISPLAY_NAME": DCC Chat List"),
+			  mg_create_generic_tab ("DCCChat", _("DCC Chat List - "DISPLAY_NAME),
 						FALSE, TRUE, dcc_chat_close_cb, NULL, 550, 180, &vbox, 0);
 	gtkutil_destroy_on_esc (dcccwin.window);
 	gtk_container_set_border_width (GTK_CONTAINER (dcccwin.window), 3);

--- a/src/fe-gtk/fkeys.c
+++ b/src/fe-gtk/fkeys.c
@@ -801,6 +801,7 @@ key_dialog_show ()
 	GtkWidget *vbox, *box;
 	GtkWidget *view, *xtext;
 	GtkListStore *store;
+	char buf[128];
 
 	if (key_dialog)
 	{
@@ -808,8 +809,9 @@ key_dialog_show ()
 		return;
 	}
 
-	key_dialog = mg_create_generic_tab ("editkeys", _("Keyboard Shortcuts - "DISPLAY_NAME),
-									TRUE, FALSE, key_dialog_close, NULL, 600, 360, &vbox, 0);
+	g_snprintf(buf, sizeof(buf), _("Keyboard Shortcuts - %s"), _(DISPLAY_NAME));
+	key_dialog = mg_create_generic_tab ("editkeys", buf, TRUE, FALSE, key_dialog_close,
+									NULL, 600, 360, &vbox, 0);
 
 	view = key_dialog_treeview_new (vbox);
 	xtext = gtk_xtext_new (colors, 0);

--- a/src/fe-gtk/fkeys.c
+++ b/src/fe-gtk/fkeys.c
@@ -808,7 +808,7 @@ key_dialog_show ()
 		return;
 	}
 
-	key_dialog = mg_create_generic_tab ("editkeys", _(DISPLAY_NAME": Keyboard Shortcuts"),
+	key_dialog = mg_create_generic_tab ("editkeys", _("Keyboard Shortcuts - "DISPLAY_NAME),
 									TRUE, FALSE, key_dialog_close, NULL, 600, 360, &vbox, 0);
 
 	view = key_dialog_treeview_new (vbox);

--- a/src/fe-gtk/ignoregui.c
+++ b/src/fe-gtk/ignoregui.c
@@ -347,7 +347,7 @@ ignore_gui_open ()
 	}
 
 	ignorewin =
-			  mg_create_generic_tab ("IgnoreList", _(DISPLAY_NAME": Ignore list"),
+			  mg_create_generic_tab ("IgnoreList", _("Ignore list - "DISPLAY_NAME),
 											FALSE, TRUE, close_ignore_gui_callback,
 											NULL, 700, 300, &vbox, 0);
 	gtkutil_destroy_on_esc (ignorewin);

--- a/src/fe-gtk/ignoregui.c
+++ b/src/fe-gtk/ignoregui.c
@@ -339,6 +339,7 @@ ignore_gui_open ()
 	GSList *temp = ignore_list;
 	char *mask;
 	gboolean private, chan, notice, ctcp, dcc, invite, unignore;
+	char buf[128];
 
 	if (ignorewin)
 	{
@@ -346,9 +347,10 @@ ignore_gui_open ()
 		return;
 	}
 
+	g_snprintf(buf, sizeof(buf), _("Ignore list - %s"), _(DISPLAY_NAME));
 	ignorewin =
-			  mg_create_generic_tab ("IgnoreList", _("Ignore list - "DISPLAY_NAME),
-											FALSE, TRUE, close_ignore_gui_callback,
+			  mg_create_generic_tab ("IgnoreList", buf, FALSE, TRUE,
+											close_ignore_gui_callback,
 											NULL, 700, 300, &vbox, 0);
 	gtkutil_destroy_on_esc (ignorewin);
 

--- a/src/fe-gtk/joind.c
+++ b/src/fe-gtk/joind.c
@@ -130,7 +130,8 @@ joind_show_dialog (server *serv)
 	char buf2[256];
 
 	serv->gui->joind_win = dialog1 = gtk_dialog_new ();
-	gtk_window_set_title (GTK_WINDOW (dialog1), _("Connection Complete - "DISPLAY_NAME));
+	g_snprintf(buf, sizeof(buf), _("Connection Complete - %s"), _(DISPLAY_NAME));
+	gtk_window_set_title (GTK_WINDOW (dialog1), buf);
 	gtk_window_set_type_hint (GTK_WINDOW (dialog1), GDK_WINDOW_TYPE_HINT_DIALOG);
 	gtk_window_set_position (GTK_WINDOW (dialog1), GTK_WIN_POS_CENTER_ON_PARENT);
 	gtk_window_set_transient_for (GTK_WINDOW(dialog1), GTK_WINDOW(serv->front_session->gui->window));

--- a/src/fe-gtk/joind.c
+++ b/src/fe-gtk/joind.c
@@ -130,7 +130,7 @@ joind_show_dialog (server *serv)
 	char buf2[256];
 
 	serv->gui->joind_win = dialog1 = gtk_dialog_new ();
-	gtk_window_set_title (GTK_WINDOW (dialog1), _(DISPLAY_NAME": Connection Complete"));
+	gtk_window_set_title (GTK_WINDOW (dialog1), _("Connection Complete - "DISPLAY_NAME));
 	gtk_window_set_type_hint (GTK_WINDOW (dialog1), GDK_WINDOW_TYPE_HINT_DIALOG);
 	gtk_window_set_position (GTK_WINDOW (dialog1), GTK_WIN_POS_CENTER_ON_PARENT);
 	gtk_window_set_transient_for (GTK_WINDOW(dialog1), GTK_WINDOW(serv->front_session->gui->window));

--- a/src/fe-gtk/maingui.c
+++ b/src/fe-gtk/maingui.c
@@ -382,11 +382,11 @@ fe_set_title (session *sess)
 	switch (type)
 	{
 	case SESS_DIALOG:
-		g_snprintf (tbuf, sizeof (tbuf), DISPLAY_NAME": %s %s @ %s",
+		g_snprintf (tbuf, sizeof (tbuf), "%s %s @ %s - "DISPLAY_NAME,
 					 _("Dialog with"), sess->channel, server_get_network (sess->server, TRUE));
 		break;
 	case SESS_SERVER:
-		g_snprintf (tbuf, sizeof (tbuf), DISPLAY_NAME": %s @ %s",
+		g_snprintf (tbuf, sizeof (tbuf), "%s @ %s - "DISPLAY_NAME,
 					 sess->server->nick, server_get_network (sess->server, TRUE));
 		break;
 	case SESS_CHANNEL:
@@ -394,14 +394,14 @@ fe_set_title (session *sess)
 		if (prefs.hex_gui_win_modes)
 		{
 			g_snprintf (tbuf, sizeof (tbuf),
-						 DISPLAY_NAME": %s @ %s / %s (%s)",
+						 "%s @ %s / %s (%s) - "DISPLAY_NAME,
 						 sess->server->nick, server_get_network (sess->server, TRUE),
 						 sess->channel, sess->current_modes ? sess->current_modes : "");
 		}
 		else
 		{
 			g_snprintf (tbuf, sizeof (tbuf),
-						 DISPLAY_NAME": %s @ %s / %s",
+						 "%s @ %s / %s - "DISPLAY_NAME,
 						 sess->server->nick, server_get_network (sess->server, TRUE),
 						 sess->channel);
 		}
@@ -412,7 +412,7 @@ fe_set_title (session *sess)
 		break;
 	case SESS_NOTICES:
 	case SESS_SNOTICES:
-		g_snprintf (tbuf, sizeof (tbuf), DISPLAY_NAME": %s @ %s (notices)",
+		g_snprintf (tbuf, sizeof (tbuf), "%s @ %s (notices) - "DISPLAY_NAME,
 					 sess->server->nick, server_get_network (sess->server, TRUE));
 		break;
 	default:

--- a/src/fe-gtk/maingui.c
+++ b/src/fe-gtk/maingui.c
@@ -382,28 +382,31 @@ fe_set_title (session *sess)
 	switch (type)
 	{
 	case SESS_DIALOG:
-		g_snprintf (tbuf, sizeof (tbuf), "%s %s @ %s - "DISPLAY_NAME,
-					 _("Dialog with"), sess->channel, server_get_network (sess->server, TRUE));
+		g_snprintf (tbuf, sizeof (tbuf), "%s %s @ %s - %s",
+					 _("Dialog with"), sess->channel, server_get_network (sess->server, TRUE),
+					 _(DISPLAY_NAME));
 		break;
 	case SESS_SERVER:
-		g_snprintf (tbuf, sizeof (tbuf), "%s @ %s - "DISPLAY_NAME,
-					 sess->server->nick, server_get_network (sess->server, TRUE));
+		g_snprintf (tbuf, sizeof (tbuf), "%s @ %s - %s",
+					 sess->server->nick, server_get_network (sess->server, TRUE),
+					 _(DISPLAY_NAME));
 		break;
 	case SESS_CHANNEL:
 		/* don't display keys in the titlebar */
 		if (prefs.hex_gui_win_modes)
 		{
 			g_snprintf (tbuf, sizeof (tbuf),
-						 "%s @ %s / %s (%s) - "DISPLAY_NAME,
+						 "%s @ %s / %s (%s) - %s",
 						 sess->server->nick, server_get_network (sess->server, TRUE),
-						 sess->channel, sess->current_modes ? sess->current_modes : "");
+						 sess->channel, sess->current_modes ? sess->current_modes : "",
+						 _(DISPLAY_NAME));
 		}
 		else
 		{
 			g_snprintf (tbuf, sizeof (tbuf),
-						 "%s @ %s / %s - "DISPLAY_NAME,
+						 "%s @ %s / %s - %s",
 						 sess->server->nick, server_get_network (sess->server, TRUE),
-						 sess->channel);
+						 sess->channel, _(DISPLAY_NAME));
 		}
 		if (prefs.hex_gui_win_ucount)
 		{
@@ -412,12 +415,13 @@ fe_set_title (session *sess)
 		break;
 	case SESS_NOTICES:
 	case SESS_SNOTICES:
-		g_snprintf (tbuf, sizeof (tbuf), "%s @ %s (notices) - "DISPLAY_NAME,
-					 sess->server->nick, server_get_network (sess->server, TRUE));
+		g_snprintf (tbuf, sizeof (tbuf), "%s @ %s (notices) - %s",
+					 sess->server->nick, server_get_network (sess->server, TRUE),
+					 _(DISPLAY_NAME));
 		break;
 	default:
 	def:
-		g_snprintf (tbuf, sizeof (tbuf), DISPLAY_NAME);
+		g_snprintf (tbuf, sizeof (tbuf), _(DISPLAY_NAME));
 		gtk_window_set_title (GTK_WINDOW (sess->gui->window), tbuf);
 		return;
 	}

--- a/src/fe-gtk/menu.c
+++ b/src/fe-gtk/menu.c
@@ -1134,8 +1134,9 @@ menu_settings (GtkWidget * wid, gpointer none)
 static void
 menu_usermenu (void)
 {
-	editlist_gui_open (NULL, NULL, usermenu_list, _("User menu - "DISPLAY_NAME),
-							 "usermenu", "usermenu.conf", 0);
+	char buf[128];
+	g_snprintf(buf, sizeof(buf), _("User menu - %s"), _(DISPLAY_NAME));
+	editlist_gui_open (NULL, NULL, usermenu_list, buf, "usermenu", "usermenu.conf", 0);
 }
 
 static void
@@ -1524,29 +1525,34 @@ menu_noplugin_info (void)
 static void
 menu_usercommands (void)
 {
-	editlist_gui_open (NULL, NULL, command_list, _("User Defined Commands - "DISPLAY_NAME),
-							 "commands", "commands.conf", usercommands_help);
+	char buf[128];
+	g_snprintf(buf, sizeof(buf), _("User Defined Commands - %s"), _(DISPLAY_NAME));
+	editlist_gui_open (NULL, NULL, command_list, buf, "commands", "commands.conf",
+							usercommands_help);
 }
 
 static void
 menu_ulpopup (void)
 {
-	editlist_gui_open (NULL, NULL, popup_list, _("Userlist Popup menu - "DISPLAY_NAME), "popup",
-							 "popup.conf", ulbutton_help);
+	char buf[128];
+	g_snprintf(buf, sizeof(buf), _("Userlist Popup menu -  %s"), _(DISPLAY_NAME));
+	editlist_gui_open (NULL, NULL, popup_list, buf, "popup", "popup.conf", ulbutton_help);
 }
 
 static void
 menu_rpopup (void)
 {
-	editlist_gui_open (_("Text"), _("Replace with"), replace_list, _("Replace - "DISPLAY_NAME), "replace",
-							 "replace.conf", 0);
+	char buf[128];
+	g_snprintf(buf, sizeof(buf), _("Replace - %s"), _(DISPLAY_NAME));
+	editlist_gui_open (_("Text"), _("Replace with"), replace_list, buf, "replace", "replace.conf", 0);
 }
 
 static void
 menu_urlhandlers (void)
 {
-	editlist_gui_open (NULL, NULL, urlhandler_list, _("URL Handlers - "DISPLAY_NAME), "urlhandlers",
-							 "urlhandlers.conf", url_help);
+	char buf[128];
+	g_snprintf(buf, sizeof(buf), _("URL Handlers - %s"), _(DISPLAY_NAME));
+	editlist_gui_open (NULL, NULL, urlhandler_list, buf, "urlhandlers", "urlhandlers.conf", url_help);
 }
 
 static void
@@ -1564,22 +1570,26 @@ menu_keypopup (void)
 static void
 menu_ulbuttons (void)
 {
-	editlist_gui_open (NULL, NULL, button_list, _("Userlist buttons - "DISPLAY_NAME), "buttons",
-							 "buttons.conf", ulbutton_help);
+	char buf[128];
+	g_snprintf(buf, sizeof(buf), _("Userlist buttons - %s"), _(DISPLAY_NAME));
+	editlist_gui_open (NULL, NULL, button_list, buf, "buttons", "buttons.conf", ulbutton_help);
 }
 
 static void
 menu_dlgbuttons (void)
 {
-	editlist_gui_open (NULL, NULL, dlgbutton_list, _("Dialog buttons - "DISPLAY_NAME), "dlgbuttons",
-							 "dlgbuttons.conf", dlgbutton_help);
+	char buf[128];
+	g_snprintf(buf, sizeof(buf), _("Dialog buttons - %s"), _(DISPLAY_NAME));
+	editlist_gui_open (NULL, NULL, dlgbutton_list, buf, "dlgbuttons", "dlgbuttons.conf",
+							 dlgbutton_help);
 }
 
 static void
 menu_ctcpguiopen (void)
 {
-	editlist_gui_open (NULL, NULL, ctcp_list, _("CTCP Replies - "DISPLAY_NAME), "ctcpreply",
-							 "ctcpreply.conf", ctcp_help);
+	char buf[128];
+	g_snprintf(buf, sizeof(buf), _("CTCP Replies - %s"), _(DISPLAY_NAME));
+	editlist_gui_open (NULL, NULL, ctcp_list, buf, "ctcpreply", "ctcpreply.conf", ctcp_help);
 }
 
 static void
@@ -1727,7 +1737,7 @@ menu_about (GtkWidget *wid, gpointer sess)
 #endif
 				get_sys_str (0));
 
-	gtk_about_dialog_set_program_name (dialog, DISPLAY_NAME);
+	gtk_about_dialog_set_program_name (dialog, _(DISPLAY_NAME));
 	gtk_about_dialog_set_version (dialog, PACKAGE_VERSION);
 	gtk_about_dialog_set_license (dialog, license); /* gtk3 can use GTK_LICENSE_GPL_2_0 */
 	gtk_about_dialog_set_website (dialog, "http://hexchat.github.io");

--- a/src/fe-gtk/menu.c
+++ b/src/fe-gtk/menu.c
@@ -1134,7 +1134,7 @@ menu_settings (GtkWidget * wid, gpointer none)
 static void
 menu_usermenu (void)
 {
-	editlist_gui_open (NULL, NULL, usermenu_list, _(DISPLAY_NAME": User menu"),
+	editlist_gui_open (NULL, NULL, usermenu_list, _("User menu - "DISPLAY_NAME),
 							 "usermenu", "usermenu.conf", 0);
 }
 
@@ -1524,28 +1524,28 @@ menu_noplugin_info (void)
 static void
 menu_usercommands (void)
 {
-	editlist_gui_open (NULL, NULL, command_list, _(DISPLAY_NAME": User Defined Commands"),
+	editlist_gui_open (NULL, NULL, command_list, _("User Defined Commands - "DISPLAY_NAME),
 							 "commands", "commands.conf", usercommands_help);
 }
 
 static void
 menu_ulpopup (void)
 {
-	editlist_gui_open (NULL, NULL, popup_list, _(DISPLAY_NAME": Userlist Popup menu"), "popup",
+	editlist_gui_open (NULL, NULL, popup_list, _("Userlist Popup menu - "DISPLAY_NAME), "popup",
 							 "popup.conf", ulbutton_help);
 }
 
 static void
 menu_rpopup (void)
 {
-	editlist_gui_open (_("Text"), _("Replace with"), replace_list, _(DISPLAY_NAME": Replace"), "replace",
+	editlist_gui_open (_("Text"), _("Replace with"), replace_list, _("Replace - "DISPLAY_NAME), "replace",
 							 "replace.conf", 0);
 }
 
 static void
 menu_urlhandlers (void)
 {
-	editlist_gui_open (NULL, NULL, urlhandler_list, _(DISPLAY_NAME": URL Handlers"), "urlhandlers",
+	editlist_gui_open (NULL, NULL, urlhandler_list, _("URL Handlers - "DISPLAY_NAME), "urlhandlers",
 							 "urlhandlers.conf", url_help);
 }
 
@@ -1564,21 +1564,21 @@ menu_keypopup (void)
 static void
 menu_ulbuttons (void)
 {
-	editlist_gui_open (NULL, NULL, button_list, _(DISPLAY_NAME": Userlist buttons"), "buttons",
+	editlist_gui_open (NULL, NULL, button_list, _("Userlist buttons - "DISPLAY_NAME), "buttons",
 							 "buttons.conf", ulbutton_help);
 }
 
 static void
 menu_dlgbuttons (void)
 {
-	editlist_gui_open (NULL, NULL, dlgbutton_list, _(DISPLAY_NAME": Dialog buttons"), "dlgbuttons",
+	editlist_gui_open (NULL, NULL, dlgbutton_list, _("Dialog buttons - "DISPLAY_NAME), "dlgbuttons",
 							 "dlgbuttons.conf", dlgbutton_help);
 }
 
 static void
 menu_ctcpguiopen (void)
 {
-	editlist_gui_open (NULL, NULL, ctcp_list, _(DISPLAY_NAME": CTCP Replies"), "ctcpreply",
+	editlist_gui_open (NULL, NULL, ctcp_list, _("CTCP Replies - "DISPLAY_NAME), "ctcpreply",
 							 "ctcpreply.conf", ctcp_help);
 }
 

--- a/src/fe-gtk/notifygui.c
+++ b/src/fe-gtk/notifygui.c
@@ -406,7 +406,7 @@ notify_opengui (void)
 	}
 
 	notify_window =
-		mg_create_generic_tab ("Notify", _(DISPLAY_NAME": Friends List"), FALSE, TRUE,
+		mg_create_generic_tab ("Notify", _("Friends List - "DISPLAY_NAME), FALSE, TRUE,
 		                       notify_closegui, NULL, 400, 250, &vbox, 0);
 	gtkutil_destroy_on_esc (notify_window);
 

--- a/src/fe-gtk/notifygui.c
+++ b/src/fe-gtk/notifygui.c
@@ -398,6 +398,7 @@ notify_opengui (void)
 {
 	GtkWidget *vbox, *bbox;
 	GtkWidget *view;
+	char buf[128];
 
 	if (notify_window)
 	{
@@ -405,9 +406,10 @@ notify_opengui (void)
 		return;
 	}
 
+	g_snprintf(buf, sizeof(buf), _("Friends List - %s"), _(DISPLAY_NAME));
 	notify_window =
-		mg_create_generic_tab ("Notify", _("Friends List - "DISPLAY_NAME), FALSE, TRUE,
-		                       notify_closegui, NULL, 400, 250, &vbox, 0);
+		mg_create_generic_tab ("Notify", buf, FALSE, TRUE, notify_closegui, NULL, 400,
+								250, &vbox, 0);
 	gtkutil_destroy_on_esc (notify_window);
 
 	view = notify_treeview_new (vbox);

--- a/src/fe-gtk/plugin-tray.c
+++ b/src/fe-gtk/plugin-tray.c
@@ -174,10 +174,10 @@ tray_stop_flash (void)
 		nets = tray_count_networks ();
 		chans = tray_count_channels ();
 		if (nets)
-			tray_set_tipf (_(DISPLAY_NAME": Connected to %u networks and %u channels"),
+			tray_set_tipf (_("Connected to %u networks and %u channels - "DISPLAY_NAME),
 								nets, chans);
 		else
-			tray_set_tipf (DISPLAY_NAME": %s", _("Not connected."));
+			tray_set_tipf ("%s - "DISPLAY_NAME, _("Not connected."));
 	}
 
 	if (custom_icon1)
@@ -628,10 +628,10 @@ tray_hilight_cb (char *word[], void *userdata)
 		/* FIXME: hides any previous private messages */
 		tray_hilight_count++;
 		if (tray_hilight_count == 1)
-			tray_set_tipf (_(DISPLAY_NAME": Highlighted message from: %s (%s)"),
+			tray_set_tipf (_("Highlighted message from: %s (%s) - "DISPLAY_NAME),
 								word[1], hexchat_get_info (ph, "channel"));
 		else
-			tray_set_tipf (_(DISPLAY_NAME": %u highlighted messages, latest from: %s (%s)"),
+			tray_set_tipf (_("%u highlighted messages, latest from: %s (%s) - "DISPLAY_NAME),
 								tray_hilight_count, word[1], hexchat_get_info (ph, "channel"));
 	}
 
@@ -650,10 +650,10 @@ tray_message_cb (char *word[], void *userdata)
 
 		tray_pub_count++;
 		if (tray_pub_count == 1)
-			tray_set_tipf (_(DISPLAY_NAME": Channel message from: %s (%s)"),
+			tray_set_tipf (_("Channel message from: %s (%s) - "DISPLAY_NAME),
 								word[1], hexchat_get_info (ph, "channel"));
 		else
-			tray_set_tipf (_(DISPLAY_NAME": %u channel messages."), tray_pub_count);
+			tray_set_tipf (_("%u channel messages. - "DISPLAY_NAME), tray_pub_count);
 	}
 
 	return HEXCHAT_EAT_NONE;
@@ -677,10 +677,10 @@ tray_priv (char *from, char *text)
 
 		tray_priv_count++;
 		if (tray_priv_count == 1)
-			tray_set_tipf (_(DISPLAY_NAME": Private message from: %s (%s)"),
+			tray_set_tipf (_("Private message from: %s (%s) - "DISPLAY_NAME),
 								from, network);
 		else
-			tray_set_tipf (_(DISPLAY_NAME": %u private messages, latest from: %s (%s)"),
+			tray_set_tipf (_("%u private messages, latest from: %s (%s) - "DISPLAY_NAME),
 								tray_priv_count, from, network);
 	}
 }
@@ -720,10 +720,10 @@ tray_dcc_cb (char *word[], void *userdata)
 
 		tray_file_count++;
 		if (tray_file_count == 1)
-			tray_set_tipf (_(DISPLAY_NAME": File offer from: %s (%s)"),
+			tray_set_tipf (_("File offer from: %s (%s) - "DISPLAY_NAME),
 								word[1], network);
 		else
-			tray_set_tipf (_(DISPLAY_NAME": %u file offers, latest from: %s (%s)"),
+			tray_set_tipf (_("%u file offers, latest from: %s (%s) - "DISPLAY_NAME),
 								tray_file_count, word[1], network);
 	}
 

--- a/src/fe-gtk/plugin-tray.c
+++ b/src/fe-gtk/plugin-tray.c
@@ -174,10 +174,10 @@ tray_stop_flash (void)
 		nets = tray_count_networks ();
 		chans = tray_count_channels ();
 		if (nets)
-			tray_set_tipf (_("Connected to %u networks and %u channels - "DISPLAY_NAME),
-								nets, chans);
+			tray_set_tipf (_("Connected to %u networks and %u channels - %s"),
+								nets, chans, _(DISPLAY_NAME));
 		else
-			tray_set_tipf ("%s - "DISPLAY_NAME, _("Not connected."));
+			tray_set_tipf ("%s - %s", _("Not connected."), _(DISPLAY_NAME));
 	}
 
 	if (custom_icon1)
@@ -628,11 +628,12 @@ tray_hilight_cb (char *word[], void *userdata)
 		/* FIXME: hides any previous private messages */
 		tray_hilight_count++;
 		if (tray_hilight_count == 1)
-			tray_set_tipf (_("Highlighted message from: %s (%s) - "DISPLAY_NAME),
-								word[1], hexchat_get_info (ph, "channel"));
+			tray_set_tipf (_("Highlighted message from: %s (%s) - %s"),
+								word[1], hexchat_get_info (ph, "channel"), _(DISPLAY_NAME));
 		else
-			tray_set_tipf (_("%u highlighted messages, latest from: %s (%s) - "DISPLAY_NAME),
-								tray_hilight_count, word[1], hexchat_get_info (ph, "channel"));
+			tray_set_tipf (_("%u highlighted messages, latest from: %s (%s) - %s"),
+								tray_hilight_count, word[1], hexchat_get_info (ph, "channel"),
+								_(DISPLAY_NAME));
 	}
 
 	return HEXCHAT_EAT_NONE;
@@ -650,10 +651,10 @@ tray_message_cb (char *word[], void *userdata)
 
 		tray_pub_count++;
 		if (tray_pub_count == 1)
-			tray_set_tipf (_("Channel message from: %s (%s) - "DISPLAY_NAME),
-								word[1], hexchat_get_info (ph, "channel"));
+			tray_set_tipf (_("Channel message from: %s (%s) - %s"),
+								word[1], hexchat_get_info (ph, "channel"), _(DISPLAY_NAME));
 		else
-			tray_set_tipf (_("%u channel messages. - "DISPLAY_NAME), tray_pub_count);
+			tray_set_tipf (_("%u channel messages. - %s"), tray_pub_count, _(DISPLAY_NAME));
 	}
 
 	return HEXCHAT_EAT_NONE;
@@ -677,11 +678,11 @@ tray_priv (char *from, char *text)
 
 		tray_priv_count++;
 		if (tray_priv_count == 1)
-			tray_set_tipf (_("Private message from: %s (%s) - "DISPLAY_NAME),
-								from, network);
+			tray_set_tipf (_("Private message from: %s (%s) - %s"), from,
+								network, _(DISPLAY_NAME));
 		else
-			tray_set_tipf (_("%u private messages, latest from: %s (%s) - "DISPLAY_NAME),
-								tray_priv_count, from, network);
+			tray_set_tipf (_("%u private messages, latest from: %s (%s) - %s"),
+								tray_priv_count, from, network, _(DISPLAY_NAME));
 	}
 }
 
@@ -720,11 +721,11 @@ tray_dcc_cb (char *word[], void *userdata)
 
 		tray_file_count++;
 		if (tray_file_count == 1)
-			tray_set_tipf (_("File offer from: %s (%s) - "DISPLAY_NAME),
-								word[1], network);
+			tray_set_tipf (_("File offer from: %s (%s) - %s"), word[1], network,
+								_(DISPLAY_NAME));
 		else
-			tray_set_tipf (_("%u file offers, latest from: %s (%s) - "DISPLAY_NAME),
-								tray_file_count, word[1], network);
+			tray_set_tipf (_("%u file offers, latest from: %s (%s) - %s"),
+								tray_file_count, word[1], network, _(DISPLAY_NAME));
 	}
 
 	return HEXCHAT_EAT_NONE;

--- a/src/fe-gtk/plugingui.c
+++ b/src/fe-gtk/plugingui.c
@@ -237,7 +237,7 @@ plugingui_open (void)
 		return;
 	}
 
-	plugin_window = mg_create_generic_tab ("Addons", _(DISPLAY_NAME": Plugins and Scripts"),
+	plugin_window = mg_create_generic_tab ("Addons", _("Plugins and Scripts - "DISPLAY_NAME),
 														 FALSE, TRUE, plugingui_close, NULL,
 														 700, 300, &vbox, 0);
 	gtkutil_destroy_on_esc (plugin_window);

--- a/src/fe-gtk/plugingui.c
+++ b/src/fe-gtk/plugingui.c
@@ -230,6 +230,7 @@ plugingui_open (void)
 {
 	GtkWidget *view;
 	GtkWidget *vbox, *hbox;
+	char buf[128];
 
 	if (plugin_window)
 	{
@@ -237,8 +238,8 @@ plugingui_open (void)
 		return;
 	}
 
-	plugin_window = mg_create_generic_tab ("Addons", _("Plugins and Scripts - "DISPLAY_NAME),
-														 FALSE, TRUE, plugingui_close, NULL,
+	g_snprintf(buf, sizeof(buf), _("Plugins and Scripts - %s"), _(DISPLAY_NAME));
+	plugin_window = mg_create_generic_tab ("Addons", buf, FALSE, TRUE, plugingui_close, NULL,
 														 700, 300, &vbox, 0);
 	gtkutil_destroy_on_esc (plugin_window);
 

--- a/src/fe-gtk/rawlog.c
+++ b/src/fe-gtk/rawlog.c
@@ -109,7 +109,7 @@ open_rawlog (struct server *serv)
 		return;
 	}
 
-	g_snprintf (tbuf, sizeof tbuf, _(DISPLAY_NAME": Raw Log (%s)"), serv->servername);
+	g_snprintf (tbuf, sizeof tbuf, _("Raw Log (%s) - "DISPLAY_NAME), serv->servername);
 	serv->gui->rawlog_window =
 		mg_create_generic_tab ("RawLog", tbuf, FALSE, TRUE, close_rawlog, serv,
 							 640, 320, &vbox, serv);

--- a/src/fe-gtk/rawlog.c
+++ b/src/fe-gtk/rawlog.c
@@ -109,7 +109,7 @@ open_rawlog (struct server *serv)
 		return;
 	}
 
-	g_snprintf (tbuf, sizeof tbuf, _("Raw Log (%s) - "DISPLAY_NAME), serv->servername);
+	g_snprintf (tbuf, sizeof tbuf, _("Raw Log (%s) - %s"), serv->servername, _(DISPLAY_NAME));
 	serv->gui->rawlog_window =
 		mg_create_generic_tab ("RawLog", tbuf, FALSE, TRUE, close_rawlog, serv,
 							 640, 320, &vbox, serv);

--- a/src/fe-gtk/servlistgui.c
+++ b/src/fe-gtk/servlistgui.c
@@ -1707,7 +1707,7 @@ servlist_open_edit (GtkWidget *parent, ircnet *net)
 
 	editwindow = gtk_window_new (GTK_WINDOW_TOPLEVEL);
 	gtk_container_set_border_width (GTK_CONTAINER (editwindow), 4);
-	g_snprintf (buf, sizeof (buf), _("Edit %s - "DISPLAY_NAME), net->name);
+	g_snprintf (buf, sizeof (buf), _("Edit %s - %s"), net->name, _(DISPLAY_NAME));
 	gtk_window_set_title (GTK_WINDOW (editwindow), buf);
 	gtk_window_set_default_size (GTK_WINDOW (editwindow), netedit_win_width, netedit_win_height);
 	gtk_window_set_transient_for (GTK_WINDOW (editwindow), GTK_WINDOW (parent));
@@ -1970,10 +1970,12 @@ servlist_open_networks (void)
 	GtkTreeModel *model;
 	GtkListStore *store;
 	GtkCellRenderer *renderer;
+	char buf[128];
 
 	servlist = gtk_window_new (GTK_WINDOW_TOPLEVEL);
 	gtk_container_set_border_width (GTK_CONTAINER (servlist), 4);
-	gtk_window_set_title (GTK_WINDOW (servlist), _("Network List - "DISPLAY_NAME));
+	g_snprintf(buf, sizeof(buf), _("Network List - %s"), _(DISPLAY_NAME));
+	gtk_window_set_title (GTK_WINDOW (servlist), buf);
 	gtk_window_set_default_size (GTK_WINDOW (servlist), netlist_win_width, netlist_win_height);
 	gtk_window_set_role (GTK_WINDOW (servlist), "servlist");
 	gtk_window_set_type_hint (GTK_WINDOW (servlist), GDK_WINDOW_TYPE_HINT_DIALOG);

--- a/src/fe-gtk/servlistgui.c
+++ b/src/fe-gtk/servlistgui.c
@@ -1707,7 +1707,7 @@ servlist_open_edit (GtkWidget *parent, ircnet *net)
 
 	editwindow = gtk_window_new (GTK_WINDOW_TOPLEVEL);
 	gtk_container_set_border_width (GTK_CONTAINER (editwindow), 4);
-	g_snprintf (buf, sizeof (buf), _(DISPLAY_NAME": Edit %s"), net->name);
+	g_snprintf (buf, sizeof (buf), _("Edit %s - "DISPLAY_NAME), net->name);
 	gtk_window_set_title (GTK_WINDOW (editwindow), buf);
 	gtk_window_set_default_size (GTK_WINDOW (editwindow), netedit_win_width, netedit_win_height);
 	gtk_window_set_transient_for (GTK_WINDOW (editwindow), GTK_WINDOW (parent));
@@ -1973,7 +1973,7 @@ servlist_open_networks (void)
 
 	servlist = gtk_window_new (GTK_WINDOW_TOPLEVEL);
 	gtk_container_set_border_width (GTK_CONTAINER (servlist), 4);
-	gtk_window_set_title (GTK_WINDOW (servlist), _(DISPLAY_NAME": Network List"));
+	gtk_window_set_title (GTK_WINDOW (servlist), _("Network List - "DISPLAY_NAME));
 	gtk_window_set_default_size (GTK_WINDOW (servlist), netlist_win_width, netlist_win_height);
 	gtk_window_set_role (GTK_WINDOW (servlist), "servlist");
 	gtk_window_set_type_hint (GTK_WINDOW (servlist), GDK_WINDOW_TYPE_HINT_DIALOG);

--- a/src/fe-gtk/setup.c
+++ b/src/fe-gtk/setup.c
@@ -2289,7 +2289,7 @@ setup_window_open (void)
 {
 	GtkWidget *wid, *win, *vbox, *hbox, *hbbox;
 
-	win = gtkutil_window_new (_(DISPLAY_NAME": Preferences"), "prefs", 0, 600, 2);
+	win = gtkutil_window_new (_("Preferences - "DISPLAY_NAME), "prefs", 0, 600, 2);
 
 	vbox = gtk_vbox_new (FALSE, 5);
 	gtk_container_set_border_width (GTK_CONTAINER (vbox), 6);

--- a/src/fe-gtk/setup.c
+++ b/src/fe-gtk/setup.c
@@ -2288,8 +2288,10 @@ static GtkWidget *
 setup_window_open (void)
 {
 	GtkWidget *wid, *win, *vbox, *hbox, *hbbox;
+	char buf[128];
 
-	win = gtkutil_window_new (_("Preferences - "DISPLAY_NAME), "prefs", 0, 600, 2);
+	g_snprintf(buf, sizeof(buf), _("Preferences - %s"), _(DISPLAY_NAME));
+	win = gtkutil_window_new (buf, "prefs", 0, 600, 2);
 
 	vbox = gtk_vbox_new (FALSE, 5);
 	gtk_container_set_border_width (GTK_CONTAINER (vbox), 6);

--- a/src/fe-gtk/urlgrab.c
+++ b/src/fe-gtk/urlgrab.c
@@ -195,7 +195,7 @@ url_opengui ()
 	}
 
 	urlgrabberwindow =
-		mg_create_generic_tab ("UrlGrabber", _(DISPLAY_NAME": URL Grabber"), FALSE,
+		mg_create_generic_tab ("UrlGrabber", _("URL Grabber - "DISPLAY_NAME), FALSE,
 							 TRUE, url_closegui, NULL, 400, 256, &vbox, 0);
 	gtkutil_destroy_on_esc (urlgrabberwindow);
 	view = url_treeview_new (vbox);

--- a/src/fe-gtk/urlgrab.c
+++ b/src/fe-gtk/urlgrab.c
@@ -187,6 +187,7 @@ void
 url_opengui ()
 {
 	GtkWidget *vbox, *hbox, *view;
+	char buf[128];
 
 	if (urlgrabberwindow)
 	{
@@ -194,9 +195,10 @@ url_opengui ()
 		return;
 	}
 
+	g_snprintf(buf, sizeof(buf), _("URL Grabber - %s"), _(DISPLAY_NAME));
 	urlgrabberwindow =
-		mg_create_generic_tab ("UrlGrabber", _("URL Grabber - "DISPLAY_NAME), FALSE,
-							 TRUE, url_closegui, NULL, 400, 256, &vbox, 0);
+		mg_create_generic_tab ("UrlGrabber", buf, FALSE, TRUE, url_closegui, NULL,
+							 400, 256, &vbox, 0);
 	gtkutil_destroy_on_esc (urlgrabberwindow);
 	view = url_treeview_new (vbox);
 	g_object_set_data (G_OBJECT (urlgrabberwindow), "model",


### PR DESCRIPTION
This changes all Hexchat windows from starting with "Hexchat: " to ending instead with " - Hexchat"

This is done because particularly when Hexchat is used such that all buffers open new windows, it becomes impossible to distinguish any window from another in the window manager window list.  By moving the program branding to the end of the string, the possibly truncated window title visible will provide the most useful information to the user first.

This also makes Hexchat behave more like most other programs (Firefox, Chrome, Thunderbird, etc.) where the branding is at the end of the title.  (Presumably for the same reason.) 

This pull request touches a lot of files, most of them are .po files for the translations as the ": " was a part of the msgid and so each entry needed to be changed.  No change in the style of these messages has been made, and so now the msgid ends with " - ".  Additionally, a number of files using Unicode had a mixture of double-byte and single-byte colons "：" and ":", all instances have been replaced with single-byte at this time.

I personally also believe the "Dialog with" text in the window title for query buffers should be done away with, as it gets in the way of seeing the nick as above when titles are truncated, but this pull request does not make that change.