### PR TITLE
Fix rfc_ncasecmp handling of n reaching 0

### DIFF
--- a/src/common/util.c
+++ b/src/common/util.c
@@ -1040,11 +1040,8 @@ rfc_ncasecmp (char *s1, char *s2, int n)
 {
 	int c1, c2;
 
-	while (*s1 && *s2)
+	while (*s1 && *s2 && n > 0)
 	{
-		if (n == 0)
-			return 0;
-
 		c1 = (int)rfc_tolower (*s1);
 		c2 = (int)rfc_tolower (*s2);
 		if (c1 != c2)
@@ -1055,7 +1052,7 @@ rfc_ncasecmp (char *s1, char *s2, int n)
 	}
 	c1 = (int)rfc_tolower (*s1);
 	c2 = (int)rfc_tolower (*s2);
-	return (c1 - c2);
+	return (n == 0) ? 0 : (c1 - c2);
 }
 
 const unsigned char rfc_tolowertab[] =


### PR DESCRIPTION
If n becomes 0 at the same time that the end of either s1 or s2 are
reached, the next iteration of the while loop wouldn't happen, so we
wouldn't correctly return 0.