### PR TITLE
Various fixes (errors in hexchat-text on windows, and crlf issues in server list)

### DIFF
--- a/src/common/outbound.c
+++ b/src/common/outbound.c
@@ -2560,7 +2560,6 @@ gboolean
 load_perform_file (session *sess, char *file)
 {
 	char tbuf[1024 + 4];
-	char *nl;
 	FILE *fp;
 
 	fp = hexchat_fopen_file (file, "r", 0);		/* load files from config dir */
@@ -2570,11 +2569,9 @@ load_perform_file (session *sess, char *file)
 	tbuf[1024] = 0;
 	while (fgets (tbuf, 1024, fp))
 	{
-		nl = strchr (tbuf, '\n');
-		if (nl == tbuf) /* skip empty commands */
+		tbuf[strcspn (tbuf, "\r\n")] = 0;
+		if (!*tbuf) /* skip empty commands */
 			continue;
-		if (nl)
-			*nl = 0;
 		if (tbuf[0] == prefs.hex_input_command_char[0])
 			handle_command (sess, tbuf + 1, TRUE);
 		else

--- a/src/common/servlist.c
+++ b/src/common/servlist.c
@@ -984,7 +984,6 @@ servlist_load (void)
 {
 	FILE *fp;
 	char buf[2048];
-	int len;
 	ircnet *net = NULL;
 
 	/* simple migration we will keep for a short while */
@@ -1005,11 +1004,9 @@ servlist_load (void)
 
 	while (fgets (buf, sizeof (buf) - 2, fp))
 	{
-		len = strlen (buf);
-		if (!len)
+		buf[strcspn (buf, "\r\n")] = 0;
+		if (!*buf)
 			continue;
-		buf[len] = 0;
-		buf[len-1] = 0;	/* remove the trailing \n */
 		if (net)
 		{
 			switch (buf[0])

--- a/src/common/util.c
+++ b/src/common/util.c
@@ -214,11 +214,14 @@ waitline2 (GIOChannel *source, char *buf, int bufsize)
 	gsize len;
 	GError *error = NULL;
 
+	if (g_io_channel_get_buffered (source))
+	{
+		g_io_channel_set_encoding (source, NULL, &error);
+		g_io_channel_set_buffered (source, FALSE);
+	}
+
 	while (1)
 	{
-		g_io_channel_set_buffered (source, FALSE);
-		g_io_channel_set_encoding (source, NULL, &error);
-
 		if (g_io_channel_read_chars (source, &buf[i], 1, &len, &error) != G_IO_STATUS_NORMAL)
 		{
 			return -1;


### PR DESCRIPTION
The call to g_io_channel_set_buffered with encoding not being NULL was failing and producing lots of error messages in hexchat-text. Btw, I'm not sure if we really need unbuffered i/o here and reads byte by byte. But, well... it works.

The other commit just skips \r when reading the server list file (and also the startup.txt). Other files are not created with fwrite and shouldn't have this issue unless the user edits them manually.