### PR TITLE
Update servlist.c - Fixes #2324

### DIFF
--- a/src/common/servlist.c
+++ b/src/common/servlist.c
@@ -166,9 +166,6 @@ static const struct defaultserver def[] =
 	/* irc. points to chat. but many users and urls still reference it */
 	{0,				"irc.freenode.net"},
 
-	{"Furnet", 0, 0, 0, 0, 0, TRUE},
-	{0,			"irc.furnet.org"},
-
 	{"GalaxyNet",	0},
 	{0,			"irc.galaxynet.org"},
 


### PR DESCRIPTION
Update to servlist.c, removes 3 lines for furnet; fixes #2324 