### PR TITLE
Bump minimum Meson version to 0.46

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('hexchat', 'c',
   version: '2.14.2',
-  meson_version: '>= 0.40.0',
+  meson_version: '>= 0.46.0',
   default_options: [
     'c_std=gnu89',
     'buildtype=debugoptimized',


### PR DESCRIPTION
Solves the following warning when calling `meson`:
```
WARNING: Project specifies a minimum meson_version '>= 0.40.0' but uses features which were added in newer versions:
 * 0.46.0: {'compiler.has_link_argument', 'compiler.has_multi_link_argument'}
```