### PR TITLE
fix /py exec behaviour

### DIFF
--- a/plugins/python/python.py
+++ b/plugins/python/python.py
@@ -97,7 +97,7 @@ else:
         return compile(data, filename, 'exec', optimize=2, dont_inherit=True)
 
     def compile_line(string):
-        return compile(string, '<string>', 'eval', optimize=2, dont_inherit=True)
+        return compile(string, '<string>', 'single', optimize=2, dont_inherit=True)
 
 
 class Plugin:


### PR DESCRIPTION
`/py exec` was previously syntax erroring when something like `/py exec import sys; print(sys.modules)` was run