### PR TITLE
Change the installation path of the appdata file to {datadir}/metainfo

### DIFF
--- a/data/misc/meson.build
+++ b/data/misc/meson.build
@@ -7,7 +7,7 @@ if get_option('with-gtk')
     output: 'io.github.Hexchat.appdata.xml',
     po_dir: '../../po',
     install: true,
-    install_dir: join_paths(get_option('datadir'), 'appdata')
+    install_dir: join_paths(get_option('datadir'), 'metainfo')
   )
 
   appstream_util = find_program('appstream-util', required: false)


### PR DESCRIPTION
The path where appdata/appstream files should be installed has been
changed from /usr/share/appdata/ to /usr/share/metainfo/.

https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#spec-component-location


I don't know *when* it happened, but in Debian we had a check for this since some time already.

Also note, I didn't try to build the project and see whether it does what I expect to.