### PR TITLE
made sure to set sys.argv if it is not set. fixes #2282

### DIFF
--- a/plugins/python/python.py
+++ b/plugins/python/python.py
@@ -10,6 +10,9 @@ import traceback
 import weakref
 from _hexchat_embedded import ffi, lib
 
+if not hasattr(sys, 'argv'):
+    sys.argv = ['<hexchat>']
+
 VERSION = b'2.0'  # Sync with hexchat.__version__
 PLUGIN_NAME = ffi.new('char[]', b'Python')
 PLUGIN_DESC = ffi.new('char[]', b'Python %d.%d scripting interface'


### PR DESCRIPTION
Name set to match [old behavior](https://github.com/hexchat/hexchat/blob/02c92599faa8adbe8710177f943c3ca3cb4a65d9/plugins/python/python.c#L2693)