### PR TITLE
This is to correct my errant include.

### DIFF
--- a/src/fe-gtk/maingui.c
+++ b/src/fe-gtk/maingui.c
@@ -54,7 +54,7 @@
 #include "gtkutil.h"
 
 #ifdef G_OS_WIN32
-#include <winuser.h>
+#include <windows.h>
 #endif
 
 #define GUI_SPACING (3)

--- a/src/fe-gtk/maingui.c
+++ b/src/fe-gtk/maingui.c
@@ -53,6 +53,10 @@
 #include "sexy-spell-entry.h"
 #include "gtkutil.h"
 
+#ifdef WIN32
+#include <winuser.h>
+#endif
+
 #define GUI_SPACING (3)
 #define GUI_BORDER (0)
 

--- a/src/fe-gtk/maingui.c
+++ b/src/fe-gtk/maingui.c
@@ -53,7 +53,7 @@
 #include "sexy-spell-entry.h"
 #include "gtkutil.h"
 
-#ifdef WIN32
+#ifdef G_OS_WIN32
 #include <winuser.h>
 #endif
 


### PR DESCRIPTION
MinGW needs windows.h not winuser.h, while yes winuser.h has the declaration, windows.h has the proper requirements needed and includes winuser.h and allows hexchat to compile against MinGW-w64 Version 6+