### PR TITLE
WIN32: Respond to WM_TIMECHANGE by updating the CRT timezone info.

### DIFF
--- a/src/fe-gtk/maingui.c
+++ b/src/fe-gtk/maingui.c
@@ -3200,11 +3200,29 @@ mg_tabwindow_de_cb (GtkWidget *widget, GdkEvent *event, gpointer user_data)
 	return TRUE;
 }
 
+#ifdef _WIN32
+static GdkFilterReturn
+mg_time_change (GdkXEvent *xevent, GdkEvent *event, gpointer data)
+{
+	MSG* msg = (MSG*)xevent;
+
+	if (msg->message == WM_TIMECHANGE)
+	{
+		_tzset();
+	}
+
+	return GDK_FILTER_CONTINUE;
+}
+#endif
+
 static void
 mg_create_tabwindow (session *sess)
 {
 	GtkWidget *win;
 	GtkWidget *table;
+#ifdef _WIN32
+	GdkWindow *parent_win;
+#endif
 
 	win = gtkutil_window_new ("HexChat", NULL, prefs.hex_gui_win_width,
 									  prefs.hex_gui_win_height, 0);
@@ -3269,6 +3287,11 @@ mg_create_tabwindow (session *sess)
 	mg_place_userlist_and_chanview (sess->gui);
 
 	gtk_widget_show (win);
+
+#ifdef WIN32
+	parent_win = gtk_widget_get_window (win);
+	gdk_window_add_filter (parent_win, mg_time_change, NULL);
+#endif
 }
 
 void


### PR DESCRIPTION
Fix for #1851 