### PR TITLE
Make dcc_ip being a per-server value.

### DIFF
--- a/src/common/dcc.c
+++ b/src/common/dcc.c
@@ -1618,13 +1618,13 @@ dcc_accept (GIOChannel *source, GIOCondition condition, struct DCC *dcc)
 }
 
 guint32
-dcc_get_my_address (void)	/* the address we'll tell the other person */
+dcc_get_my_address (session *sess)	/* the address we'll tell the other person */
 {
 	struct hostent *dns_query;
 	guint32 addr = 0;
 
-	if (prefs.hex_dcc_ip_from_server && prefs.dcc_ip)
-		addr = prefs.dcc_ip;
+	if (prefs.hex_dcc_ip_from_server && sess->server->dcc_ip)
+		addr = sess->server->dcc_ip;
 	else if (prefs.hex_dcc_ip[0])
 	{
 	   dns_query = gethostbyname ((const char *) prefs.hex_dcc_ip);
@@ -1710,7 +1710,7 @@ dcc_listen_init (struct DCC *dcc, session *sess)
 	/*if we have a dcc_ip, we use that, so the remote client can connect*/
 	/*else we try to take an address from hex_dcc_ip*/
 	/*if something goes wrong we tell the client to connect to our LAN ip*/
-	dcc->addr = dcc_get_my_address ();
+	dcc->addr = dcc_get_my_address (sess);
 
 	/*if nothing else worked we use the address we bound to*/
 	if (dcc->addr == 0)

--- a/src/common/dcc.h
+++ b/src/common/dcc.h
@@ -124,7 +124,7 @@ void dcc_chat (session *sess, char *nick, int passive);
 void handle_dcc (session *sess, char *nick, char *word[], char *word_eol[],
 					  const message_tags_data *tags_data);
 void dcc_show_list (session *sess);
-guint32 dcc_get_my_address (void);
+guint32 dcc_get_my_address (session *sess);
 void dcc_get_with_destfile (struct DCC *dcc, char *utf8file);
 
 #endif

--- a/src/common/hexchat.h
+++ b/src/common/hexchat.h
@@ -313,7 +313,6 @@ struct hexchatprefs
 
 	/* these are the private variables */
 	guint32 local_ip;
-	guint32 dcc_ip;
 
 	unsigned int wait_on_exit;	/* wait for logs to be flushed to disk IF we're connected */
 
@@ -482,6 +481,10 @@ typedef struct server
 	int proxy_sok4;
 	int proxy_sok6;
 	int id;					/* unique ID number (for plugin API) */
+
+	/* dcc_ip moved from haxchatprefs to make it per-server */
+	guint32 dcc_ip;
+
 #ifdef USE_OPENSSL
 	SSL_CTX *ctx;
 	SSL *ssl;

--- a/src/common/hexchat.h
+++ b/src/common/hexchat.h
@@ -482,7 +482,7 @@ typedef struct server
 	int proxy_sok6;
 	int id;					/* unique ID number (for plugin API) */
 
-	/* dcc_ip moved from haxchatprefs to make it per-server */
+	/* dcc_ip moved from hexchatprefs to make it per-server */
 	guint32 dcc_ip;
 
 #ifdef USE_OPENSSL

--- a/src/common/inbound.c
+++ b/src/common/inbound.c
@@ -1420,7 +1420,7 @@ inbound_foundip (session *sess, char *ip, const message_tags_data *tags_data)
 	HostAddr = gethostbyname (ip);
 	if (HostAddr)
 	{
-		prefs.dcc_ip = ((struct in_addr *) HostAddr->h_addr)->s_addr;
+		sess->server->dcc_ip = ((struct in_addr *) HostAddr->h_addr)->s_addr;
 		EMIT_SIGNAL_TIMESTAMP (XP_TE_FOUNDIP, sess->server->server_session,
 									  inet_ntoa (*((struct in_addr *) HostAddr->h_addr)),
 									  NULL, NULL, NULL, 0, tags_data->timestamp);

--- a/src/common/outbound.c
+++ b/src/common/outbound.c
@@ -3287,7 +3287,7 @@ cmd_send (struct session *sess, char *tbuf, char *word[], char *word_eol[])
 	if (!word[2][0])
 		return FALSE;
 
-	addr = dcc_get_my_address ();
+	addr = dcc_get_my_address (sess);
 	if (addr == 0)
 	{
 		/* use the one from our connected server socket */


### PR DESCRIPTION
Moved dcc_ip from prefs to sess->server.

Currently the DCC IP address is a global setting in Preferences. It can be set globally, and optionally, the IP address can be acquired from the IRC server. Currently only a single IP address can be stored, the last detected IP address wins.

When using multiple IRC servers or networks from which at least one is available via VPN while the other use Internet, only the last detected IP address is stored, causing DCC not working with autodetected IP address on the first-connected IRC server or network.

This change makes dcc_ip a server property, allowing per-server record of the detected address. Very useful when both "VPN" and "Internet" connections use dynamic addresses.

The global setting still overrides it, if set. 
