### PR TITLE
xtext: support 99 colors

### DIFF
--- a/src/fe-gtk/palette.c
+++ b/src/fe-gtk/palette.c
@@ -37,7 +37,7 @@
 #include "../common/typedef.h"
 
 
-GdkColor colors[] = {
+GdkColor colors[MAX_COL+1] = {
 	/* colors for xtext */
 	{0, 0xd3d3, 0xd7d7, 0xcfcf}, /* 0 white */
 	{0, 0x2e2e, 0x3434, 0x3636}, /* 1 black */
@@ -56,36 +56,107 @@ GdkColor colors[] = {
 	{0, 0x5555, 0x5757, 0x5353}, /* 14 grey */
 	{0, 0x8888, 0x8a8a, 0x8585}, /* 15 light grey */
 
-	{0, 0xd3d3, 0xd7d7, 0xcfcf}, /* 16 white */
-	{0, 0x2e2e, 0x3434, 0x3636}, /* 17 black */
-	{0, 0x3434, 0x6565, 0xa4a4}, /* 18 blue */
-	{0, 0x4e4e, 0x9a9a, 0x0606}, /* 19 green */
-	{0, 0xcccc, 0x0000, 0x0000}, /* 20 red */
-	{0, 0x8f8f, 0x3939, 0x0202}, /* 21 light red */
-	{0, 0x5c5c, 0x3535, 0x6666}, /* 22 purple */
-	{0, 0xcece, 0x5c5c, 0x0000}, /* 23 orange */
-	{0, 0xc4c4, 0xa0a0, 0x0000}, /* 24 yellow */
-	{0, 0x7373, 0xd2d2, 0x1616}, /* 25 green */
-	{0, 0x1111, 0xa8a8, 0x7979}, /* 26 aqua */
-	{0, 0x5858, 0xa1a1, 0x9d9d}, /* 27 light aqua */
-	{0, 0x5757, 0x7979, 0x9e9e}, /* 28 blue */
-	{0, 0xa0d0, 0x42d4, 0x6562}, /* 29 light purple */
-	{0, 0x5555, 0x5757, 0x5353}, /* 30 grey */
-	{0, 0x8888, 0x8a8a, 0x8585}, /* 31 light grey */
+	/* extended 99 colors */
+	{0, 0x477f, 0x0000, 0x0000},
+	{0, 0x477f, 0x217f, 0x0000},
+	{0, 0x477f, 0x477f, 0x0000},
+	{0, 0x327f, 0x477f, 0x0000},
+	{0, 0x0000, 0x477f, 0x0000},
+	{0, 0x0000, 0x477f, 0x2c7f},
+	{0, 0x0000, 0x477f, 0x477f},
+	{0, 0x0000, 0x277f, 0x477f},
+	{0, 0x0000, 0x0000, 0x477f},
+	{0, 0x2e7f, 0x0000, 0x477f},
+	{0, 0x477f, 0x0000, 0x477f},
+	{0, 0x477f, 0x0000, 0x2a7f},
+	{0, 0x747f, 0x0000, 0x0000},
+	{0, 0x747f, 0x3a7f, 0x0000},
+	{0, 0x747f, 0x747f, 0x0000},
+	{0, 0x517f, 0x747f, 0x0000},
+	{0, 0x0000, 0x747f, 0x0000},
+	{0, 0x0000, 0x747f, 0x497f},
+	{0, 0x0000, 0x747f, 0x747f},
+	{0, 0x0000, 0x407f, 0x747f},
+	{0, 0x0000, 0x0000, 0x747f},
+	{0, 0x4b7f, 0x0000, 0x747f},
+	{0, 0x747f, 0x0000, 0x747f},
+	{0, 0x747f, 0x0000, 0x457f},
+	{0, 0xb57f, 0x0000, 0x0000},
+	{0, 0xb57f, 0x637f, 0x0000},
+	{0, 0xb57f, 0xb57f, 0x0000},
+	{0, 0x7d7f, 0xb57f, 0x0000},
+	{0, 0x0000, 0xb57f, 0x0000},
+	{0, 0x0000, 0xb57f, 0x717f},
+	{0, 0x0000, 0xb57f, 0xb57f},
+	{0, 0x0000, 0x637f, 0xb57f},
+	{0, 0x0000, 0x0000, 0xb57f},
+	{0, 0x757f, 0x0000, 0xb57f},
+	{0, 0xb57f, 0x0000, 0xb57f},
+	{0, 0xb57f, 0x0000, 0x6b7f},
+	{0, 0xff7f, 0x0000, 0x0000},
+	{0, 0xff7f, 0x8c7f, 0x0000},
+	{0, 0xff7f, 0xff7f, 0x0000},
+	{0, 0xb27f, 0xff7f, 0x0000},
+	{0, 0x0000, 0xff7f, 0x0000},
+	{0, 0x0000, 0xff7f, 0xa07f},
+	{0, 0x0000, 0xff7f, 0xff7f},
+	{0, 0x0000, 0x8c7f, 0xff7f},
+	{0, 0x0000, 0x0000, 0xff7f},
+	{0, 0xa57f, 0x0000, 0xff7f},
+	{0, 0xff7f, 0x0000, 0xff7f},
+	{0, 0xff7f, 0x0000, 0x97f8},
+	{0, 0xff7f, 0x597f, 0x597f},
+	{0, 0xff7f, 0xb47f, 0x597f},
+	{0, 0xff7f, 0xff7f, 0x717f},
+	{0, 0xcf7f, 0xff7f, 0x607f},
+	{0, 0x6f7f, 0xff7f, 0x6f7f},
+	{0, 0x657f, 0xff7f, 0xc97f},
+	{0, 0x6d7f, 0xff7f, 0xff7f},
+	{0, 0x597f, 0xb47f, 0xff7f},
+	{0, 0x597f, 0x597f, 0xff7f},
+	{0, 0xc47f, 0x597f, 0xff7f},
+	{0, 0xff7f, 0x667f, 0xff7f},
+	{0, 0xff7f, 0x597f, 0xbc7f},
+	{0, 0xff7f, 0x9c7f, 0x9c7f},
+	{0, 0xff7f, 0xd37f, 0x9c7f},
+	{0, 0xff7f, 0xff7f, 0x9c7f},
+	{0, 0xe27f, 0xff7f, 0x9c7f},
+	{0, 0x9c7f, 0xff7f, 0x9c7f},
+	{0, 0x9c7f, 0xff7f, 0xdb7f},
+	{0, 0x9c7f, 0xff7f, 0xff7f},
+	{0, 0x9c7f, 0xd37f, 0xff7f},
+	{0, 0x9c7f, 0x9c7f, 0xff7f},
+	{0, 0xdc7f, 0x9c7f, 0xff7f},
+	{0, 0xff7f, 0x9c7f, 0xff7f},
+	{0, 0xff7f, 0x947f, 0xd37f},
+	{0, 0x0000, 0x0000, 0x0000},
+	{0, 0x137f, 0x137f, 0x137f},
+	{0, 0x27f8, 0x27f8, 0x27f8},
+	{0, 0x367f, 0x367f, 0x367f},
+	{0, 0x4d7f, 0x4d7f, 0x4d7f},
+	{0, 0x657f, 0x657f, 0x657f},
+	{0, 0x817f, 0x817f, 0x817f},
+	{0, 0x9f7f, 0x9f7f, 0x9f7f},
+	{0, 0xbc7f, 0xbc7f, 0xbc7f},
+	{0, 0xe27f, 0xe27f, 0xe27f},
+	{0, 0xff7f, 0xff7f, 0xff7f}, /* 98 */
 
-	{0, 0xd3d3, 0xd7d7, 0xcfcf}, /* 32 marktext Fore (white) */
-	{0, 0x2020, 0x4a4a, 0x8787}, /* 33 marktext Back (blue) */
-	{0, 0x2512, 0x29e8, 0x2b85}, /* 34 foreground (black) */
-	{0, 0xfae0, 0xfae0, 0xf8c4}, /* 35 background (white) */
-	{0, 0x8f8f, 0x3939, 0x0202}, /* 36 marker line (red) */
+	/* start of xtext special colors */
+
+	{0, 0xd3d3, 0xd7d7, 0xcfcf}, /* marktext Fore (white) */
+	{0, 0x2020, 0x4a4a, 0x8787}, /* marktext Back (blue) */
+	{0, 0x2512, 0x29e8, 0x2b85}, /* foreground (black) */
+	{0, 0xfae0, 0xfae0, 0xf8c4}, /* background (white) */
+	{0, 0x8f8f, 0x3939, 0x0202}, /* marker line (red) */
 
 	/* colors for GUI */
-	{0, 0x3434, 0x6565, 0xa4a4}, /* 37 tab New Data (dark red) */
-	{0, 0x4e4e, 0x9a9a, 0x0606}, /* 38 tab Nick Mentioned (blue) */
-	{0, 0xcece, 0x5c5c, 0x0000}, /* 39 tab New Message (red) */
-	{0, 0x8888, 0x8a8a, 0x8585}, /* 40 away user (grey) */
-	{0, 0xa4a4, 0x0000, 0x0000}, /* 41 spell checker color (red) */
+	{0, 0x3434, 0x6565, 0xa4a4}, /* tab New Data (dark red) */
+	{0, 0x4e4e, 0x9a9a, 0x0606}, /* tab Nick Mentioned (blue) */
+	{0, 0xcece, 0x5c5c, 0x0000}, /* tab New Message (red) */
+	{0, 0x8888, 0x8a8a, 0x8585}, /* away user (grey) */
+	{0, 0xa4a4, 0x0000, 0x0000}, /* spell checker color (red) */
 };
+
 
 void
 palette_alloc (GtkWidget * widget)
@@ -119,24 +190,65 @@ palette_load (void)
 		cfg = g_malloc0 (st.st_size + 1);
 		read (fh, cfg, st.st_size);
 
-		/* mIRC colors 0-31 are here */
-		for (i = 0; i < 32; i++)
+		/* old theme format writes colors [0, THEME_MAX_MIRC_COLORS) and [256, ...) */
+		g_snprintf (prefname, sizeof prefname, "color_%d", THEME_MAX_MIRC_COLS);
+		if (!cfg_get_color (cfg, prefname, &red, &green, &blue))
 		{
-			g_snprintf (prefname, sizeof prefname, "color_%d", i);
-			cfg_get_color (cfg, prefname, &red, &green, &blue);
-			colors[i].red = red;
-			colors[i].green = green;
-			colors[i].blue = blue;
+			/* old theme detected, migrate low local colors [0, 32) */
+			for (i = 0; i < THEME_MAX_MIRC_COLS; i++)
+			{
+				g_snprintf (prefname, sizeof prefname, "color_%d", i);
+				if (cfg_get_color (cfg, prefname, &red, &green, &blue))
+				{
+					colors[i].red = red;
+					colors[i].green = green;
+					colors[i].blue = blue;
+				}
+			}
+
+			/* continue mapping special colors 256+ into mirc colors [32, ...) */
+			for (i = 256, j = THEME_MAX_MIRC_COLS; j < THEME_MAX_COLOR+1; i++, j++)
+			{
+				g_snprintf (prefname, sizeof prefname, "color_%d", i);
+				if (cfg_get_color (cfg, prefname, &red, &green, &blue))
+				{
+					colors[j].red = red;
+					colors[j].green = green;
+					colors[j].blue = blue;
+				}
+			}
+
+			/* handle mirc color wrap around after max theme colors */
+			for (i = THEME_MAX_COLOR + 1; i < COL_START_SYS; i++)
+			{
+				colors[i] = colors[i % THEME_MAX_MIRC_COLS];
+			}
+		}
+		else
+		{
+			/* mIRC colors 0-98 are here */
+			for (i = 0; i < COL_START_SYS; i++)
+			{
+				g_snprintf (prefname, sizeof prefname, "color_%d", i);
+				if (cfg_get_color (cfg, prefname, &red, &green, &blue))
+				{
+					colors[i].red = red;
+					colors[i].green = green;
+					colors[i].blue = blue;
+				}
+			}
 		}
 
-		/* our special colors are mapped at 256+ */
-		for (i = 256, j = 32; j < MAX_COL+1; i++, j++)
+		/* our special colors are mapped at 256+ and have codes above 99 */
+		for (i = 256, j = COL_START_SYS; j < MAX_COL+1; i++, j++)
 		{
 			g_snprintf (prefname, sizeof prefname, "color_%d", i);
-			cfg_get_color (cfg, prefname, &red, &green, &blue);
-			colors[j].red = red;
-			colors[j].green = green;
-			colors[j].blue = blue;
+			if (cfg_get_color (cfg, prefname, &red, &green, &blue))
+			{
+				colors[j].red = red;
+				colors[j].green = green;
+				colors[j].blue = blue;
+			}
 		}
 		g_free (cfg);
 		close (fh);
@@ -152,15 +264,15 @@ palette_save (void)
 	fh = hexchat_open_file ("colors.conf", O_TRUNC | O_WRONLY | O_CREAT, 0600, XOF_DOMODE);
 	if (fh != -1)
 	{
-		/* mIRC colors 0-31 are here */
-		for (i = 0; i < 32; i++)
+		/* mIRC colors 0-98 are here */
+		for (i = 0; i < COL_START_SYS; i++)
 		{
 			g_snprintf (prefname, sizeof prefname, "color_%d", i);
 			cfg_put_color (fh, colors[i].red, colors[i].green, colors[i].blue, prefname);
 		}
 
 		/* our special colors are mapped at 256+ */
-		for (i = 256, j = 32; j < MAX_COL+1; i++, j++)
+		for (i = 256, j = COL_START_SYS; j < MAX_COL+1; i++, j++)
 		{
 			g_snprintf (prefname, sizeof prefname, "color_%d", i);
 			cfg_put_color (fh, colors[j].red, colors[j].green, colors[j].blue, prefname);

--- a/src/fe-gtk/palette.h
+++ b/src/fe-gtk/palette.h
@@ -22,17 +22,21 @@
 
 extern GdkColor colors[];
 
-#define COL_MARK_FG 32
-#define COL_MARK_BG 33
-#define COL_FG 34
-#define COL_BG 35
-#define COL_MARKER 36
-#define COL_NEW_DATA 37
-#define COL_HILIGHT 38
-#define COL_NEW_MSG 39
-#define COL_AWAY 40
-#define COL_SPELL 41
-#define MAX_COL 41
+#define THEME_MAX_MIRC_COLS 32
+#define THEME_MAX_COLOR (THEME_MAX_MIRC_COLS + 9)
+
+#define COL_START_SYS 99 /* beginning index of system colors */
+#define COL_MARK_FG (COL_START_SYS)
+#define COL_MARK_BG (COL_START_SYS + 1)
+#define COL_FG (COL_START_SYS + 2)
+#define COL_BG (COL_START_SYS + 3)
+#define COL_MARKER (COL_START_SYS + 4)
+#define COL_NEW_DATA (COL_START_SYS + 5)
+#define COL_HILIGHT (COL_START_SYS + 6)
+#define COL_NEW_MSG (COL_START_SYS + 7)
+#define COL_AWAY (COL_START_SYS + 8)
+#define COL_SPELL (COL_START_SYS + 9)
+#define MAX_COL COL_SPELL
 
 void palette_alloc (GtkWidget * widget);
 void palette_load (void);

--- a/src/fe-gtk/xtext.h
+++ b/src/fe-gtk/xtext.h
@@ -41,14 +41,14 @@
 #define ATTR_UNDERLINE	'\037'
 
 /* these match palette.h */
-#define XTEXT_MIRC_COLS 32
-#define XTEXT_COLS 37		/* 32 plus 5 for extra stuff below */
-#define XTEXT_MARK_FG 32	/* for marking text */
-#define XTEXT_MARK_BG 33
-#define XTEXT_FG 34
-#define XTEXT_BG 35
-#define XTEXT_MARKER 36		/* for marker line */
-#define XTEXT_MAX_COLOR 41
+#define XTEXT_MIRC_COLS 99
+#define XTEXT_COLS (XTEXT_MIRC_COLS + 5)/* plus 5 for extra stuff below */
+#define XTEXT_MARK_FG (XTEXT_MIRC_COLS)	/* for marking text */
+#define XTEXT_MARK_BG (XTEXT_MIRC_COLS + 1)
+#define XTEXT_FG (XTEXT_MIRC_COLS + 2)
+#define XTEXT_BG (XTEXT_MIRC_COLS + 3)
+#define XTEXT_MARKER (XTEXT_MIRC_COLS + 4) /* for marker line */
+#define XTEXT_MAX_COLOR (XTEXT_MIRC_COLS + 9)
 
 typedef struct _GtkXText GtkXText;
 typedef struct _GtkXTextClass GtkXTextClass;


### PR DESCRIPTION
Extends palette to support 99 colors. Current local color settings are
preserved, but a default palette based on 99 color codes is provided if no
local colors are configured.

Fixes #2389