### PR TITLE
Fix plugins on macOS

### DIFF
--- a/src/common/outbound.c
+++ b/src/common/outbound.c
@@ -2610,7 +2610,7 @@ cmd_load (struct session *sess, char *tbuf, char *word[], char *word_eol[])
 	}
 
 #ifdef USE_PLUGIN
-	if (g_str_has_suffix (word[2], "."G_MODULE_SUFFIX))
+	if (g_str_has_suffix (word[2], "."PLUGIN_SUFFIX))
 	{
 		arg = NULL;
 		if (word_eol[3][0])
@@ -3616,7 +3616,7 @@ cmd_unload (struct session *sess, char *tbuf, char *word[], char *word_eol[])
 #ifdef USE_PLUGIN
 	gboolean by_file = FALSE;
 
-	if (g_str_has_suffix (word[2], "."G_MODULE_SUFFIX))
+	if (g_str_has_suffix (word[2], "."PLUGIN_SUFFIX))
 		by_file = TRUE;
 
 	switch (plugin_kill (word[2], by_file))
@@ -3641,7 +3641,7 @@ cmd_reload (struct session *sess, char *tbuf, char *word[], char *word_eol[])
 #ifdef USE_PLUGIN
 	gboolean by_file = FALSE;
 
-	if (g_str_has_suffix (word[2], "."G_MODULE_SUFFIX))
+	if (g_str_has_suffix (word[2], "."PLUGIN_SUFFIX))
 		by_file = TRUE;
 
 	switch (plugin_reload (sess, word[2], by_file))

--- a/src/common/plugin.c
+++ b/src/common/plugin.c
@@ -464,10 +464,10 @@ plugin_auto_load (session *sess)
 	for_files (lib_dir, "hcwinamp.dll", plugin_auto_load_cb);
 	for_files (lib_dir, "hcsysinfo.dll", plugin_auto_load_cb);
 #else
-	for_files (lib_dir, "*."G_MODULE_SUFFIX, plugin_auto_load_cb);
+	for_files (lib_dir, "*."PLUGIN_SUFFIX, plugin_auto_load_cb);
 #endif
 
-	for_files (sub_dir, "*."G_MODULE_SUFFIX, plugin_auto_load_cb);
+	for_files (sub_dir, "*."PLUGIN_SUFFIX, plugin_auto_load_cb);
 
 	g_free (sub_dir);
 }

--- a/src/common/plugin.h
+++ b/src/common/plugin.h
@@ -181,4 +181,12 @@ int plugin_show_help (session *sess, char *cmd);
 void plugin_command_foreach (session *sess, void *userdata, void (*cb) (session *sess, void *userdata, char *name, char *usage));
 session *plugin_find_context (const char *servname, const char *channel, server *current_server);
 
+/* On macOS, G_MODULE_SUFFIX says "so" but meson uses "dylib"
+ * https://github.com/mesonbuild/meson/issues/1160 */
+#if defined(__APPLE__)
+#  define PLUGIN_SUFFIX "dylib"
+#else
+#  define PLUGIN_SUFFIX G_MODULE_SUFFIX
+#endif
+
 #endif

--- a/src/fe-gtk/plugingui.c
+++ b/src/fe-gtk/plugingui.c
@@ -162,7 +162,7 @@ plugingui_load (void)
 	char *sub_dir = g_build_filename (get_xdir(), "addons", NULL);
 
 	gtkutil_file_req (_("Select a Plugin or Script to load"), plugingui_load_cb, current_sess,
-							sub_dir, "*."G_MODULE_SUFFIX";*.lua;*.pl;*.py;*.tcl;*.js", FRF_FILTERISINITIAL|FRF_EXTENSIONS);
+							sub_dir, "*."PLUGIN_SUFFIX";*.lua;*.pl;*.py;*.tcl;*.js", FRF_FILTERISINITIAL|FRF_EXTENSIONS);
 
 	g_free (sub_dir);
 }
@@ -185,7 +185,7 @@ plugingui_unload (GtkWidget * wid, gpointer unused)
 	                                    FILEPATH_COLUMN, &file, -1))
 		return;
 
-	if (g_str_has_suffix (file, "."G_MODULE_SUFFIX))
+	if (g_str_has_suffix (file, "."PLUGIN_SUFFIX))
 	{
 		if (plugin_kill (modname, FALSE) == 2)
 			fe_message (_("That plugin is refusing to unload.\n"), FE_MSG_ERROR);


### PR DESCRIPTION
The switch to the meson build system broke plugins on macOS. GNU libtool
builds shared libraries with ".dylib" and shared modules (plugins) with
the extension ".so", but meson is using ".dylib" for both.

Although overriding the name_suffix for shared_module() in meson is
possible, this would be messy for other platforms as there is no way to
query the default. Therefore it seems like we have to go with ".dylib"
for now on macOS.

However, G_MODULE_SUFFIX is defined to ".so", because glib follows what
GNU libtool does. Therefore define a separate preprocessor macro that
has the correct extension.

See: https://github.com/mesonbuild/meson/issues/1160