### PR TITLE
Fix oob read caused by ptr[0] being NULL in inbound_notice

### DIFF
--- a/src/common/inbound.c
+++ b/src/common/inbound.c
@@ -940,7 +940,7 @@ inbound_notice (server *serv, char *to, char *nick, char *msg, char *ip, int id,
 		sess = find_channel (serv, ptr);
 
 	/* /notice [mode-prefix]#channel should end up in that channel */
-	if (!sess && strchr(serv->nick_prefixes, ptr[0]) != NULL)
+	if (!sess && ptr[0] && strchr(serv->nick_prefixes, ptr[0]) != NULL)
 	{
 		ptr++;
 		sess = find_channel (serv, ptr);


### PR DESCRIPTION
If ptr[0] is NULL, then strchr may return a pointer to the NULL
terminator for serv->nick_prefixes, making the if statement true, which
then leads to the pointer increment leaving ptr oob. Now we check to
ensure ptr[0] != NULL.

From the Linux manpages for strchr:
The terminating null byte is considered part of the string, so that if c is
       specified as '\0', these functions return a pointer to the terminator.

This fixes the underlying issue that I was attempting to fix in #2058, which did not actually fix the issue since the pointer is already oob by the time we get to rfc_casecmp as a result of the inbound_notice code, which I fix here.