### PR TITLE
Fix issue #1587 (IO Related Freezing during XDCC receive/move)

### DIFF
--- a/src/common/dcc.c
+++ b/src/common/dcc.c
@@ -628,6 +628,7 @@ dcc_read_chat (GIOChannel *source, GIOCondition condition, struct DCC *dcc)
 		}
 		i++;
 	}
+        return TRUE;
 }
 
 static void
@@ -770,6 +771,7 @@ dcc_read (GIOChannel *source, GIOCondition condition, struct DCC *dcc)
 						 dcc->file, dcc->destfile, dcc->nick, buf, 0);
 		return TRUE;
 	}
+        return TRUE;
 }
 
 static void

--- a/src/common/dcc.c
+++ b/src/common/dcc.c
@@ -713,68 +713,65 @@ dcc_read (GIOChannel *source, GIOCondition condition, struct DCC *dcc)
 		dcc_close (dcc, STAT_FAILED, FALSE);
 		return TRUE;
 	}
-	while (1)
+	if (dcc->throttled)
 	{
-		if (dcc->throttled)
-		{
-			if (need_ack)
-				dcc_send_ack (dcc);
-
-			fe_input_remove (dcc->iotag);
-			dcc->iotag = 0;
-			return FALSE;
-		}
-
-		if (!dcc->iotag)
-			dcc->iotag = fe_input_add (dcc->sok, FIA_READ|FIA_EX, dcc_read, dcc);
-
-		n = recv (dcc->sok, buf, sizeof (buf), 0);
-		if (n < 1)
-		{
-			if (n < 0)
-			{
-				if (would_block ())
-				{
-					if (need_ack)
-						dcc_send_ack (dcc);
-					return TRUE;
-				}
-			}
-			EMIT_SIGNAL (XP_TE_DCCRECVERR, dcc->serv->front_session, dcc->file,
-							 dcc->destfile, dcc->nick,
-							 errorstring ((n < 0) ? sock_error () : 0), 0);
-			/* send ack here? but the socket is dead */
-			/*if (need_ack)
-				dcc_send_ack (dcc);*/
-			dcc_close (dcc, STAT_FAILED, FALSE);
-			return TRUE;
-		}
-
-		if (write (dcc->fp, buf, n) == -1) /* could be out of hdd space */
-		{
-			EMIT_SIGNAL (XP_TE_DCCRECVERR, dcc->serv->front_session, dcc->file,
-							 dcc->destfile, dcc->nick, errorstring (errno), 0);
-			if (need_ack)
-				dcc_send_ack (dcc);
-			dcc_close (dcc, STAT_FAILED, FALSE);
-			return TRUE;
-		}
-
-		dcc->lasttime = time (0);
-		dcc->pos += n;
-		need_ack = TRUE;	/* send ack when we're done recv()ing */
-
-		if (dcc->pos >= dcc->size)
-		{
+		if (need_ack)
 			dcc_send_ack (dcc);
-			dcc_close (dcc, STAT_DONE, FALSE);
-			dcc_calc_average_cps (dcc);	/* this must be done _after_ dcc_close, or dcc_remove_from_sum will see the wrong value in dcc->cps */
-			/* cppcheck-suppress deallocuse */
-			sprintf (buf, "%" G_GINT64_FORMAT, dcc->cps);
-			EMIT_SIGNAL (XP_TE_DCCRECVCOMP, dcc->serv->front_session,
-							 dcc->file, dcc->destfile, dcc->nick, buf, 0);
-			return TRUE;
+
+		fe_input_remove (dcc->iotag);
+		dcc->iotag = 0;
+		return FALSE;
+	}
+
+	if (!dcc->iotag)
+		dcc->iotag = fe_input_add (dcc->sok, FIA_READ|FIA_EX, dcc_read, dcc);
+
+	n = recv (dcc->sok, buf, sizeof (buf), 0);
+	if (n < 1)
+	{
+		if (n < 0)
+		{
+			if (would_block ())
+			{
+				if (need_ack)
+					dcc_send_ack (dcc);
+				return TRUE;
+			}
 		}
+		EMIT_SIGNAL (XP_TE_DCCRECVERR, dcc->serv->front_session, dcc->file,
+						 dcc->destfile, dcc->nick,
+						 errorstring ((n < 0) ? sock_error () : 0), 0);
+		/* send ack here? but the socket is dead */
+		/*if (need_ack)
+			dcc_send_ack (dcc);*/
+		dcc_close (dcc, STAT_FAILED, FALSE);
+		return TRUE;
+	}
+
+	if (write (dcc->fp, buf, n) == -1) /* could be out of hdd space */
+	{
+		EMIT_SIGNAL (XP_TE_DCCRECVERR, dcc->serv->front_session, dcc->file,
+						 dcc->destfile, dcc->nick, errorstring (errno), 0);
+		if (need_ack)
+			dcc_send_ack (dcc);
+		dcc_close (dcc, STAT_FAILED, FALSE);
+		return TRUE;
+	}
+
+	dcc->lasttime = time (0);
+	dcc->pos += n;
+	need_ack = TRUE;	/* send ack when we're done recv()ing */
+
+	if (dcc->pos >= dcc->size)
+	{
+		dcc_send_ack (dcc);
+		dcc_close (dcc, STAT_DONE, FALSE);
+		dcc_calc_average_cps (dcc);	/* this must be done _after_ dcc_close, or dcc_remove_from_sum will see the wrong value in dcc->cps */
+		/* cppcheck-suppress deallocuse */
+		sprintf (buf, "%" G_GINT64_FORMAT, dcc->cps);
+		EMIT_SIGNAL (XP_TE_DCCRECVCOMP, dcc->serv->front_session,
+						 dcc->file, dcc->destfile, dcc->nick, buf, 0);
+		return TRUE;
 	}
 }
 

