### PR TITLE
Remove : from various trailing parameters

### DIFF
--- a/src/common/modes.c
+++ b/src/common/modes.c
@@ -735,6 +735,8 @@ handle_mode (server * serv, char *word[], char *word_eol[],
 		if (!(*word[i + offset]))
 			break;
 		num_args++;
+		if (word[i + offset][0] == ':')
+			break;
 	}
 
 	/* count the number of modes (without the -/+ chars */

--- a/src/common/modes.c
+++ b/src/common/modes.c
@@ -767,7 +767,7 @@ handle_mode (server * serv, char *word[], char *word_eol[],
 				arg++;
 				// is this the last argument?
 				if (arg == num_args + 1)
-					argstr = STRIP_COLON(word[arg + offset]);
+					argstr = STRIP_COLON(word, word_eol, arg+offset);
 				else
 					argstr = word[arg + offset];
 			}

--- a/src/common/modes.c
+++ b/src/common/modes.c
@@ -767,11 +767,7 @@ handle_mode (server * serv, char *word[], char *word_eol[],
 			if ((all_modes_have_args || mode_has_arg (serv, sign, *modes)) && arg < (num_args + 1))
 			{
 				arg++;
-				// is this the last argument?
-				if (arg == num_args + 1)
-					argstr = STRIP_COLON(word, word_eol, arg+offset);
-				else
-					argstr = word[arg + offset];
+				argstr = STRIP_COLON(word, word_eol, arg+offset);
 			}
 			handle_single_mode (&mr, sign, *modes, nick, chan,
 									  argstr, numeric_324 || prefs.hex_irc_raw_modes,

--- a/src/common/modes.c
+++ b/src/common/modes.c
@@ -765,7 +765,11 @@ handle_mode (server * serv, char *word[], char *word_eol[],
 			if ((all_modes_have_args || mode_has_arg (serv, sign, *modes)) && arg < (num_args + 1))
 			{
 				arg++;
-				argstr = word[arg + offset];
+				// is this the last argument?
+				if (arg == num_args + 1)
+					argstr = STRIP_COLON(word[arg + offset]);
+				else
+					argstr = word[arg + offset];
 			}
 			handle_single_mode (&mr, sign, *modes, nick, chan,
 									  argstr, numeric_324 || prefs.hex_irc_raw_modes,

--- a/src/common/proto-irc.c
+++ b/src/common/proto-irc.c
@@ -714,7 +714,7 @@ process_numeric (session * sess, int n,
 		break;
 
 	case 333:
-		inbound_topictime (serv, word[4], word[5], atol (word[6]), tags_data);
+		inbound_topictime (serv, word[4], word[5], atol (STRIP_COLON(word[6])), tags_data);
 		break;
 
 #if 0
@@ -726,7 +726,7 @@ process_numeric (session * sess, int n,
 #endif
 
 	case 341:						  /* INVITE ACK */
-		EMIT_SIGNAL_TIMESTAMP (XP_TE_UINVITE, sess, word[4], word[5],
+		EMIT_SIGNAL_TIMESTAMP (XP_TE_UINVITE, sess, word[4], STRIP_COLON(word[5]),
 									  serv->servername, NULL, 0, tags_data->timestamp);
 		break;
 
@@ -1142,7 +1142,7 @@ process_named_msg (session *sess, char *type, char *word[], char *word_eol[],
 		{
 
 		case WORDL('A','C','C','O'):
-			inbound_account (serv, nick, word[3], tags_data);
+			inbound_account (serv, nick, STRIP_COLON(word[3]), tags_data);
 			return;
 
 		case WORDL('A', 'U', 'T', 'H'):
@@ -1150,7 +1150,7 @@ process_named_msg (session *sess, char *type, char *word[], char *word_eol[],
 			return;
 
 		case WORDL('C', 'H', 'G', 'H'):
-			inbound_user_info (sess, NULL, word[3], word[4], NULL, nick, NULL,
+			inbound_user_info (sess, NULL, word[3], STRIP_COLON(word[4]), NULL, nick, NULL,
 							   NULL, 0xff, tags_data);
 			return;
 

--- a/src/common/proto-irc.c
+++ b/src/common/proto-irc.c
@@ -714,7 +714,7 @@ process_numeric (session * sess, int n,
 		break;
 
 	case 333:
-		inbound_topictime (serv, word[4], word[5], atol (STRIP_COLON(word[6])), tags_data);
+		inbound_topictime (serv, word[4], word[5], atol (STRIP_COLON(word, word_eol, 6)), tags_data);
 		break;
 
 #if 0
@@ -726,7 +726,7 @@ process_numeric (session * sess, int n,
 #endif
 
 	case 341:						  /* INVITE ACK */
-		EMIT_SIGNAL_TIMESTAMP (XP_TE_UINVITE, sess, word[4], STRIP_COLON(word[5]),
+		EMIT_SIGNAL_TIMESTAMP (XP_TE_UINVITE, sess, word[4], STRIP_COLON(word, word_eol, 5),
 									  serv->servername, NULL, 0, tags_data->timestamp);
 		break;
 
@@ -1142,7 +1142,7 @@ process_named_msg (session *sess, char *type, char *word[], char *word_eol[],
 		{
 
 		case WORDL('A','C','C','O'):
-			inbound_account (serv, nick, STRIP_COLON(word[3]), tags_data);
+			inbound_account (serv, nick, STRIP_COLON(word, word_eol, 3), tags_data);
 			return;
 
 		case WORDL('A', 'U', 'T', 'H'):
@@ -1150,7 +1150,7 @@ process_named_msg (session *sess, char *type, char *word[], char *word_eol[],
 			return;
 
 		case WORDL('C', 'H', 'G', 'H'):
-			inbound_user_info (sess, NULL, word[3], STRIP_COLON(word[4]), NULL, nick, NULL,
+			inbound_user_info (sess, NULL, word[3], STRIP_COLON(word, word_eol, 4), NULL, nick, NULL,
 							   NULL, 0xff, tags_data);
 			return;
 

--- a/src/common/proto-irc.h
+++ b/src/common/proto-irc.h
@@ -28,6 +28,8 @@
 		(time_t)0, /* timestamp */		\
 	}
 
+#define STRIP_COLON(s) (s)[0] == ':' ? (s)+1 : (s)
+
 /* Message tag information that might be passed along with a server message
  *
  * See http://ircv3.atheme.org/specification/capability-negotiation-3.1

--- a/src/common/proto-irc.h
+++ b/src/common/proto-irc.h
@@ -28,7 +28,7 @@
 		(time_t)0, /* timestamp */		\
 	}
 
-#define STRIP_COLON(s) (s)[0] == ':' ? (s)+1 : (s)
+#define STRIP_COLON(word, word_eol, idx) (word)[(idx)][0] == ':' ? (word_eol)[(idx)]+1 : (word)[(idx)]
 
 /* Message tag information that might be passed along with a server message
  *


### PR DESCRIPTION
Partial fix for #2271 

This isn't an exhaustive list, but it's everything I could find. The bug still exists in the parser though, this is just a workaround for the moment