### PR TITLE
win32: Fix building executables with invalid entrypoints

### DIFF
--- a/src/fe-gtk/meson.build
+++ b/src/fe-gtk/meson.build
@@ -80,6 +80,10 @@ resources = gnome.compile_resources('resources',
   extra_args: ['--manual-register']
 )
 
+if host_machine.system() == 'windows'
+  hexchat_gtk_ldflags += '-Wl,-e,mainCRTStartup'
+endif
+
 executable('hexchat',
   sources:  resources + hexchat_gtk_sources,
   dependencies: hexchat_gtk_deps,


### PR DESCRIPTION
Windows builds of the GTK frontend use the pie flag to compile
hexchat.exe. Windows needs an explicit entrypoint when compiling with
--pie, otherwise an invalid executable is created.

This sets the entrypoint of the executable on Windows (as it is
currently set in the Visual Studio project files).

This fixes a critical build issue which prevents all Windows builds using
Meson from working.