### PR TITLE
Add an option to disable rejoin on auto reconnect

### DIFF
--- a/src/common/cfgfiles.c
+++ b/src/common/cfgfiles.c
@@ -496,6 +496,7 @@ const struct prefs vars[] =
 	{"input_tray_priv", P_OFFINT (hex_input_tray_priv), TYPE_BOOL},
 
 	{"irc_auto_rejoin", P_OFFINT (hex_irc_auto_rejoin), TYPE_BOOL},
+	{"irc_reconnect_rejoin", P_OFFINT (hex_irc_reconnect_rejoin), TYPE_BOOL},
 	{"irc_ban_type", P_OFFINT (hex_irc_ban_type), TYPE_INT},
 	{"irc_cap_server_time", P_OFFINT (hex_irc_cap_server_time), TYPE_BOOL},
 	{"irc_conf_mode", P_OFFINT (hex_irc_conf_mode), TYPE_BOOL},
@@ -777,6 +778,7 @@ load_default_config(void)
 	prefs.hex_input_flash_priv = 1;
 	prefs.hex_input_tray_hilight = 1;
 	prefs.hex_input_tray_priv = 1;
+	prefs.hex_irc_reconnect_rejoin = 1;
 	prefs.hex_irc_cap_server_time = 1;
 	prefs.hex_irc_logging = 1;
 	prefs.hex_irc_who_join = 1; /* Can kick with inordinate amount of channels, required for some of our features though, TODO: add cap like away check? */

--- a/src/common/hexchat.h
+++ b/src/common/hexchat.h
@@ -170,6 +170,7 @@ struct hexchatprefs
 	unsigned int hex_input_tray_hilight;
 	unsigned int hex_input_tray_priv;
 	unsigned int hex_irc_auto_rejoin;
+	unsigned int hex_irc_reconnect_rejoin;
 	unsigned int hex_irc_conf_mode;
 	unsigned int hex_irc_hidehost;
 	unsigned int hex_irc_hide_nickchange;

--- a/src/common/server.c
+++ b/src/common/server.c
@@ -681,22 +681,25 @@ static void
 auto_reconnect (server *serv, int send_quit, int err)
 {
 	session *s;
-	GSList *list;
 	int del;
 
 	if (serv->server_session == NULL)
 		return;
 
-	list = sess_list;
-	while (list)				  /* make sure auto rejoin can work */
+	if (prefs.hex_irc_reconnect_rejoin)
 	{
-		s = list->data;
-		if (s->type == SESS_CHANNEL && s->channel[0])
+		GSList *list;
+		list = sess_list;
+		while (list)				  /* make sure auto rejoin can work */
 		{
-			strcpy (s->waitchannel, s->channel);
-			strcpy (s->willjoinchannel, s->channel);
+			s = list->data;
+			if (s->type == SESS_CHANNEL && s->channel[0])
+			{
+				strcpy (s->waitchannel, s->channel);
+				strcpy (s->willjoinchannel, s->channel);
+			}
+			list = list->next;
 		}
-		list = list->next;
 	}
 
 	if (serv->connected)


### PR DESCRIPTION
This change adds an option `irc_reconnect_rejoin` (default ON)
which when turned OFF will prevent hexchat from rejoining channels
after an auto reconnect.

hexchat/hexchat#2069