### PR TITLE
Prevent undefined behaviour on memcpy

### DIFF
--- a/src/fe-gtk/xtext.c
+++ b/src/fe-gtk/xtext.c
@@ -4677,9 +4677,11 @@ gtk_xtext_append_indent (xtext_buffer *buf,
 	ent = g_malloc (left_len + right_len + 2 + sizeof (textentry));
 	str = (unsigned char *) ent + sizeof (textentry);
 
-	memcpy (str, left_text, left_len);
+	if (left_len)
+		memcpy (str, left_text, left_len);
 	str[left_len] = ' ';
-	memcpy (str + left_len + 1, right_text, right_len);
+	if (right_len)
+		memcpy (str + left_len + 1, right_text, right_len);
 	str[left_len + 1 + right_len] = 0;
 
 	left_width = gtk_xtext_text_width (buf->xtext, left_text, left_len);


### PR DESCRIPTION
`gtk_xtext_append_indent` is getting passed `left_text = 0` and `left_len = 0` from `PrintTextLine`, so `memcpy` is being called like `memcpy(str, 0, 0)` which is undefined behaviour.