### PR TITLE
Added ability to ignore joins, parts and quits of an ignored user

### DIFF
--- a/src/common/ignore.c
+++ b/src/common/ignore.c
@@ -147,6 +147,10 @@ ignore_showlist (session *sess)
 			strcat (tbuf, _("YES  "));
 		else
 			strcat (tbuf, _("NO   "));
+		if (ig->type & IG_JOINS_PARTS)
+			strcat (tbuf, _("YES         "));
+		else
+			strcat (tbuf, _("NO          "));
 		if (ig->type & IG_UNIG)
 			strcat (tbuf, _("YES  "));
 		else

--- a/src/common/ignore.c
+++ b/src/common/ignore.c
@@ -77,7 +77,7 @@ ignore_exists (char *mask)
  */
 
 int
-ignore_add (char *mask, int type, gboolean overwrite)
+ignore_add (char *mask, guint type, gboolean overwrite)
 {
 	struct ignore *ig = NULL;
 	int change_only = FALSE;
@@ -200,7 +200,7 @@ ignore_del (char *mask, struct ignore *ig)
 /* check if a msg should be ignored by browsing our ignore list */
 
 int
-ignore_check (char *host, int type)
+ignore_check (char *host, guint type)
 {
 	struct ignore *ig;
 	GSList *list = ignore_list;

--- a/src/common/ignore.h
+++ b/src/common/ignore.h
@@ -36,6 +36,7 @@ extern int ignored_invi;
 #define IG_UNIG	32
 #define IG_NOSAVE	64
 #define IG_DCC		128
+#define IG_JOINS_PARTS 256
 
 struct ignore
 {

--- a/src/common/ignore.h
+++ b/src/common/ignore.h
@@ -40,14 +40,14 @@ extern int ignored_invi;
 struct ignore
 {
 	char *mask;
-	unsigned int type;	/* one of more of IG_* ORed together */
+	guint type; /* one of more of IG_* ORed together */
 };
 
 struct ignore *ignore_exists (char *mask);
-int ignore_add (char *mask, int type, gboolean overwrite);
+int ignore_add (char *mask, guint type, gboolean overwrite);
 void ignore_showlist (session *sess);
 int ignore_del (char *mask, struct ignore *ig);
-int ignore_check (char *mask, int type);
+int ignore_check (char *mask, guint type);
 void ignore_load (void);
 void ignore_save (void);
 void ignore_gui_open (void);

--- a/src/common/inbound.c
+++ b/src/common/inbound.c
@@ -763,14 +763,15 @@ inbound_topicnew (server *serv, char *nick, char *chan, char *topic,
 }
 
 void
-inbound_join (server *serv, char *chan, char *user, char *ip, char *account,
+inbound_join (server *serv, char *chan, char *host, char *user, char *ip, char *account,
 				  char *realname, const message_tags_data *tags_data)
 {
 	session *sess = find_channel (serv, chan);
 	if (sess)
 	{
-		EMIT_SIGNAL_TIMESTAMP (XP_TE_JOIN, sess, user, chan, ip, account, 0,
-									  tags_data->timestamp);
+		if (!ignore_check(host, IG_JOINS_PARTS))
+			EMIT_SIGNAL_TIMESTAMP (XP_TE_JOIN, sess, user, chan, ip, account, 0,
+			                       tags_data->timestamp);
 		userlist_add (sess, user, ip, account, realname, tags_data);
 	}
 }
@@ -789,18 +790,21 @@ inbound_kick (server *serv, char *chan, char *user, char *kicker, char *reason,
 }
 
 void
-inbound_part (server *serv, char *chan, char *user, char *ip, char *reason,
+inbound_part (server *serv, char *chan, char *host, char *user, char *ip, char *reason,
 				  const message_tags_data *tags_data)
 {
 	session *sess = find_channel (serv, chan);
 	if (sess)
 	{
-		if (*reason)
-			EMIT_SIGNAL_TIMESTAMP (XP_TE_PARTREASON, sess, user, ip, chan, reason,
-										  0, tags_data->timestamp);
-		else
-			EMIT_SIGNAL_TIMESTAMP (XP_TE_PART, sess, user, ip, chan, NULL, 0,
-										  tags_data->timestamp);
+		if (!ignore_check(host, IG_JOINS_PARTS))
+		{
+			if (*reason)
+				EMIT_SIGNAL_TIMESTAMP (XP_TE_PARTREASON, sess, user, ip, chan, reason,
+				                       0, tags_data->timestamp);
+			else
+				EMIT_SIGNAL_TIMESTAMP (XP_TE_PART, sess, user, ip, chan, NULL, 0,
+				                       tags_data->timestamp);
+		}
 		userlist_remove (sess, user);
 	}
 }
@@ -821,7 +825,7 @@ inbound_topictime (server *serv, char *chan, char *nick, time_t stamp,
 }
 
 void
-inbound_quit (server *serv, char *nick, char *ip, char *reason,
+inbound_quit (server *serv, char *host, char *nick, char *ip, char *reason,
 				  const message_tags_data *tags_data)
 {
 	GSList *list = sess_list;
@@ -838,8 +842,9 @@ inbound_quit (server *serv, char *nick, char *ip, char *reason,
  				was_on_front_session = TRUE;
 			if ((user = userlist_find (sess, nick)))
 			{
-				EMIT_SIGNAL_TIMESTAMP (XP_TE_QUIT, sess, nick, reason, ip, NULL, 0,
-											  tags_data->timestamp);
+				if (!ignore_check(host, IG_JOINS_PARTS))
+					EMIT_SIGNAL_TIMESTAMP (XP_TE_QUIT, sess, nick, reason, ip, NULL, 0,
+					                       tags_data->timestamp);
 				userlist_remove_user (sess, user);
 			} else if (sess->type == SESS_DIALOG && !serv->p_cmp (sess->channel, nick))
 			{

--- a/src/common/inbound.h
+++ b/src/common/inbound.h
@@ -28,7 +28,7 @@ void inbound_uback (server *serv, const message_tags_data *tags_data);
 void inbound_uaway (server *serv, const message_tags_data *tags_data);
 void inbound_account (server *serv, char *nick, char *account,
 							 const message_tags_data *tags_data);
-void inbound_part (server *serv, char *chan, char *user, char *ip, char *reason,
+void inbound_part (server *serv, char *chan, char *host, char *user, char *ip, char *reason,
 						 const message_tags_data *tags_data);
 void inbound_upart (server *serv, char *chan, char *ip, char *reason,
 						  const message_tags_data *tags_data);
@@ -38,11 +38,11 @@ void inbound_kick (server *serv, char *chan, char *user, char *kicker,
 						 char *reason, const message_tags_data *tags_data);
 void inbound_notice (server *serv, char *to, char *nick, char *msg, char *ip,
 							int id, const message_tags_data *tags_data);
-void inbound_quit (server *serv, char *nick, char *ip, char *reason,
+void inbound_quit (server *serv, char *host, char *nick, char *ip, char *reason,
 						 const message_tags_data *tags_data);
 void inbound_topicnew (server *serv, char *nick, char *chan, char *topic,
 							  const message_tags_data *tags_data);
-void inbound_join (server *serv, char *chan, char *user, char *ip, 
+void inbound_join (server *serv, char *chan, char *host, char *user, char *ip,
 						 char *account, char *realname, 
 						 const message_tags_data *tags_data);
 void inbound_ujoin (server *serv, char *chan, char *nick, char *ip,

--- a/src/common/outbound.c
+++ b/src/common/outbound.c
@@ -2385,6 +2385,8 @@ cmd_ignore (struct session *sess, char *tbuf, char *word[], char *word_eol[])
 			type |= IG_NOSAVE;
 		else if (!g_ascii_strcasecmp (word[i], "DCC"))
 			type |= IG_DCC;
+		else if (!g_ascii_strcasecmp (word[i], "JOINS_PARTS"))
+			type |= IG_JOINS_PARTS;
 		else
 		{
 			sprintf (tbuf, _("Unknown arg '%s' ignored."), word[i]);
@@ -4011,7 +4013,7 @@ const struct commands xc_cmds[] = {
 	 N_("IGNORE <mask> <types..> <options..>\n"
 	 "    mask - host mask to ignore, eg: *!*@*.aol.com\n"
 	 "    types - types of data to ignore, one or all of:\n"
-	 "            PRIV, CHAN, NOTI, CTCP, DCC, INVI, ALL\n"
+	 "            PRIV, CHAN, NOTI, CTCP, DCC, INVI, JOINS_PARTS, ALL\n"
 	 "    options - NOSAVE, QUIET")},
 
 	{"INVITE", cmd_invite, 1, 0, 1,

--- a/src/common/proto-irc.c
+++ b/src/common/proto-irc.c
@@ -1048,8 +1048,8 @@ process_named_msg (session *sess, char *type, char *word[], char *word_eol[],
 				if (!serv->p_cmp (nick, serv->nick))
 					inbound_ujoin (serv, chan, nick, ip, tags_data);
 				else
-					inbound_join (serv, chan, nick, ip, account, realname,
-									  tags_data);
+					inbound_join (serv, chan, word[1], nick, ip, account, realname,
+					              tags_data);
 			}
 			return;
 
@@ -1102,7 +1102,7 @@ process_named_msg (session *sess, char *type, char *word[], char *word_eol[],
 				if (!strcmp (nick, serv->nick))
 					inbound_upart (serv, chan, ip, reason, tags_data);
 				else
-					inbound_part (serv, chan, nick, ip, reason, tags_data);
+					inbound_part (serv, chan, word[1], nick, ip, reason, tags_data);
 			}
 			return;
 
@@ -1117,9 +1117,9 @@ process_named_msg (session *sess, char *type, char *word[], char *word_eol[],
 			return;
 
 		case WORDL('Q','U','I','T'):
-			inbound_quit (serv, nick, ip,
-							  (word_eol[3][0] == ':') ? word_eol[3] + 1 : word_eol[3],
-							  tags_data);
+			inbound_quit (serv, word[1], nick, ip,
+			              (word_eol[3][0] == ':') ? word_eol[3] + 1 : word_eol[3],
+			              tags_data);
 			return;
 
 		case WORDL('A','W','A','Y'):

--- a/src/common/textevents.in
+++ b/src/common/textevents.in
@@ -463,13 +463,13 @@ pevt_ignoreaddremove_help
 Ignore Footer
 XP_TE_IGNOREFOOTER
 pevt_generic_none_help
-%C16,17                                                              
+%C16,17                                                                          
 0
 
 Ignore Header
 XP_TE_IGNOREHEADER
 pevt_generic_none_help
-%C16,17 Hostmask                  PRIV NOTI CHAN CTCP DCC  INVI UNIG 
+%C16,17 Hostmask                  PRIV NOTI CHAN CTCP DCC  INVI JOINS_PARTS UNIG
 0
 
 Ignore Remove

--- a/src/fe-gtk/ignoregui.c
+++ b/src/fe-gtk/ignoregui.c
@@ -58,14 +58,22 @@ get_store (void)
 	return gtk_tree_view_get_model (g_object_get_data (G_OBJECT (ignorewin), "view"));
 }
 
-static int
+static guint
 ignore_get_flags (GtkTreeModel *model, GtkTreeIter *iter)
 {
 	gboolean chan, priv, noti, ctcp, dcc, invi, unig;
-	int flags = 0;
+	guint flags = 0;
 
-	gtk_tree_model_get (model, iter, 1, &chan, 2, &priv, 3, &noti,
-	                    4, &ctcp, 5, &dcc, 6, &invi, 7, &unig, -1);
+	gtk_tree_model_get (
+		model, iter,
+		CHAN_COLUMN, &chan,
+		PRIV_COLUMN, &priv,
+		NOTICE_COLUMN, &noti,
+		CTCP_COLUMN, &ctcp,
+		DCC_COLUMN, &dcc,
+		INVITE_COLUMN, &invi,
+		UNIGNORE_COLUMN, &unig,
+		-1);
 	if (chan)
 		flags |= IG_CHAN;
 	if (priv)
@@ -89,11 +97,11 @@ mask_edited (GtkCellRendererText *render, gchar *path, gchar *new, gpointer dat)
 	GtkListStore *store = GTK_LIST_STORE (get_store ());
 	GtkTreeIter iter;
 	char *old;
-	int flags;
+	guint flags;
 
 	gtkutil_treemodel_string_to_iter (GTK_TREE_MODEL (store), path, &iter);
 	gtk_tree_model_get (GTK_TREE_MODEL (store), &iter, 0, &old, -1);
-	
+
 	if (!strcmp (old, new))	/* no change */
 		;
 	else if (ignore_exists (new))	/* duplicate, ignore */
@@ -109,7 +117,6 @@ mask_edited (GtkCellRendererText *render, gchar *path, gchar *new, gpointer dat)
 		gtk_list_store_set (store, &iter, MASK_COLUMN, new, -1);
 	}
 	g_free (old);
-	
 }
 
 static void
@@ -120,7 +127,7 @@ option_toggled (GtkCellRendererToggle *render, gchar *path, gpointer data)
 	int col_id = GPOINTER_TO_INT (data);
 	gboolean active;
 	char *mask;
-	int flags;
+	guint flags;
 
 	gtkutil_treemodel_string_to_iter (GTK_TREE_MODEL (store), path, &iter);
 
@@ -233,7 +240,7 @@ ignore_store_new (int cancel, char *mask, gpointer data)
 	GtkListStore *store = GTK_LIST_STORE (get_store ());
 	GtkTreeIter iter;
 	GtkTreePath *path;
-	int flags = IG_CHAN | IG_PRIV | IG_NOTI | IG_CTCP | IG_DCC | IG_INVI;
+	guint flags = IG_CHAN | IG_PRIV | IG_NOTI | IG_CTCP | IG_DCC | IG_INVI;
 
 	if (cancel)
 		return;
@@ -248,8 +255,17 @@ ignore_store_new (int cancel, char *mask, gpointer data)
 
 	gtk_list_store_append (store, &iter);
 	/* ignore everything by default */
-	gtk_list_store_set (store, &iter, 0, mask, 1, TRUE, 2, TRUE, 3, TRUE,
-	                    4, TRUE, 5, TRUE, 6, TRUE, 7, FALSE, -1);
+	gtk_list_store_set (
+		store, &iter,
+		MASK_COLUMN, mask,
+		CHAN_COLUMN, TRUE,
+		PRIV_COLUMN, TRUE,
+		NOTICE_COLUMN, TRUE,
+		CTCP_COLUMN, TRUE,
+		DCC_COLUMN, TRUE,
+		INVITE_COLUMN, TRUE,
+		UNIGNORE_COLUMN, FALSE,
+		-1);
 	/* make sure the new row is visible and selected */
 	path = gtk_tree_model_get_path (GTK_TREE_MODEL (store), &iter);
 	gtk_tree_view_scroll_to_cell (view, path, NULL, TRUE, 1.0, 0.0);

--- a/src/fe-gtk/ignoregui.c
+++ b/src/fe-gtk/ignoregui.c
@@ -40,6 +40,7 @@ enum
 	CTCP_COLUMN,
 	DCC_COLUMN,
 	INVITE_COLUMN,
+	JOINS_PARTS_COLUMN,
 	UNIGNORE_COLUMN,
 	N_COLUMNS
 };
@@ -61,7 +62,7 @@ get_store (void)
 static guint
 ignore_get_flags (GtkTreeModel *model, GtkTreeIter *iter)
 {
-	gboolean chan, priv, noti, ctcp, dcc, invi, unig;
+	gboolean chan, priv, noti, ctcp, dcc, invi, joins_parts, unig;
 	guint flags = 0;
 
 	gtk_tree_model_get (
@@ -72,6 +73,7 @@ ignore_get_flags (GtkTreeModel *model, GtkTreeIter *iter)
 		CTCP_COLUMN, &ctcp,
 		DCC_COLUMN, &dcc,
 		INVITE_COLUMN, &invi,
+		JOINS_PARTS_COLUMN, &joins_parts,
 		UNIGNORE_COLUMN, &unig,
 		-1);
 	if (chan)
@@ -86,6 +88,8 @@ ignore_get_flags (GtkTreeModel *model, GtkTreeIter *iter)
 		flags |= IG_DCC;
 	if (invi)
 		flags |= IG_INVI;
+	if (joins_parts)
+		flags |= IG_JOINS_PARTS;
 	if (unig)
 		flags |= IG_UNIG;
 	return flags;
@@ -169,6 +173,7 @@ ignore_treeview_new (GtkWidget *box)
 	                             CTCP_COLUMN, _("CTCP"),
 	                             DCC_COLUMN, _("DCC"),
 	                             INVITE_COLUMN, _("Invite"),
+	                             JOINS_PARTS_COLUMN, _("Joins & Parts"),
 	                             UNIGNORE_COLUMN, _("Unignore"),
 	                             -1);
 
@@ -240,7 +245,7 @@ ignore_store_new (int cancel, char *mask, gpointer data)
 	GtkListStore *store = GTK_LIST_STORE (get_store ());
 	GtkTreeIter iter;
 	GtkTreePath *path;
-	guint flags = IG_CHAN | IG_PRIV | IG_NOTI | IG_CTCP | IG_DCC | IG_INVI;
+	guint flags = IG_CHAN | IG_PRIV | IG_NOTI | IG_CTCP | IG_DCC | IG_INVI | IG_JOINS_PARTS;
 
 	if (cancel)
 		return;
@@ -264,6 +269,7 @@ ignore_store_new (int cancel, char *mask, gpointer data)
 		CTCP_COLUMN, TRUE,
 		DCC_COLUMN, TRUE,
 		INVITE_COLUMN, TRUE,
+		JOINS_PARTS_COLUMN, TRUE,
 		UNIGNORE_COLUMN, FALSE,
 		-1);
 	/* make sure the new row is visible and selected */
@@ -354,7 +360,7 @@ ignore_gui_open ()
 	GtkTreeIter iter;
 	GSList *temp = ignore_list;
 	char *mask;
-	gboolean private, chan, notice, ctcp, dcc, invite, unignore;
+	gboolean private, chan, notice, ctcp, dcc, invite, joins_parts, unignore;
 	char buf[128];
 
 	if (ignorewin)
@@ -415,6 +421,7 @@ ignore_gui_open ()
 		ctcp = (ignore->type & IG_CTCP);
 		dcc = (ignore->type & IG_DCC);
 		invite = (ignore->type & IG_INVI);
+		joins_parts = (ignore->type & IG_JOINS_PARTS);
 		unignore = (ignore->type & IG_UNIG);
 
 		gtk_list_store_append (store, &iter);
@@ -426,6 +433,7 @@ ignore_gui_open ()
 		                    CTCP_COLUMN, ctcp,
 		                    DCC_COLUMN, dcc,
 		                    INVITE_COLUMN, invite,
+		                    JOINS_PARTS_COLUMN, joins_parts,
 		                    UNIGNORE_COLUMN, unignore,
 		                    -1);
 		


### PR DESCRIPTION
(Previously opened as https://github.com/hexchat/hexchat/pull/1712 but I can't push to that branch any more.)

---

Mentioned in #500 

---

Note that only the text events emit is skipped, to keep HC's state of the channel sane. For example, the ignored user will still be added to the channel list when they join and be available for tab-complete, etc. which would not be the case if the JOIN had been ignored in inbound.c. Otherwise you could end up in strange states, such as if the ignored user was present in the channel list before being ignored, and now would not be removed even if they quit.