### PR TITLE
Ignore some non-interesting filesystem types in sysinfo plugin

### DIFF
--- a/plugins/sysinfo/shared/df.c
+++ b/plugins/sysinfo/shared/df.c
@@ -26,7 +26,7 @@ int xs_parse_df(gint64 *out_total, gint64 *out_free)
 	FILE *pipe;
 	char buffer[bsize];
 	
-	pipe = popen("df -k -l -P", "r");
+	pipe = popen("df -k -l -P --exclude-type=squashfs --exclude-type=devtmpfs --exclude-type=tmpfs", "r");
 	if(pipe==NULL)
 		return 1;
 


### PR DESCRIPTION
Generally, how much space we have in squashfs, or tmpfs shouldn't
interest us. This becomes more relevant in distros like Ubuntu, where
snaps are a thing, and each snap mounts their own FS in a squashfs that
is always full, thus falsifying the output of sysinfo.

Some other things to consider, where I haven't found a good solution yet: ZFS. On my desktop, I have a ZFS array for data storage, and that makes the df-output go a little crazy and yield very wrong results, which would require significantly more complex parsing and detection. Example:

```
Filesystem                        Size  Used Avail Use% Mounted on
desktop-zfs-crypt/misc            510G  133M  510G   1% /home/simon/misc
desktop-zfs-crypt/videos          2,2T  1,7T  510G  78% /home/simon/Videos
desktop-zfs-crypt/bitcoin         510G   18M  510G   1% /home/simon/.bitcoin
desktop-zfs-crypt/desktop-backup  974G  465G  510G  48% /desktop-backup
```

These numbers are all a bit off because "Size" is "what space is available *in total* for this file system". If you don't set quotas on the ZFS volumes, they all "share" the full capacity of the entire zpool, which technically has a much smaller capacity:

```
NAME                SIZE  ALLOC   FREE  CKPOINT  EXPANDSZ   FRAG    CAP  DEDUP    HEALTH  ALTROOT
desktop-zfs-crypt  2,72T  2,14T   597G        -         -     0%    78%  1.00x    ONLINE  -
```

One way that *could* work would be also excluding zfs, attempting to figure out if the ```zfs``` and ```zpool``` binaries are on the path, and then getting the size of those pools that way. Though I'm not sure if that is worth the effort.
