### PR TITLE
Ignore update/upgrade build directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /build
+/update
+/upgrade
 builddir/
 doxygen*.tmp
 html/


### PR DESCRIPTION
The standard build process generates these directories, so add them to `.gitignore`.