### PR TITLE
Fix UB (dangling pointer usage)

### DIFF
--- a/src/common/hexchat.c
+++ b/src/common/hexchat.c
@@ -191,7 +191,7 @@ lastact_getfirst(int (*filter) (session *sess))
 int
 is_session (session * sess)
 {
-	return g_slist_find (sess_list, sess) ? 1 : 0;
+	return sess != NULL && (g_slist_find (sess_list, sess) ? 1 : 0);
 }
 
 session *


### PR DESCRIPTION
Using dangling pointers, even if it's just to compare them with valid
pointers (such as comparing them with the ones in sess_list), is UB.

This fixes that.

Oh yeah and btw this is completely untested, but it didn't have any compile warnings or errors so I assume it's good, right?