### PR TITLE
Fix oob read in ctcp_check

### DIFF
--- a/src/common/ctcp.c
+++ b/src/common/ctcp.c
@@ -148,6 +148,9 @@ ctcp_handle (session *sess, char *to, char *nick, char *ip,
 		serv->p_nctcp (serv, nick, outbuf);
 	}
 
+	if (word[4][1] == '\0')
+		return;
+
 	if (!ctcp_check (sess, nick, word, word_eol, word[4] + ctcp_offset))
 	{
 		if (!g_ascii_strncasecmp (msg, "SOUND", 5))


### PR DESCRIPTION
word[4] can be too short, leading to the addition of ctcp_offset
putting us out of bounds. This results in an oob read in ctcp_check.