### PR TITLE
fkeys: re-add ctrl+w keybinding

### DIFF
--- a/src/fe-gtk/fkeys.c
+++ b/src/fe-gtk/fkeys.c
@@ -208,7 +208,8 @@ static const struct key_action key_actions[KEY_MAX_ACTIONS + 1] = {
 	"ACCEL=<Alt>Right\nMove front tab right\nD1!\nD2!\n\n"\
 	"ACCEL=<Primary><Shift>Page_Up\nMove tab family left\nD1!\nD2!\n\n"\
 	"ACCEL=<Primary><Shift>Page_Down\nMove tab family right\nD1!\nD2!\n\n"\
-	"ACCEL=F9\nRun Command\nD1:/GUI MENU TOGGLE\nD2!\n\n"
+	"ACCEL=F9\nRun Command\nD1:/GUI MENU TOGGLE\nD2!\n\n"\
+	"ACCEL=Ctrl+W\nClose current tab\nD1:/CLOSE\nD2!\n\n"
 
 void
 key_init ()


### PR DESCRIPTION
Now that the Ctrl+W key binding is no longer hard coded, users are free to add it in order to close the current tab. However, I believe this should be the default behavior.
After this commit, users can still manually disable the Ctrl+W key binding if they desire.

This is my first commit, so please let me know if I made this change incorrectly.