### PR TITLE
Add include for winuser.h for mingw compilers.

### DIFF
--- a/src/fe-gtk/maingui.c
+++ b/src/fe-gtk/maingui.c
@@ -53,6 +53,10 @@
 #include "sexy-spell-entry.h"
 #include "gtkutil.h"
 
+#ifdef WIN32
+#include <winuser.h>
+#endif
+
 #define GUI_SPACING (3)
 #define GUI_BORDER (0)
 

--- a/src/fe-gtk/maingui.c
+++ b/src/fe-gtk/maingui.c
@@ -53,7 +53,7 @@
 #include "sexy-spell-entry.h"
 #include "gtkutil.h"
 
-#ifdef WIN32
+#ifdef G_OS_WIN32
 #include <winuser.h>
 #endif
 


### PR DESCRIPTION
Without the include gcc will complain about WM_TIMECHANGE as undeclared.