### PR TITLE
build: perl as a dependency in meson.build

### DIFF
--- a/plugins/perl/meson.build
+++ b/plugins/perl/meson.build
@@ -76,11 +76,14 @@ int main(void) {
   error('found perl not suitable for plugin')
 endif
 
+perl_dep = declare_dependency(
+  compile_args: perl_cflags,
+  link_args: perl_ldflags
+)
+
 shared_module('perl',
   sources: ['perl.c', hexchat_perl_module, irc_perl_module],
-  dependencies: [libgio_dep, hexchat_plugin_dep],
-  c_args: perl_cflags,
-  link_args: perl_ldflags,
+  dependencies: [libgio_dep, hexchat_plugin_dep, perl_dep],
   install: true,
   install_dir: plugindir,
   install_rpath: perl_rpath,


### PR DESCRIPTION
With the switch to meson, the problem previously fixed in #1822 came
back. The build system might pick up the installed hexchat-config.h
instead of using the header in the source directory, as the compiler
arguments would be in the order of "-I${prefix}/include -I..".

It seems that the c_args in meson are always put to the front of the
compiler arguments, in order to be able to override any include paths
from dependencies. However, this was not the intention here, so perl
should also be modeled as a dependency. This ensures that the arguments
with local include directories come first.