### PR TITLE
Make sure `help()` doesn't cause hexchat to hang

### DIFF
--- a/plugins/python/python.py
+++ b/plugins/python/python.py
@@ -9,7 +9,11 @@ import signal
 import site
 import traceback
 import weakref
-from io import StringIO
+
+if sys.version_info < (3, 0):
+    from io import BytesIO as HelpEater
+else:
+    from io import StringIO as HelpEater
 
 from _hexchat_embedded import ffi, lib
 
@@ -476,7 +480,7 @@ def _on_plugin_init(plugin_name, plugin_desc, plugin_version, arg, libdir):
     hexchat_stdout = Stdout()
     sys.stdout = hexchat_stdout
     sys.stderr = hexchat_stdout
-    pydoc.help = pydoc.Helper(StringIO(), StringIO())
+    pydoc.help = pydoc.Helper(HelpEater(), HelpEater())
 
     lib.hexchat_hook_command(lib.ph, b'', 0, lib._on_say_command, ffi.NULL, ffi.NULL)
     lib.hexchat_hook_command(lib.ph, b'LOAD', 0, lib._on_load_command, ffi.NULL, ffi.NULL)

--- a/plugins/python/python.py
+++ b/plugins/python/python.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import os
+import pydoc
 import sys
 from contextlib import contextmanager
 import importlib
@@ -8,6 +9,8 @@ import signal
 import site
 import traceback
 import weakref
+from io import StringIO
+
 from _hexchat_embedded import ffi, lib
 
 if not hasattr(sys, 'argv'):
@@ -57,7 +60,6 @@ class Stdout:
             self.buffer += string
 
     def isatty(self):
-        # FIXME: help() locks app despite this?
         return False
 
 
@@ -474,6 +476,7 @@ def _on_plugin_init(plugin_name, plugin_desc, plugin_version, arg, libdir):
     hexchat_stdout = Stdout()
     sys.stdout = hexchat_stdout
     sys.stderr = hexchat_stdout
+    pydoc.help = pydoc.Helper(StringIO(), StringIO())
 
     lib.hexchat_hook_command(lib.ph, b'', 0, lib._on_say_command, ffi.NULL, ffi.NULL)
     lib.hexchat_hook_command(lib.ph, b'LOAD', 0, lib._on_load_command, ffi.NULL, ffi.NULL)
@@ -505,6 +508,7 @@ def _on_plugin_deinit():
     hexchat_stdout = None
     sys.stdout = sys.__stdout__
     sys.stderr = sys.__stderr__
+    pydoc.help = pydoc.Helper()
 
     for mod in ('_hexchat', 'hexchat', 'xchat', '_hexchat_embedded'):
         try:


### PR DESCRIPTION
Replace `pydoc.help` with a copy of `pydoc.Helper` with an empty
`StringIO` instead of stdin