### PR TITLE
Apply font changes to server list

### DIFF
--- a/src/fe-gtk/chanview-tree.c
+++ b/src/fe-gtk/chanview-tree.c
@@ -153,7 +153,6 @@ cv_tree_init (chanview *cv)
 	renderer = gtk_cell_renderer_text_new ();
 	if (prefs.hex_gui_compact)
 		g_object_set (G_OBJECT (renderer), "ypad", 0, NULL);
-	gtk_cell_renderer_text_set_fixed_height_from_font (GTK_CELL_RENDERER_TEXT (renderer), 1);
 	gtk_tree_view_column_pack_start(col, renderer, TRUE);
 	gtk_tree_view_column_set_attributes (col, renderer, "text", COL_NAME, "attributes", COL_ATTR, NULL);
 	gtk_tree_view_append_column(GTK_TREE_VIEW(view), col);									
@@ -393,4 +392,15 @@ cv_tree_is_collapsed (chan *ch)
 	gtk_tree_path_free (path);
 	
 	return ret;
+}
+
+static void
+cv_tree_queue_draw (chanview *cv)
+{
+	/* assign the model again to cause the tree view to be redrawn
+	   note: Simply using gtk_widget_queue_draw() is not sufficient. */
+	GtkTreeView *tree_view = ((treeview *)cv)->tree;
+	GtkTreeModel *model = gtk_tree_view_get_model(tree_view);
+	gtk_tree_view_set_model(tree_view, NULL);
+	gtk_tree_view_set_model(tree_view, model);
 }

--- a/src/fe-gtk/chanview.c
+++ b/src/fe-gtk/chanview.c
@@ -69,6 +69,7 @@ struct _chanview
 	gboolean (*func_is_collapsed) (chan *);
 	chan *(*func_get_parent) (chan *);
 	void (*func_cleanup) (chanview *);
+	void (*func_queue_draw) (chanview *);
 
 	unsigned int sorted:1;
 	unsigned int vertical:1;
@@ -192,6 +193,7 @@ chanview_set_impl (chanview *cv, int type)
 		cv->func_is_collapsed = cv_tabs_is_collapsed;
 		cv->func_get_parent = cv_tabs_get_parent;
 		cv->func_cleanup = cv_tabs_cleanup;
+		cv->func_queue_draw = NULL;
 		break;
 
 	default:
@@ -209,6 +211,7 @@ chanview_set_impl (chanview *cv, int type)
 		cv->func_is_collapsed = cv_tree_is_collapsed;
 		cv->func_get_parent = cv_tree_get_parent;
 		cv->func_cleanup = cv_tree_cleanup;
+		cv->func_queue_draw = cv_tree_queue_draw;
 		break;
 	}
 
@@ -437,6 +440,16 @@ chanview_set_orientation (chanview *cv, gboolean vertical)
 		cv->vertical = vertical;
 		cv->func_change_orientation (cv);
 	}
+}
+
+void
+chanview_queue_draw (chanview *cv)
+{
+	if (!cv->func_queue_draw) {
+		return;
+	}
+	cv->func_queue_draw (cv);
+	cv->func_postinit (cv);
 }
 
 int

--- a/src/fe-gtk/chanview.h
+++ b/src/fe-gtk/chanview.h
@@ -36,6 +36,7 @@ GtkWidget *chanview_get_box (chanview *cv);
 void chanview_move_focus (chanview *cv, gboolean relative, int num);
 GtkOrientation chanview_get_orientation (chanview *cv);
 void chanview_set_orientation (chanview *cv, gboolean vertical);
+void chanview_queue_draw (chanview *cv);
 
 int chan_get_tag (chan *ch);
 void *chan_get_userdata (chan *ch);

--- a/src/fe-gtk/maingui.c
+++ b/src/fe-gtk/maingui.c
@@ -3312,6 +3312,8 @@ mg_apply_setup (void)
 			mg_place_userlist_and_chanview (sess->gui);
 		if (sess->gui->is_tab)
 			done_main = TRUE;
+		/* redraw the chanview to prevent visual glitches due to font changes */
+		chanview_queue_draw(sess->gui->chanview);
 		list = list->next;
 	}
 }


### PR DESCRIPTION
* Prevent use of inflexible
  gtk_cell_renderer_text_set_fixed_height_from_font()
  (performance with lots of servers still seems good)
* Redraw server list when applying setup

See https://github.com/hexchat/hexchat/issues/2023

---

I'm aware this fixes only one of the lists in the issue. But I would like to wait for feedback first because it is my first time working GTK.