### PR TITLE
Implement SASL setting that uses nick as username

### DIFF
--- a/src/common/inbound.c
+++ b/src/common/inbound.c
@@ -1805,7 +1805,8 @@ inbound_cap_ls (server *serv, char *nick, char *extensions_str,
 
 		/* if the SASL password is set AND auth mode is set to SASL, request SASL auth */
 		if (!g_strcmp0 (extension, "sasl") &&
-			((serv->loginmethod == LOGIN_SASL && strlen (serv->password) != 0)
+			(((serv->loginmethod == LOGIN_SASL || serv->loginmethod == LOGIN_SASL_NICK)
+                    && strlen (serv->password) != 0)
 				|| (serv->loginmethod == LOGIN_SASLEXTERNAL && serv->have_cert)))
 		{
 			if (value)
@@ -1889,6 +1890,13 @@ inbound_sasl_authenticate (server *serv, char *data)
 			user = net->user;
 		else
 			user = prefs.hex_irc_user_name;
+
+		if (serv->loginmethod == LOGIN_SASL_NICK) {
+			if (net->user && !(net->flags & FLAG_USE_GLOBAL))
+				user = net->nick;
+			else
+			user = prefs.hex_irc_nick1;
+		}
 
 		switch (serv->sasl_mech)
 		{

--- a/src/common/servlist.c
+++ b/src/common/servlist.c
@@ -161,7 +161,7 @@ static const struct defaultserver def[] =
 	/* Self signed */
 	{0,			"irc.fdfnet.net"},
 
-	{"freenode", 0, 0, 0, LOGIN_SASL, 0, TRUE},
+	{"freenode", 0, 0, 0, LOGIN_SASL_NICK, 0, TRUE},
 	{0,				"chat.freenode.net"},
 	/* irc. points to chat. but many users and urls still reference it */
 	{0,				"irc.freenode.net"},

--- a/src/common/servlist.h
+++ b/src/common/servlist.h
@@ -75,6 +75,7 @@ extern GSList *network_list;
 #define LOGIN_AUTH				5
 #endif
 #define LOGIN_SASL				6
+#define LOGIN_SASL_NICK			11
 #define LOGIN_PASS				7
 #define LOGIN_CHALLENGEAUTH		8
 #define LOGIN_CUSTOM			9

--- a/src/fe-gtk/servlistgui.c
+++ b/src/fe-gtk/servlistgui.c
@@ -120,6 +120,7 @@ static int login_types_conf[] =
 {
 	LOGIN_DEFAULT,			/* default entry - we don't use this but it makes indexing consistent with login_types[] so it's nice */
 	LOGIN_SASL,
+	LOGIN_SASL_NICK,
 #ifdef USE_OPENSSL
 	LOGIN_SASLEXTERNAL,
 #endif
@@ -141,6 +142,7 @@ static const char *login_types[]=
 {
 	"Default",
 	"SASL (username + password)",
+	"SASL (nick + password)",
 #ifdef USE_OPENSSL
 	"SASL EXTERNAL (cert)",
 #endif


### PR DESCRIPTION
Just like https://github.com/hexchat/hexchat/issues/569#issuecomment-300791905 suggested.

Partially addresses #569.

This new mode is automatically enabled for Freenode by default.