### PR TITLE
Fix typo in German translation

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -1562,7 +1562,7 @@ msgstr "%C29*%O$tVerbunden."
 
 #: src/common/textevents.h:373
 msgid "%C29*%O$tLooking up %C29$1%O"
-msgstr "%C29*%O$tLSuche nach %C29$1%O"
+msgstr "%C29*%O$tSuche nach %C29$1%O"
 
 #: src/common/textevents.h:385
 msgid "%C23*%O$tStopped previous connection attempt (%C24$1%O)"


### PR DESCRIPTION
The German string contained was prefixed by a `L`, which most probably
was an artefact of copy-pasting the original string. This removes it.