### PR TITLE
build: Make generated headers a dependency for users of common.

### DIFF
--- a/src/common/meson.build
+++ b/src/common/meson.build
@@ -105,6 +105,7 @@ hexchat_common = static_library('hexchatcommon',
 )
 
 hexchat_common_dep = declare_dependency(
+  sources: [textevents] + marshal,
   link_with: hexchat_common,
   include_directories: common_includes,
   compile_args: common_cflags,


### PR DESCRIPTION
I'm staring at this build error:

~~~
[1/74] Compiling C object 'plugins/fishlim/c61e818@@fishlim@sha/irc.c.o'.
[2/74] Compiling C object 'plugins/fishlim/c61e818@@fishlim@sha/fish.c.o'.
[3/74] Compiling C object 'plugins/fishlim/c61e818@@fishlim@sha/dh1080.c.o'.
[4/74] Compiling C object 'plugins/fishlim/c61e818@@fishlim@sha/keystore.c.o'.
[5/74] Generating resources_h with a custom command.
[6/74] Generating resources_c with a custom command.
[7/74] Compiling C object 'plugins/fishlim/c61e818@@fishlim@sha/plugin_hexchat.c.o'.
[8/74] Compiling C object 'plugins/checksum/c016833@@checksum@sha/checksum.c.o'.
[9/74] Linking target plugins/checksum/checksum.so.
[10/74] Linking target plugins/fishlim/fishlim.so.
[11/74] Compiling C object 'src/fe-text/cdba4cc@@hexchat-text@exe/fe-text.c.o'.
[12/74] Compiling C object 'src/fe-gtk/c4b29cb@@hexchat@exe/notifygui.c.o'.
[13/74] Compiling C object 'src/fe-gtk/c4b29cb@@hexchat@exe/palette.c.o'.
[14/74] Compiling C object 'src/fe-gtk/c4b29cb@@hexchat@exe/pixmaps.c.o'.
[15/74] Generating io.github.Hexchat.desktop_data@misc_merge with a custom command.
[16/74] Compiling C object 'src/fe-gtk/c4b29cb@@hexchat@exe/menu.c.o'.
[17/74] Compiling C object 'src/fe-gtk/c4b29cb@@hexchat@exe/plugin-tray.c.o'.
[18/74] Compiling C object 'src/fe-gtk/c4b29cb@@hexchat@exe/plugin-notification.c.o'.
[19/74] Compiling C object 'src/fe-gtk/c4b29cb@@hexchat@exe/maingui.c.o'.
[20/74] Compiling C object 'src/fe-gtk/c4b29cb@@hexchat@exe/rawlog.c.o'.
[21/74] Compiling C object 'src/fe-gtk/c4b29cb@@hexchat@exe/sexy-spell-entry.c.o'.
FAILED: src/fe-gtk/c4b29cb@@hexchat@exe/sexy-spell-entry.c.o 
gcc -Isrc/fe-gtk/c4b29cb@@hexchat@exe -Isrc/fe-gtk -I../src/fe-gtk -I. -I../ -Isrc/common -I../src/common -I/usr/pkg/include -I/usr/pkg/include/glib-2.0 -I/usr/pkg/lib/glib-2.0/include -I/usr/pkg/include/gtk-2.0 -I/usr/pkg/lib/gtk-2.0/include -I/usr/pkg/include/pango-1.0 -I/usr/pkg/include/fribidi -I/usr/pkg/include/cairo -I/usr/X11R7/include/pixman-1 -I/usr/X11R7/include -I/usr/X11R7/include/freetype2 -I/usr/pkg/include/libpng16 -I/usr/pkg/include/harfbuzz -I/usr/pkg/include/gio-unix-2.0 -I/usr/pkg/include/gdk-pixbuf-2.0 -I/usr/pkg/include/atk-1.0 -I/usr/include -I/usr/X11R7/include/libdrm -I/usr/pkg/include/python3.7 -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -std=gnu89 -fPIE -funsigned-char -Wno-conversion -Wno-pointer-sign -Wno-padded -Wno-unused-parameter -Wno-missing-prototypes -Winline -Wstrict-prototypes -Werror=implicit-function-declaration -Werror=pointer-arith -Werror=init-self -Werror=format-security -Werror=format=1 -Werror=missing-include-dirs -Werror=date-time -O2 -D_FORTIFY_SOURCE=2 -fPIE -D_REENTRANT -pthread -DHAVE_CONFIG_H '-DHEXCHATLIBDIR="/usr/pkg/lib/hexchat/plugins"' -fPIE '-DISO_CODES_PREFIX="/usr/pkg"' '-DISO_CODES_LOCALEDIR="/usr/pkg/share/locale"' -MD -MQ 'src/fe-gtk/c4b29cb@@hexchat@exe/sexy-spell-entry.c.o' -MF 'src/fe-gtk/c4b29cb@@hexchat@exe/sexy-spell-entry.c.o.d' -o 'src/fe-gtk/c4b29cb@@hexchat@exe/sexy-spell-entry.c.o' -c ../src/fe-gtk/sexy-spell-entry.c
../src/fe-gtk/sexy-spell-entry.c:38:10: fatal error: ../common/marshal.h: No such file or directory
 #include "../common/marshal.h"
          ^~~~~~~~~~~~~~~~~~~~~
compilation terminated.
[22/74] Compiling C object 'src/fe-gtk/c4b29cb@@hexchat@exe/urlgrab.c.o'.
[23/74] Compiling C object 'src/fe-gtk/c4b29cb@@hexchat@exe/userlistgui.c.o'.
[24/74] Compiling C object 'src/fe-gtk/c4b29cb@@hexchat@exe/textgui.c.o'.
[25/74] Compiling C object 'src/fe-gtk/c4b29cb@@hexchat@exe/servlistgui.c.o'.
[26/74] Compiling C object 'src/fe-gtk/c4b29cb@@hexchat@exe/setup.c.o'.
ninja: build stopped: subcommand failed.
*** Error code 1

Stop.
make[1]: stopped in /amd/pkgsrc/CHROOT/P/pkgsrc/chat/hexchat
*** Error code 1

Stop.
make: stopped in /amd/pkgsrc/CHROOT/P/pkgsrc/chat/hexchat
~~~


Since I can't reproduce it consistently (only about ~20% of the time), I suspect it's a race condition between generating headers in "common" and building "fe-gtk".

This PR makes fe-gtk require the generated headers as 'sources'.

I've been chasing this for a while now (it's been problematic for NetBSD's bulk package builds) and have tried various things that reduced the failure rate - this seems closest to a correct fix, but it's hard for me to tell due to difficulty reproducing and unfamiliarity with meson.