### PR TITLE
Socks5 user pass limit

### DIFF
--- a/src/common/hexchat.h
+++ b/src/common/hexchat.h
@@ -301,8 +301,8 @@ struct hexchatprefs
 	char hex_irc_user_name[127];
 	char hex_net_bind_host[127];
 	char hex_net_proxy_host[64];
-	char hex_net_proxy_pass[32];
-	char hex_net_proxy_user[32];
+	char hex_net_proxy_pass[256];
+	char hex_net_proxy_user[256];
 	char hex_stamp_log_format[64];
 	char hex_stamp_text_format[64];
 	char hex_text_background[PATHLEN + 1];


### PR DESCRIPTION
Updated the maximum length of the socks5 user and password to comply to RFC 1929, where both the password and the username length is defined as a maximum of 255.

This PR is based on #1994 (thanks @kelek-) and will resolve #1296.