### PR TITLE
fixed /exec behaviour (again)

### DIFF
--- a/plugins/python/python.py
+++ b/plugins/python/python.py
@@ -97,7 +97,8 @@ else:
         return compile(data, filename, 'exec', optimize=2, dont_inherit=True)
 
     def compile_line(string):
-        return compile(string, '<string>', 'single', optimize=2, dont_inherit=True)
+        # using exec over single as single causes weird behaviour
+        return compile(string, '<string>', 'exec', optimize=2, dont_inherit=True)
 
 
 class Plugin:

--- a/plugins/python/python.py
+++ b/plugins/python/python.py
@@ -97,8 +97,8 @@ else:
         return compile(data, filename, 'exec', optimize=2, dont_inherit=True)
 
     def compile_line(string):
-        # using exec over single as single causes weird behaviour
-        return compile(string, '<string>', 'exec', optimize=2, dont_inherit=True)
+        # newline appended to solve unexpected EOF issues
+        return compile(string + "\n", '<string>', 'single', optimize=2, dont_inherit=True)
 
 
 class Plugin:

--- a/plugins/python/python.py
+++ b/plugins/python/python.py
@@ -98,7 +98,7 @@ else:
 
     def compile_line(string):
         # newline appended to solve unexpected EOF issues
-        return compile(string + "\n", '<string>', 'single', optimize=2, dont_inherit=True)
+        return compile(string + '\n', '<string>', 'single', optimize=2, dont_inherit=True)
 
 
 class Plugin:


### PR DESCRIPTION
resolves issues where using 'multiline' statements cause syntax errors:

```python
 From cffi callback <function _on_py_command at 0x7f29afe40378>:
 Traceback (most recent call last):
   File "<init code for '_hexchat_embedded'>", line 411, in _on_py_command
   File "<init code for '_hexchat_embedded'>", line 369, in exec_in_interp
   File "<init code for '_hexchat_embedded'>", line 100, in compile_line
   File "<string>", line 1
     for x in "test": print(x)
                             ^
 SyntaxError: unexpected EOF while parsing
```