### PR TITLE
FiSHLiM: Support for CBC mode + more commands

### DIFF
--- a/plugins/fishlim/base64.c
+++ b/plugins/fishlim/base64.c
@@ -48,7 +48,7 @@ size_t calcDecodeLength(const char *b64input) { //Calculates the length of a dec
     return (len * 3) / 4 - padding;
 }
 
-int base64_encode(const unsigned char *buffer, size_t length, char **b64text) { //Encodes a binary safe base 64 string
+int openssl_base64_encode(const unsigned char *buffer, size_t length, char **b64text) { //Encodes a binary safe base 64 string
     BIO *bio, *b64;
     BUF_MEM *bufferPtr;
 
@@ -70,7 +70,7 @@ int base64_encode(const unsigned char *buffer, size_t length, char **b64text) { 
     return (0); //success
 }
 
-int base64_decode(const char *b64message, unsigned char **buffer, size_t *length) { //Decodes a base64 encoded string
+int openssl_base64_decode(const char *b64message, unsigned char **buffer, size_t *length) { //Decodes a base64 encoded string
     BIO *bio = NULL, *b64 = NULL;
     int decodeLen = 0;
 

--- a/plugins/fishlim/base64.c
+++ b/plugins/fishlim/base64.c
@@ -1,0 +1,103 @@
+/*
+
+  MIT License
+
+  Copyright (c) 2013 Barry Steyn
+  Copyright (c) 2019 <bakasura@protonmail.ch>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+
+*/
+
+#include "base64.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <openssl/bio.h>
+#include <openssl/evp.h>
+#include <openssl/buffer.h>
+#include <stdint.h>
+
+static const char base64_chars[65] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+
+size_t calcDecodeLength(const char *b64input) { //Calculates the length of a decoded string
+    size_t len = strlen(b64input),
+            padding = 0;
+
+    if (b64input[len - 1] == '=' && b64input[len - 2] == '=') //last two chars are =
+        padding = 2;
+    else if (b64input[len - 1] == '=') //last char is =
+        padding = 1;
+
+    return (len * 3) / 4 - padding;
+}
+
+int base64_encode(const unsigned char *buffer, size_t length, char **b64text) { //Encodes a binary safe base 64 string
+    BIO *bio, *b64;
+    BUF_MEM *bufferPtr;
+
+    b64 = BIO_new(BIO_f_base64());
+    bio = BIO_new(BIO_s_mem());
+    bio = BIO_push(b64, bio);
+
+    BIO_set_flags(bio, BIO_FLAGS_BASE64_NO_NL); //Ignore newlines - write everything in one line
+    BIO_set_close(bio, BIO_CLOSE);
+    BIO_write(bio, buffer, length);
+    BIO_flush(bio);
+    BIO_get_mem_ptr(bio, &bufferPtr);
+
+    *b64text = (char *) g_malloc0((*bufferPtr).length + 1);
+    memcpy(*b64text, (*bufferPtr).data, (*bufferPtr).length);
+
+    BIO_free_all(bio);
+
+    return (0); //success
+}
+
+int base64_decode(const char *b64message, unsigned char **buffer, size_t *length) { //Decodes a base64 encoded string
+    BIO *bio = NULL, *b64 = NULL;
+    int decodeLen = 0;
+
+    if (strspn(b64message, base64_chars) != strlen(b64message))
+        return -1;
+
+    decodeLen = calcDecodeLength(b64message);
+
+    if (decodeLen == 0)
+        return -1;
+
+    *buffer = (unsigned char *) malloc(decodeLen + 1);
+    (*buffer)[decodeLen] = '\0';
+
+    bio = BIO_new_mem_buf(b64message, -1);
+    b64 = BIO_new(BIO_f_base64());
+    bio = BIO_push(b64, bio);
+
+    BIO_set_flags(bio, BIO_FLAGS_BASE64_NO_NL); //Do not use newlines to flush buffer
+    *length = BIO_read(bio, *buffer, strlen(b64message));
+    BIO_free_all(bio);
+
+    if (*length == decodeLen) {
+        return 0;
+    } else {
+        *length = 0;
+        free(*buffer);
+        return -1;
+    }
+}

--- a/plugins/fishlim/base64.h
+++ b/plugins/fishlim/base64.h
@@ -30,7 +30,7 @@
 
 #include <glib.h>
 
-int base64_encode(const unsigned char *buffer, size_t length, char **b64text);
-int base64_decode(const char *b64message, unsigned char **buffer, size_t *length);
+int openssl_base64_encode(const unsigned char *buffer, size_t length, char **b64text);
+int openssl_base64_decode(const char *b64message, unsigned char **buffer, size_t *length);
 
 #endif //BASE64_H

--- a/plugins/fishlim/base64.h
+++ b/plugins/fishlim/base64.h
@@ -1,6 +1,8 @@
 /*
 
-  Copyright (c) 2010 Samuel Lidén Borell <samuel@kodafritt.se>
+  MIT License
+
+  Copyright (c) 2013 Barry Steyn
   Copyright (c) 2019 <bakasura@protonmail.ch>
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -10,34 +12,25 @@
   copies of the Software, and to permit persons to whom the Software is
   furnished to do so, subject to the following conditions:
 
-  The above copyright notice and this permission notice shall be included in
-  all copies or substantial portions of the Software.
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
 
   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-  THE SOFTWARE.
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
 
 */
 
-#ifndef FISH_H
-#define FISH_H
-
-#include <stddef.h>
+#ifndef BASE64_H
+#define BASE64_H
 
 #include <glib.h>
 
-# define FISH_ECB_MODE 0x1
-# define FISH_CBC_MODE 0x2
+int base64_encode(const unsigned char *buffer, size_t length, char **b64text);
+int base64_decode(const char *b64message, unsigned char **buffer, size_t *length);
 
-char *fish_encrypt(const char *key, size_t keylen, const char *message, size_t message_len, int mode);
-char *fish_decrypt(const char *key, size_t keylen, const char *data, int mode);
-char *fish_encrypt_for_nick(const char *nick, const char *data);
-char *fish_decrypt_from_nick(const char *nick, const char *data);
-
-#endif
-
-
+#endif //BASE64_H

--- a/plugins/fishlim/fish.c
+++ b/plugins/fishlim/fish.c
@@ -284,7 +284,7 @@ char *fish_encrypt(const char *key, size_t keylen, const char *message, size_t m
 
     switch (mode) {
         case FISH_CBC_MODE:
-            base64_encode((const unsigned char *) ciphertext, ciphertext_len, &b64);
+            openssl_base64_encode((const unsigned char *) ciphertext, ciphertext_len, &b64);
             break;
 
         case FISH_ECB_MODE:
@@ -310,7 +310,7 @@ char *fish_decrypt(const char *key, size_t keylen, const char *data, int mode) {
 
     switch (mode) {
         case FISH_CBC_MODE:
-            if (base64_decode(data, (unsigned char **) &ciphertext, &ciphertext_len) != 0)
+            if (openssl_base64_decode(data, (unsigned char **) &ciphertext, &ciphertext_len) != 0)
                 return NULL;
             break;
 

--- a/plugins/fishlim/fish.c
+++ b/plugins/fishlim/fish.c
@@ -77,14 +77,14 @@ static const signed char fish_unbase64[256] = {
  * @param [in] message_len  Size of bytes to encode
  * @return Array of char with encoded string
  */
-char *fish_base64_encode(const char *message, int message_len) {
+char *fish_base64_encode(const char *message, size_t message_len) {
     BF_LONG left = 0, right = 0;
     int i, j;
     char *encoded = NULL;
     char *end = NULL;
     char *msg = NULL;
 
-    if (message_len <= 0)
+    if (message_len == 0)
         return NULL;
 
     encoded = g_malloc(((message_len - 1) / 8) * 12 + 12 + 1); /* each 8-byte block becomes 12 bytes */
@@ -120,17 +120,17 @@ char *fish_base64_encode(const char *message, int message_len) {
  * @param [out] final_len  Real length of message
  * @return Array of char with decoded message
  */
-char *fish_base64_decode(const char *message, int *final_len) {
+char *fish_base64_decode(const char *message, size_t *final_len) {
     BF_LONG left, right;
     int i;
     char *bytes = NULL;
     char *msg = NULL;
     char *byt = NULL;
-    int message_len;
+    size_t message_len;
 
     message_len = strlen(message);
 
-    if (message_len <= 0 || message_len % 12 != 0)
+    if (message_len == 0 || message_len % 12 != 0 || strspn(message, fish_base64) != message_len)
         return NULL;
 
     *final_len = ((message_len - 1) / 12) * 8 + 8 + 1; /* Each 12 bytes becomes 8-byte block */
@@ -173,13 +173,13 @@ char *fish_base64_decode(const char *message, int *final_len) {
  * @param [out] ciphertext_len  The bytes writen
  * @return Array of char with data crypted or uncrypted
  */
-char *fish_cipher(const char *plaintext, int plaintext_len, const char *key, size_t keylen, int encode, int *ciphertext_len) {
+char *fish_cipher(const char *plaintext, size_t plaintext_len, const char *key, size_t keylen, int encode, size_t *ciphertext_len) {
     EVP_CIPHER_CTX *ctx;
     int bytes_written = 0;
     unsigned char *ciphertext = NULL;
-    int block_size = 0;
+    size_t block_size = 0;
 
-    if(plaintext_len <= 0 || keylen <= 0 || encode < 0 || encode > 1)
+    if(plaintext_len == 0 || keylen == 0 || encode < 0 || encode > 1)
         return NULL;
 
     /* Zero Padding */
@@ -231,16 +231,16 @@ char *fish_cipher(const char *plaintext, int plaintext_len, const char *key, siz
 
 
 char *fish_encrypt(const char *key, size_t keylen, const char *message, size_t message_len) {
-    int ciphertext_len = 0;
+    size_t ciphertext_len = 0;
     char *ciphertext = NULL;
     char *b64 = NULL;
 
-    if(keylen <= 0 || message_len <= 0)
+    if(keylen == 0 || message_len == 0)
         return NULL;
 
     ciphertext = fish_cipher(message, message_len, key, keylen, 1, &ciphertext_len);
 
-    if(ciphertext == NULL || ciphertext_len <= 0)
+    if(ciphertext == NULL || ciphertext_len == 0)
         return NULL;
 
     b64 = fish_base64_encode((const char *) ciphertext, ciphertext_len);
@@ -254,23 +254,23 @@ char *fish_encrypt(const char *key, size_t keylen, const char *message, size_t m
 
 
 char *fish_decrypt(const char *key, size_t keylen, const char *data) {
-    int ciphertext_len = 0;
+    size_t ciphertext_len = 0;
     char *ciphertext = NULL;
     char *plaintext = NULL;
     char *plaintext_str = NULL;
 
-    if(keylen <= 0 || strlen(data) <= 0)
+    if(keylen == 0 || strlen(data) == 0)
         return NULL;
 
     ciphertext = fish_base64_decode(data, &ciphertext_len);
 
-    if (ciphertext == NULL || ciphertext_len <= 0)
+    if (ciphertext == NULL || ciphertext_len == 0)
         return NULL;
 
     plaintext = fish_cipher(ciphertext, ciphertext_len, key, keylen, 0, &ciphertext_len);
     g_free(ciphertext);
 
-    if (ciphertext_len <= 0)
+    if (ciphertext_len == 0)
         return NULL;
 
     plaintext_str = g_malloc0(ciphertext_len + 1);

--- a/plugins/fishlim/fish.c
+++ b/plugins/fishlim/fish.c
@@ -84,7 +84,7 @@ char *fish_base64_encode(const char *message, int message_len) {
     char *end = NULL;
     char *msg = NULL;
 
-    if (message_len == 0)
+    if (message_len <= 0)
         return NULL;
 
     encoded = g_malloc(((message_len - 1) / 8) * 12 + 12 + 1); /* each 8-byte block becomes 12 bytes */
@@ -130,7 +130,7 @@ char *fish_base64_decode(const char *message, int *final_len) {
 
     message_len = strlen(message);
 
-    if (message_len == 0 || message_len % 12 != 0)
+    if (message_len <= 0 || message_len % 12 != 0)
         return NULL;
 
     *final_len = ((message_len - 1) / 12) * 8 + 8 + 1; /* Each 12 bytes becomes 8-byte block */

--- a/plugins/fishlim/fish.c
+++ b/plugins/fishlim/fish.c
@@ -339,7 +339,7 @@ char *fish_decrypt(const char *key, size_t keylen, const char *data, int mode) {
  * Encrypts a message (see fish_decrypt). The key is searched for in the
  * key store.
  */
-char *fish_encrypt_for_nick(const char *nick, const char *data) {
+char *fish_encrypt_for_nick(const char *nick, const char *data, int *omode) {
     char *key;
     char *encrypted, *encrypted_cbc = NULL;
     int mode;
@@ -348,6 +348,8 @@ char *fish_encrypt_for_nick(const char *nick, const char *data) {
     /* Look for key */
     key = keystore_get_key(nick, &mode);
     if (!key) return NULL;
+
+    *omode = mode;
 
     /* Encrypt */
     encrypted = fish_encrypt(key, strlen(key), data, strlen(data), mode);
@@ -372,7 +374,7 @@ char *fish_encrypt_for_nick(const char *nick, const char *data) {
  * Decrypts a message (see fish_decrypt). The key is searched for in the
  * key store.
  */
-char *fish_decrypt_from_nick(const char *nick, const char *data) {
+char *fish_decrypt_from_nick(const char *nick, const char *data, int *omode) {
     char *key;
     char *decrypted;
     int mode;
@@ -380,6 +382,8 @@ char *fish_decrypt_from_nick(const char *nick, const char *data) {
     /* Look for key */
     key = keystore_get_key(nick, &mode);
     if (!key) return NULL;
+
+    *omode = mode;
 
     if (mode == FISH_CBC_MODE)
         ++data;

--- a/plugins/fishlim/fish.c
+++ b/plugins/fishlim/fish.c
@@ -28,6 +28,7 @@
 #define DEPRECATED_IN_MAC_OS_X_VERSION_10_7_AND_LATER
 #endif
 
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <openssl/evp.h>

--- a/plugins/fishlim/fish.c
+++ b/plugins/fishlim/fish.c
@@ -1,6 +1,7 @@
 /*
 
   Copyright (c) 2010 Samuel Lidén Borell <samuel@kodafritt.se>
+  Copyright (c) 2019 <bakasura@protonmail.ch>
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/plugins/fishlim/fish.h
+++ b/plugins/fishlim/fish.h
@@ -35,8 +35,8 @@
 
 char *fish_encrypt(const char *key, size_t keylen, const char *message, size_t message_len, int mode);
 char *fish_decrypt(const char *key, size_t keylen, const char *data, int mode);
-char *fish_encrypt_for_nick(const char *nick, const char *data);
-char *fish_decrypt_from_nick(const char *nick, const char *data);
+char *fish_encrypt_for_nick(const char *nick, const char *data, int *omode);
+char *fish_decrypt_from_nick(const char *nick, const char *data, int *omode);
 
 #endif
 

--- a/plugins/fishlim/fish.h
+++ b/plugins/fishlim/fish.h
@@ -29,7 +29,7 @@
 
 #include <glib.h>
 
-char *fish_encrypt(const char *key, size_t keylen, const char *message);
+char *fish_encrypt(const char *key, size_t keylen, const char *message, size_t message_len);
 char *fish_decrypt(const char *key, size_t keylen, const char *data);
 char *fish_encrypt_for_nick(const char *nick, const char *data);
 char *fish_decrypt_from_nick(const char *nick, const char *data);

--- a/plugins/fishlim/fish.h
+++ b/plugins/fishlim/fish.h
@@ -1,6 +1,7 @@
 /*
 
   Copyright (c) 2010 Samuel Lidén Borell <samuel@kodafritt.se>
+  Copyright (c) 2019 <bakasura@protonmail.ch>
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/plugins/fishlim/fishlim.vcxproj
+++ b/plugins/fishlim/fishlim.vcxproj
@@ -62,7 +62,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dh1080.c" />
-    <ClInclude Include="base64.c" />
+    <ClCompile Include="base64.c" />
     <ClCompile Include="fish.c" />
     <ClCompile Include="irc.c" />
     <ClCompile Include="keystore.c" />

--- a/plugins/fishlim/fishlim.vcxproj
+++ b/plugins/fishlim/fishlim.vcxproj
@@ -54,6 +54,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="dh1080.h" />
+    <ClInclude Include="base64.h" />
     <ClInclude Include="fish.h" />
     <ClInclude Include="irc.h" />
     <ClInclude Include="keystore.h" />
@@ -61,6 +62,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dh1080.c" />
+    <ClInclude Include="base64.c" />
     <ClCompile Include="fish.c" />
     <ClCompile Include="irc.c" />
     <ClCompile Include="keystore.c" />

--- a/plugins/fishlim/fishlim.vcxproj.filters
+++ b/plugins/fishlim/fishlim.vcxproj.filters
@@ -23,6 +23,12 @@
     <ClInclude Include="bool.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="dh1080.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="base64.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="fish.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -37,6 +43,12 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="dh1080.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="base64.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="fish.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/plugins/fishlim/keystore.c
+++ b/plugins/fishlim/keystore.c
@@ -204,7 +204,7 @@ gboolean keystore_store_key(const char *nick, const char *key) {
     password = get_keystore_password();
     if (password) {
         /* Encrypt the password */
-        encrypted = fish_encrypt(password, strlen(password), key);
+        encrypted = fish_encrypt(password, strlen(password), key, strlen(key));
         if (!encrypted) goto end;
         
         /* Prepend "+OK " */

--- a/plugins/fishlim/keystore.c
+++ b/plugins/fishlim/keystore.c
@@ -121,7 +121,7 @@ char *keystore_get_key(const char *nick) {
         /* Key is encrypted */
         const char *encrypted = value+4;
         const char *password = get_keystore_password();
-        char *decrypted = fish_decrypt(password, strlen(password), encrypted);
+        char *decrypted = fish_decrypt(password, strlen(password), encrypted, FISH_ECB_MODE);
         g_free(value);
         return decrypted;
     }
@@ -204,7 +204,7 @@ gboolean keystore_store_key(const char *nick, const char *key) {
     password = get_keystore_password();
     if (password) {
         /* Encrypt the password */
-        encrypted = fish_encrypt(password, strlen(password), key, strlen(key));
+        encrypted = fish_encrypt(password, strlen(password), key, strlen(key), FISH_ECB_MODE);
         if (!encrypted) goto end;
         
         /* Prepend "+OK " */

--- a/plugins/fishlim/keystore.h
+++ b/plugins/fishlim/keystore.h
@@ -29,8 +29,8 @@
 
 #include <glib.h>
 
-char *keystore_get_key(const char *nick);
-gboolean keystore_store_key(const char *nick, const char *key);
+char *keystore_get_key(const char *nick, int *mode);
+gboolean keystore_store_key(const char *nick, const char *key, int mode);
 gboolean keystore_delete_nick(const char *nick);
 
 #endif

--- a/plugins/fishlim/meson.build
+++ b/plugins/fishlim/meson.build
@@ -4,6 +4,7 @@ endif
 
 fishlim_sources = [
   'dh1080.c',
+  'base64.c',
   'fish.c',
   'irc.c',
   'keystore.c',

--- a/plugins/fishlim/plugin_hexchat.c
+++ b/plugins/fishlim/plugin_hexchat.c
@@ -525,6 +525,7 @@ static int handle_crypt_notice(char *word[], char *word_eol[], void *userdata)
 static int handle_crypt_msg(char *word[], char *word_eol[], void *userdata) {
     const char *target = word[2];
     const char *message = word_eol[3];
+    char *message_flag;
     const char *prefix = "";
     hexchat_context *query_ctx;
     char *buf;
@@ -549,8 +550,11 @@ static int handle_crypt_msg(char *word[], char *word_eol[], void *userdata) {
 
         prefix = get_my_own_prefix();
 
+        /* Add encrypted flag */
+        message_flag = g_strconcat("[", fish_modes[mode], "] ", message, NULL);
         hexchat_emit_print(ph, "Your Message", hexchat_get_info(ph, "nick"),
-                           message, prefix, NULL);
+                           message_flag, prefix, NULL);
+        g_free(message_flag);
     } else {
         hexchat_emit_print(ph, "Message Send", target, message);
     }

--- a/plugins/fishlim/plugin_hexchat.c
+++ b/plugins/fishlim/plugin_hexchat.c
@@ -198,7 +198,7 @@ static int handle_incoming(char *word[], char *word_eol[], hexchat_event_attrs *
     if (!decrypted) goto decrypt_error;
     
     /* Build unecrypted message */
-    message = g_string_sized_new (100); /* TODO: more accurate estimation of size */
+    message = g_string_sized_new (strlen(word_eol[1])); /* Just put at least the size of original command */
     g_string_append (message, "RECV");
 
     if (attrs->server_time_utc)

--- a/plugins/fishlim/plugin_hexchat.c
+++ b/plugins/fishlim/plugin_hexchat.c
@@ -468,6 +468,7 @@ static int handle_crypt_notice(char *word[], char *word_eol[], void *userdata)
 {
     const char *target = word[2];
     const char *notice = word_eol[3];
+    char *notice_flag;
     char *buf;
     int mode;
 
@@ -483,7 +484,9 @@ static int handle_crypt_notice(char *word[], char *word_eol[], void *userdata)
     }
 
     hexchat_commandf(ph, "quote NOTICE %s :+OK %s", target, buf);
-    hexchat_emit_print(ph, "Notice Send", target, notice);
+    notice_flag = g_strconcat("[", fish_modes[mode], "] ", notice, NULL);
+    hexchat_emit_print(ph, "Notice Send", target, notice_flag);
+    g_free(notice_flag);
     g_free(buf);
 
     return HEXCHAT_EAT_ALL;

--- a/plugins/fishlim/plugin_hexchat.c
+++ b/plugins/fishlim/plugin_hexchat.c
@@ -41,7 +41,7 @@ static const char *fish_modes[] = {"", "ECB", "CBC", NULL};
 
 static const char plugin_name[] = "FiSHLiM";
 static const char plugin_desc[] = "Encryption plugin for the FiSH protocol. Less is More!";
-static const char plugin_version[] = "0.1.0";
+static const char plugin_version[] = "0.1.1";
 
 static const char usage_setkey[] = "Usage: SETKEY [<nick or #channel>] [<mode>:]<password>, sets the key for a channel or nick. Modes: ECB, CBC";
 static const char usage_delkey[] = "Usage: DELKEY [<nick or #channel>], deletes the key for a channel or nick";

--- a/plugins/fishlim/plugin_hexchat.c
+++ b/plugins/fishlim/plugin_hexchat.c
@@ -483,7 +483,7 @@ static int handle_crypt_notice(char *word[], char *word_eol[], void *userdata)
     }
 
     hexchat_commandf(ph, "quote NOTICE %s :+OK %s", target, buf);
-    hexchat_emit_print(ph, "Notice Sent", target, notice);
+    hexchat_emit_print(ph, "Notice Send", target, notice);
     g_free(buf);
 
     return HEXCHAT_EAT_ALL;

--- a/plugins/fishlim/plugin_hexchat.c
+++ b/plugins/fishlim/plugin_hexchat.c
@@ -333,6 +333,7 @@ cleanup:
 static int handle_setkey(char *word[], char *word_eol[], void *userdata) {
     const char *nick;
     const char *key;
+    char *key_lower;
     int mode;
 
     /* Check syntax */
@@ -352,12 +353,14 @@ static int handle_setkey(char *word[], char *word_eol[], void *userdata) {
     }
 
     mode = FISH_ECB_MODE;
-    if (!strncmp("cbc:", key, 4) || !strncmp("CBC:", key, 4)) {
+    key_lower = g_ascii_strdown(key, -1);
+    if (strncmp("cbc:", key_lower, 4) == 0) {
         key = key+4;
         mode = FISH_CBC_MODE;
-    } else if (!strncmp("ecb:", key, 4) || !strncmp("ECB:", key, 4)) {
+    } else if (strncmp("ecb:", key_lower, 4) == 0) {
         key = key+4;
     }
+    g_free(key_lower);
 
     /* Set password */
     if (keystore_store_key(nick, key, mode)) {

--- a/plugins/fishlim/tests/fish.c
+++ b/plugins/fishlim/tests/fish.c
@@ -1,0 +1,195 @@
+/*
+
+  Copyright (c) 2010 Samuel Lidén Borell <samuel@kodafritt.se>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+
+*/
+
+#ifdef __APPLE__
+#define __AVAILABILITYMACROS__
+#define DEPRECATED_IN_MAC_OS_X_VERSION_10_7_AND_LATER
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+#include <openssl/blowfish.h>
+
+#include "keystore.h"
+#include "fish.h"
+
+#define IB 64
+static const char fish_base64[64] = "./0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+static const signed char fish_unbase64[256] = {
+    IB,IB,IB,IB,IB,IB,IB,IB,  IB,IB,IB,IB,IB,IB,IB,IB,
+    IB,IB,IB,IB,IB,IB,IB,IB,  IB,IB,IB,IB,IB,IB,IB,IB,
+/*      !  "  #  $  %  &  '  (    )  *  +  ,  -  .  / */
+    IB,IB,IB,IB,IB,IB,IB,IB,  IB,IB,IB,IB,IB,IB, 0, 1,
+/*   0  1  2  3  4  5  6  7    8  9  :  ;  <  =  >  ? */
+     2, 3, 4, 5, 6, 7, 8, 9,  10,11,IB,IB,IB,IB,IB,IB,
+/*   @  A  B  C  D  E  F  G    H  I  J  K  L  M  N  O */
+    IB,38,39,40,41,42,43,44,  45,46,47,48,49,50,51,52,
+/*   P  Q  R  S  T  U  V  W    X  Y  Z  [  \  ]  ^  _*/
+    53,54,55,56,57,58,59,60,  61,62,63,IB,IB,IB,IB,IB,
+/*   `  a  b  c  d  e  f  g    h  i  j  k  l  m  n  o */
+    IB,12,13,14,15,16,17,18,  19,20,21,22,23,24,25,26,
+/*   p  q  r  s  t  u  v  w    x  y  z  {  |  }  ~  <del> */
+    27,28,29,30,31,32,33,34,  35,36,37,IB,IB,IB,IB,IB,
+};
+
+#define GET_BYTES(dest, source) do { \
+    *((dest)++) = ((source) >> 24) & 0xFF; \
+    *((dest)++) = ((source) >> 16) & 0xFF; \
+    *((dest)++) = ((source) >> 8) & 0xFF; \
+    *((dest)++) = (source) & 0xFF; \
+} while (0);
+
+
+char *fish_encrypt(const char *key, size_t keylen, const char *message) {
+    BF_KEY bfkey;
+    size_t messagelen;
+    size_t i;
+    int j;
+    char *encrypted;
+    char *end;
+    unsigned char bit;
+    unsigned char word;
+    unsigned char d;
+    BF_set_key(&bfkey, keylen, (const unsigned char*)key);
+    
+    messagelen = strlen(message);
+    if (messagelen == 0) return NULL;
+    encrypted = g_malloc(((messagelen - 1) / 8) * 12 + 12 + 1); /* each 8-byte block becomes 12 bytes */
+    end = encrypted;
+     
+    while (*message) {
+        /* Read 8 bytes (a Blowfish block) */
+        BF_LONG binary[2] = { 0, 0 };
+        unsigned char c;
+        for (i = 0; i < 8; i++) {
+            c = message[i];
+            binary[i >> 2] |= c << 8*(3 - (i&3));
+            if (c == '\0') break;
+        }
+        message += 8;
+        
+        /* Encrypt block */
+        BF_encrypt(binary, &bfkey);
+        
+        /* Emit FiSH-BASE64 */
+        bit = 0;
+        word = 1;
+        for (j = 0; j < 12; j++) {
+            d = fish_base64[(binary[word] >> bit) & 63];
+            *(end++) = d;
+            bit += 6;
+            if (j == 5) {
+                bit = 0;
+                word = 0;
+            }
+        }
+        
+        /* Stop if a null terminator was found */
+        if (c == '\0') break;
+    }
+    *end = '\0';
+    return encrypted;
+}
+
+
+char *fish_decrypt(const char *key, size_t keylen, const char *data) {
+    BF_KEY bfkey;
+    size_t i;
+    char *decrypted;
+    char *end;
+    unsigned char bit;
+    unsigned char word;
+    unsigned char d;
+    BF_set_key(&bfkey, keylen, (const unsigned char*)key);
+    
+    decrypted = g_malloc(strlen(data) + 1);
+    end = decrypted;
+    
+    while (*data) {
+        /* Convert from FiSH-BASE64 */
+        BF_LONG binary[2] = { 0, 0 };
+        bit = 0;
+        word = 1;
+        for (i = 0; i < 12; i++) {
+            d = fish_unbase64[(const unsigned char)*(data++)];
+            if (d == IB) goto decrypt_end;
+            binary[word] |= (unsigned long)d << bit;
+            bit += 6;
+            if (i == 5) {
+                bit = 0;
+                word = 0;
+            }
+        }
+        
+        /* Decrypt block */
+        BF_decrypt(binary, &bfkey);
+        
+        /* Copy to buffer */
+        GET_BYTES(end, binary[0]);
+        GET_BYTES(end, binary[1]);
+    }
+    
+  decrypt_end:
+    *end = '\0';
+    return decrypted;
+}
+
+/**
+ * Encrypts a message (see fish_decrypt). The key is searched for in the
+ * key store.
+ */
+char *fish_encrypt_for_nick(const char *nick, const char *data) {
+    char *key;
+    char *encrypted;
+
+    /* Look for key */
+    key = keystore_get_key(nick);
+    if (!key) return NULL;
+    
+    /* Encrypt */
+    encrypted = fish_encrypt(key, strlen(key), data);
+    
+    g_free(key);
+    return encrypted;
+}
+
+/**
+ * Decrypts a message (see fish_decrypt). The key is searched for in the
+ * key store.
+ */
+char *fish_decrypt_from_nick(const char *nick, const char *data) {
+    char *key;
+    char *decrypted;
+    /* Look for key */
+    key = keystore_get_key(nick);
+    if (!key) return NULL;
+    
+    /* Decrypt */
+    decrypted = fish_decrypt(key, strlen(key), data);
+    
+    g_free(key);
+    return decrypted;
+}
+
+

--- a/plugins/fishlim/tests/fish.h
+++ b/plugins/fishlim/tests/fish.h
@@ -1,0 +1,39 @@
+/*
+
+  Copyright (c) 2010 Samuel Lidén Borell <samuel@kodafritt.se>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+
+*/
+
+#ifndef FISH_H
+#define FISH_H
+
+#include <stddef.h>
+
+#include <glib.h>
+
+char *fish_encrypt(const char *key, size_t keylen, const char *message);
+char *fish_decrypt(const char *key, size_t keylen, const char *data);
+char *fish_encrypt_for_nick(const char *nick, const char *data);
+char *fish_decrypt_from_nick(const char *nick, const char *data);
+
+#endif
+
+

--- a/src/common/dcc.c
+++ b/src/common/dcc.c
@@ -1618,13 +1618,13 @@ dcc_accept (GIOChannel *source, GIOCondition condition, struct DCC *dcc)
 }
 
 guint32
-dcc_get_my_address (void)	/* the address we'll tell the other person */
+dcc_get_my_address (session *sess)	/* the address we'll tell the other person */
 {
 	struct hostent *dns_query;
 	guint32 addr = 0;
 
-	if (prefs.hex_dcc_ip_from_server && prefs.dcc_ip)
-		addr = prefs.dcc_ip;
+	if (prefs.hex_dcc_ip_from_server && sess->server->dcc_ip)
+		addr = sess->server->dcc_ip;
 	else if (prefs.hex_dcc_ip[0])
 	{
 	   dns_query = gethostbyname ((const char *) prefs.hex_dcc_ip);
@@ -1710,7 +1710,7 @@ dcc_listen_init (struct DCC *dcc, session *sess)
 	/*if we have a dcc_ip, we use that, so the remote client can connect*/
 	/*else we try to take an address from hex_dcc_ip*/
 	/*if something goes wrong we tell the client to connect to our LAN ip*/
-	dcc->addr = dcc_get_my_address ();
+	dcc->addr = dcc_get_my_address (sess);
 
 	/*if nothing else worked we use the address we bound to*/
 	if (dcc->addr == 0)

--- a/src/common/dcc.h
+++ b/src/common/dcc.h
@@ -124,7 +124,7 @@ void dcc_chat (session *sess, char *nick, int passive);
 void handle_dcc (session *sess, char *nick, char *word[], char *word_eol[],
 					  const message_tags_data *tags_data);
 void dcc_show_list (session *sess);
-guint32 dcc_get_my_address (void);
+guint32 dcc_get_my_address (session *sess);
 void dcc_get_with_destfile (struct DCC *dcc, char *utf8file);
 
 #endif

--- a/src/common/hexchat.h
+++ b/src/common/hexchat.h
@@ -313,7 +313,6 @@ struct hexchatprefs
 
 	/* these are the private variables */
 	guint32 local_ip;
-	guint32 dcc_ip;
 
 	unsigned int wait_on_exit;	/* wait for logs to be flushed to disk IF we're connected */
 
@@ -482,6 +481,10 @@ typedef struct server
 	int proxy_sok4;
 	int proxy_sok6;
 	int id;					/* unique ID number (for plugin API) */
+
+	/* dcc_ip moved from haxchatprefs to make it per-server */
+	guint32 dcc_ip;
+
 #ifdef USE_OPENSSL
 	SSL_CTX *ctx;
 	SSL *ssl;

--- a/src/common/hexchat.h
+++ b/src/common/hexchat.h
@@ -482,7 +482,7 @@ typedef struct server
 	int proxy_sok6;
 	int id;					/* unique ID number (for plugin API) */
 
-	/* dcc_ip moved from haxchatprefs to make it per-server */
+	/* dcc_ip moved from hexchatprefs to make it per-server */
 	guint32 dcc_ip;
 
 #ifdef USE_OPENSSL

--- a/src/common/inbound.c
+++ b/src/common/inbound.c
@@ -1420,7 +1420,7 @@ inbound_foundip (session *sess, char *ip, const message_tags_data *tags_data)
 	HostAddr = gethostbyname (ip);
 	if (HostAddr)
 	{
-		prefs.dcc_ip = ((struct in_addr *) HostAddr->h_addr)->s_addr;
+		sess->server->dcc_ip = ((struct in_addr *) HostAddr->h_addr)->s_addr;
 		EMIT_SIGNAL_TIMESTAMP (XP_TE_FOUNDIP, sess->server->server_session,
 									  inet_ntoa (*((struct in_addr *) HostAddr->h_addr)),
 									  NULL, NULL, NULL, 0, tags_data->timestamp);

--- a/src/common/outbound.c
+++ b/src/common/outbound.c
@@ -3287,7 +3287,7 @@ cmd_send (struct session *sess, char *tbuf, char *word[], char *word_eol[])
 	if (!word[2][0])
 		return FALSE;
 
-	addr = dcc_get_my_address ();
+	addr = dcc_get_my_address (sess);
 	if (addr == 0)
 	{
 		/* use the one from our connected server socket */


### PR DESCRIPTION
I have been working to provide to hexchat a competent fish plugin with other IRC clients

Features added:
- CBC mode on SETKEY and KEYX commands
- Store keys in CBC mode (addon_fishlim.conf)
- Detect context in DELKEY command
- Encrypted flag for incoming and outgoing messages

New cipher core:
- Use of openssl EVP functions instead direct openssl functions (Now only hexchat will have this)

How to use the CBC mode:

- SETKEY command
  - for CBC mode -> /setkey cbc:key
  - for ECB mode -> /setkey ecb:key
  - for ECB mode -> /setkey key

- KEYX command: nothing for your part!

This merge keep backward compatibility with the database file addon_fishlim.conf