### PR TITLE
servlist: add hackint irc network

### DIFF
--- a/src/common/servlist.c
+++ b/src/common/servlist.c
@@ -193,6 +193,11 @@ static const struct defaultserver def[] =
 #endif
 	{0,			"irc.globalgamers.net"},
 
+#ifdef USE_OPENSSL
+	{"hackint", 0, 0, 0, LOGIN_SASL, 0, TRUE},
+	{0,			"irc.hackint.org"},
+#endif
+
 	{"Hashmark",	0},
 	{0,			"irc.hashmark.net"},
 


### PR DESCRIPTION
- requires the use of TLS to connect on port 6697
- supports and encourages authentication via SASL PLAIN and EXTERNAL

Certificates used are signed by Let's Encrypt.