### PR TITLE
win32: Disable ASLR for Windows debug builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -134,9 +134,11 @@ test_ldflags = [
   '-Wl,-z,relro',
   '-Wl,-z,now',
   # mingw
-  '-Wl,--dynamicbase',
   '-Wl,--nxcompat',
 ]
+if not (host_machine.system() == 'windows' and get_option('debug'))
+ test_ldflags += '-Wl,--dynamicbase'
+endif
 foreach ldflag : test_ldflags
   if meson.version().version_compare('>= 0.46.0')
     has_arg = cc.has_link_argument(ldflag)


### PR DESCRIPTION
GDB is usually able to debug executables with ASLR by temporarily
disabling ASLR when running that executable. This is only supported on
Linux. On Windows, GDB cannot debug ASLR executables.

This removes the dynamicbase linker flag on Windows for debug builds in
order to be able to debug that executable later.

Hardening an executable with ASLR is important for release builds, but
for debug builds being able to debug is much more important.