### PR TITLE
fix sending of server passwords

### DIFF
--- a/src/common/proto-irc.c
+++ b/src/common/proto-irc.c
@@ -53,7 +53,9 @@ irc_login (server *serv, char *user, char *realname)
 
 	if (serv->password[0] && serv->loginmethod == LOGIN_PASS)
 	{
-		tcp_sendf (serv, "PASS %s\r\n", serv->password);
+		tcp_sendf (serv, "PASS %s%s\r\n",
+			(serv->password[0] == ':' || strchr (serv->password, ' ')) ? ":" : "",
+			serv->password);
 	}
 
 	tcp_sendf (serv,


### PR DESCRIPTION
This PR fixes sending of server passwords according to RFC.
Fixes #1550 

If the server passwords contains at least one space a colon will be added in front of it when logging in.
Same applies if the password begins with a colon.