### PR TITLE
win32: Replace include of winuser.h with windows.h

### DIFF
--- a/src/fe-gtk/maingui.c
+++ b/src/fe-gtk/maingui.c
@@ -54,7 +54,7 @@
 #include "gtkutil.h"
 
 #ifdef G_OS_WIN32
-#include <winuser.h>
+#include <windows.h>
 #endif
 
 #define GUI_SPACING (3)


### PR DESCRIPTION
winuser.h should never be included directly. windows.h should be included instead.

This fixes a critical build issue added in c5d47fc which makes all MinGW builds fail.

See #2403.