### PR TITLE
win32: Fix undefined symbol for builds with -with-plugin=false

### DIFF
--- a/src/common/plugin.c
+++ b/src/common/plugin.c
@@ -355,7 +355,8 @@ plugin_kill_all (void)
 	}
 }
 
-#ifdef USE_PLUGIN
+#if defined(USE_PLUGIN) || defined(WIN32)
+/* used for loading plugins, and in fe-gtk/notifications/notification-windows.c */
 
 GModule *
 module_load (char *filename)
@@ -383,6 +384,10 @@ module_load (char *filename)
 
 	return handle;
 }
+
+#endif
+
+#ifdef USE_PLUGIN
 
 /* load a plugin from a filename. Returns: NULL-success or an error string */
 


### PR DESCRIPTION
Windows builds without plugins can use notification-windows.c, which
uses module_load in its notification_backend_init function.

module_load was previously guarded with a USE_PLUGIN ifdef, but we do
need this function for Windows builds even if plugins are disabled.

This fixes a critical build issue for all Windows builds without
plugins.