### PR TITLE
Remove Moznet

### DIFF
--- a/src/common/servlist.c
+++ b/src/common/servlist.c
@@ -248,9 +248,6 @@ static const struct defaultserver def[] =
 	{"MIXXnet",		0},
 	{0,			"irc.mixxnet.net"},
 
-	{"Moznet", 0, 0, 0, 0, 0, TRUE},
-	{0,			"irc.mozilla.org"},
-	
 	{"ObsidianIRC",  0},
 	/* Self signed */
 	{0,      "irc.obsidianirc.net"}, 


### PR DESCRIPTION
Mozilla's Moznet no longer exists. They migrated to Matrix.

> Note that on 2nd March 2020, Mozilla moved away from IRC to Matrix for its public channels, the IRC server was be shut down.

Source: https://wiki.mozilla.org/IRC