### PR TITLE
Remove colon from trailing parameters

### DIFF
--- a/src/common/proto-irc.c
+++ b/src/common/proto-irc.c
@@ -1557,6 +1557,27 @@ irc_inline (server *serv, char *buf, int len)
 
 	/* split line into words and words_to_end_of_line */
 	process_data_init (pdibuf, buf, word, word_eol, FALSE, FALSE);
+	// Ignore the prefix
+	char **trail = word_eol + 1;
+
+	// Iterate until the next element is NULL or {0, }
+	while (*trail && (*trail)[0] && (*trail)[0] != ':')
+		trail++;
+
+	if (*trail && (*trail)[0] == ':')
+		// Move the trail forward one character
+		(*trail)++;
+
+	// Ignore the prefix
+	trail = word + 1;
+
+	// Iterate until the next element is NULL or {0, }
+	while (*(trail + 1) && (*(trail + 1))[0])
+		trail++;
+
+	if (*trail && (*trail)[0] == ':')
+		// Move the trail
+		(*trail)++;
 
 	if (buf[0] == ':')
 	{


### PR DESCRIPTION
Make sure trailing parameters are treated the same as other parameters
to avoid issues like #2271

Fixes #2271 

This is not the cleanest fix in the world, but based on my (albeit limited) testing it fixes the issue and doesn't seem to introduce more.