### PR TITLE
fixed hexchat.unload_hook() failing when passed a hook id

### DIFF
--- a/plugins/python/python.py
+++ b/plugins/python/python.py
@@ -121,7 +121,7 @@ class Plugin:
     def remove_hook(self, hook):
         for h in self.hooks:
             if id(h) == hook:
-                ud = hook.userdata
+                ud = h.userdata
                 self.hooks.remove(h)
                 return ud
         else:


### PR DESCRIPTION
Fixes remove_hook() erroring when passed a hook id. This closes  #2221