### PR TITLE
Fix inconsistent behavior (re)connecting on SSL

### DIFF
--- a/src/common/server.c
+++ b/src/common/server.c
@@ -748,7 +748,6 @@ server_connect_success (server *serv)
 
 		/* it'll be a memory leak, if connection isn't terminated by
 		   server_cleanup() */
-		serv->ssl = _SSL_socket (serv->ctx, serv->sok);
 		if ((err = _SSL_set_verify (serv->ctx, ssl_cb_verify, NULL)))
 		{
 			EMIT_SIGNAL (XP_TE_CONNFAIL, serv->server_session, err, NULL,
@@ -756,6 +755,7 @@ server_connect_success (server *serv)
 			server_cleanup (serv);	/* ->connecting = FALSE */
 			return;
 		}
+		serv->ssl = _SSL_socket (serv->ctx, serv->sok);
 		/* FIXME: it'll be needed by new servers */
 		/* send(serv->sok, "STLS\r\n", 6, 0); sleep(1); */
 		set_nonblocking (serv->sok);


### PR DESCRIPTION
When connecting on SSL, the verify in the context is setup too late and does not affect the existing ssl. This creates an inconsistent behavior because the first time an SSL connection is established it won't call the verification callback:

`[17:46:40] * Looking up irc.freenode.net`
`[17:46:42] * * Certification info:`
`[17:46:42] *   Subject:`
`[17:46:42] *     CN=weber.freenode.net`

The second time is called because the context was configured from the first time:

`[17:46:47] * Looking up irc.freenode.net`
`[17:46:48] * * Subject: /O=Digital Signature Trust Co./CN=DST Root CA X3`
`[17:46:48] * * Issuer: /O=Digital Signature Trust Co./CN=DST Root CA X3`
`[17:46:48] * * Subject: /C=US/O=Let's Encrypt/CN=Let's Encrypt Authority X3`
`[17:46:48] * * Issuer: /O=Digital Signature Trust Co./CN=DST Root CA X3`
`[17:46:48] * * Subject: /CN=weber.freenode.net`
`[17:46:48] * * Issuer: /C=US/O=Let's Encrypt/CN=Let's Encrypt Authority X3`
`[17:46:49] * * Certification info:`
`[17:46:49] *   Subject:`
`[17:46:49] *     CN=weber.freenode.net`

This commit fixes this behavior by creating the SSL after the context is setup.