--- a/src/common/util.c
+++ b/src/common/util.c
@@ -1152,8 +1152,8 @@ move_file (char *src_dir, char *dst_dir, char *fname, int dccpermissions)
 		/* link failed because either the two paths aren't on the */
 		/* same filesystem or the filesystem doesn't support hard */
 		/* links, so we have to do a copy. */
-	        GFile* src_file = g_file_new_for_path(src);
-		GFile* dst_file = g_file_new_for_path(dst);
+		GFile *src_file = g_file_new_for_path(src);
+		GFile *dst_file = g_file_new_for_path(dst);
 		g_file_copy_async(src_file, dst_file, G_FILE_COPY_NONE,
 		                  G_PRIORITY_DEFAULT, NULL, NULL, NULL,
 		                  &move_file_callback, NULL);

--- a/src/common/util.c
+++ b/src/common/util.c
@@ -1096,68 +1096,24 @@ file_exists (char *fname)
 	return (g_access (fname, F_OK) == 0) ? TRUE : FALSE;
 }
 
-static gboolean
-copy_file (char *dl_src, char *dl_dest, int permissions)
+/* Called when copy is complete to delete source file. */
+void move_file_callback(GObject *source_object, GAsyncResult *res,
+                        gpointer user_data)
 {
-	int tmp_src, tmp_dest;
-	gboolean ok = FALSE;
-	char dl_tmp[4096];
-	int return_tmp, return_tmp2;
-
-	if ((tmp_src = g_open (dl_src, O_RDONLY | OFLAGS, 0600)) == -1)
-	{
-		g_fprintf (stderr, "Unable to open() file '%s' (%s) !", dl_src,
-				  strerror (errno));
-		return FALSE;
+	GFile *source_file = (GFile *)source_object;
+	GError *error;
+	if (!g_file_copy_finish(source_file, res, &error)) {
+		fprintf(stderr,
+		        "Error while copying file to save directory: %s\n",
+		        error->message);
+		g_error_free(error);
+	} else {
+		if (!g_file_delete(source_file, NULL, NULL))
+			fprintf(stderr,
+			        "Error deleting source file after copying file "
+			        "to save directory: %s\n",
+			        g_file_get_path(source_file));
 	}
-
-	if ((tmp_dest =
-		 g_open (dl_dest, O_WRONLY | O_CREAT | O_TRUNC | OFLAGS, permissions)) < 0)
-	{
-		close (tmp_src);
-		g_fprintf (stderr, "Unable to create file '%s' (%s) !", dl_src,
-				  strerror (errno));
-		return FALSE;
-	}
-
-	for (;;)
-	{
-		return_tmp = read (tmp_src, dl_tmp, sizeof (dl_tmp));
-
-		if (!return_tmp)
-		{
-			ok = TRUE;
-			break;
-		}
-
-		if (return_tmp < 0)
-		{
-			fprintf (stderr, "download_move_to_completed_dir(): "
-				"error reading while moving file to save directory (%s)",
-				 strerror (errno));
-			break;
-		}
-
-		return_tmp2 = write (tmp_dest, dl_tmp, return_tmp);
-
-		if (return_tmp2 < 0)
-		{
-			fprintf (stderr, "download_move_to_completed_dir(): "
-				"error writing while moving file to save directory (%s)",
-				 strerror (errno));
-			break;
-		}
-
-		if (return_tmp < sizeof (dl_tmp))
-		{
-			ok = TRUE;
-			break;
-		}
-	}
-
-	close (tmp_dest);
-	close (tmp_src);
-	return ok;
 }
 
 /* Takes care of moving a file from a temporary download location to a completed location. */
@@ -1196,10 +1152,14 @@ move_file (char *src_dir, char *dst_dir, char *fname, int dccpermissions)
 		/* link failed because either the two paths aren't on the */
 		/* same filesystem or the filesystem doesn't support hard */
 		/* links, so we have to do a copy. */
-		if (copy_file (src, dst, dccpermissions))
-			g_unlink (src);
+	        GFile* src_file = g_file_new_for_path(src);
+		GFile* dst_file = g_file_new_for_path(dst);
+		g_file_copy_async(src_file, dst_file, G_FILE_COPY_NONE,
+		                  G_PRIORITY_DEFAULT, NULL, NULL, NULL,
+		                  &move_file_callback, NULL);
+		g_object_unref(src_file);
+		g_object_unref(dst_file);
 	}
-
 	g_free (dst);
 	g_free (src);
 }


### PR DESCRIPTION
Finally remembered/got around to taking a look at this. This is a patch to fix #1587 as described by Arnavion: https://github.com/hexchat/hexchat/issues/1587#issuecomment-172401038. It works for me and prevents freezing in the situations I described in the report.
Questions for review:
- Is the error handling and error message implementation for the async okay?
- Is it necessary or a good idea to remove the loop in the dcc_read_ack function as well? 
