### PR TITLE
Detect hilights in NOTICEs

### DIFF
--- a/src/common/inbound.c
+++ b/src/common/inbound.c
@@ -935,6 +935,7 @@ inbound_notice (server *serv, char *to, char *nick, char *msg, char *ip, int id,
 	char *ptr = to;
 	session *sess = 0;
 	int server_notice = FALSE;
+	int hilight = FALSE;
 
 	if (is_channel (serv, ptr))
 		sess = find_channel (serv, ptr);
@@ -1021,8 +1022,14 @@ inbound_notice (server *serv, char *to, char *nick, char *msg, char *ip, int id,
 			msg[len - 1] = '\000';
 	}
 
+	if (is_hilight (nick, msg, sess, serv))
+		hilight = TRUE;
+
 	if (server_notice)
 		EMIT_SIGNAL_TIMESTAMP (XP_TE_SERVNOTICE, sess, msg, nick, NULL, NULL, 0,
+									  tags_data->timestamp);
+	else if (hilight)
+		EMIT_SIGNAL_TIMESTAMP (XP_TE_HCHANNOTICE, sess, nick, to, msg, NULL, 0,
 									  tags_data->timestamp);
 	else if (ptr)
 		EMIT_SIGNAL_TIMESTAMP (XP_TE_CHANNOTICE, sess, nick, to, msg, NULL, 0,

--- a/src/common/text.c
+++ b/src/common/text.c
@@ -2083,6 +2083,7 @@ text_emit (int index, session *sess, char *a, char *b, char *c, char *d,
 	/* ===Highlighted message=== */
 	case XP_TE_HCHANACTION:
 	case XP_TE_HCHANMSG:
+	case XP_TE_HCHANNOTICE:
 		if (chanopt_is_set (prefs.hex_input_beep_hilight, sess->alert_beep) && (!prefs.hex_away_omit_alerts || !sess->server->is_away))
 			sound_beep (sess);
 		if (chanopt_is_set (prefs.hex_input_flash_hilight, sess->alert_taskbar) && (!prefs.hex_away_omit_alerts || !sess->server->is_away))

--- a/src/common/textevents.in
+++ b/src/common/textevents.in
@@ -148,6 +148,12 @@ pevt_channotice_help
 -%C18$1%C/%C22$2%C-$t$3%O
 n3
 
+Channel Notice Hilight
+XP_TE_HCHANNOTICE
+pevt_channotice_help
+%C19-%B$1%B/$2-$t$3%O
+n3
+
 Channel Operator
 XP_TE_CHANOP
 pevt_chanop_help

--- a/src/fe-gtk/plugin-notification.c
+++ b/src/fe-gtk/plugin-notification.c
@@ -192,6 +192,7 @@ notification_plugin_init (hexchat_plugin *plugin_handle, char **plugin_name, cha
 
 	hexchat_hook_print (ph, "Channel Msg Hilight", HEXCHAT_PRI_LOWEST, incoming_hilight_cb, NULL);
 	hexchat_hook_print (ph, "Channel Action Hilight", HEXCHAT_PRI_LOWEST, incoming_hilight_cb, NULL);
+	hexchat_hook_print (ph, "Channel Notice Hilight", HEXCHAT_PRI_LOWEST, incoming_hilight_cb, NULL);
 
 	hexchat_hook_print (ph, "Channel Message", HEXCHAT_PRI_LOWEST, incoming_message_cb, NULL);
 	hexchat_hook_print (ph, "Channel Action", HEXCHAT_PRI_LOWEST, incoming_message_cb, NULL);

--- a/src/fe-gtk/plugin-tray.c
+++ b/src/fe-gtk/plugin-tray.c
@@ -783,6 +783,7 @@ tray_plugin_init (hexchat_plugin *plugin_handle, char **plugin_name,
 
 	hexchat_hook_print (ph, "Channel Msg Hilight", -1, tray_hilight_cb, NULL);
 	hexchat_hook_print (ph, "Channel Action Hilight", -1, tray_hilight_cb, NULL);
+	hexchat_hook_print (ph, "Channel Notice Hilight", -1, tray_hilight_cb, NULL);
 
 	hexchat_hook_print (ph, "Channel Message", -1, tray_message_cb, NULL);
 	hexchat_hook_print (ph, "Channel Action", -1, tray_message_cb, NULL);


### PR DESCRIPTION
Sorry for the noise — slight git mishap caused GitHub to close my previous PR.

When someone is mentioned in a channel notice, the tray and notification plugins now treat it the same as a regular channel message. 