### PR TITLE
Update servlist.c for the split of irc.2ch.net

### DIFF
--- a/src/common/servlist.c
+++ b/src/common/servlist.c
@@ -54,10 +54,8 @@ static const struct defaultserver def[] =
 	/* Invalid hostname in cert */
 	{0,			"irc.2600.net"},
 
-	{"2ch", 0, 0, "iso-2022-jp", 0, 0},
-	{0,			"irc.2ch.sc"},
-	{0,			"irc.nurs.or.jp"},
-	{0,			"irc.juggler.jp"},
+	{"5chirc", 0},
+	{0,			"irc.2ch.net"},
 
 	{"AccessIRC",	0},
 	/* Self signed */
@@ -216,6 +214,11 @@ static const struct defaultserver def[] =
 
 	{"IRCHighWay", 0, 0, 0, 0, 0, TRUE},
 	{0,				"irc.irchighway.net"},
+
+	{"irc.juggler.jp", 0, 0, "iso-2022-jp", 0, 0},
+	{0,			"irc.juggler.jp"},
+	{0,			"irc1.juggler.jp"},
+	{0,			"irc2.juggler.jp"},
 
 	{"IRCNet",		0},
 	{0,				"open.ircnet.net"},


### PR DESCRIPTION
2ch is splitted. Now it become 3 networks: irc.2ch.net (5chirc) , irc.2ch.sc, and irc.juggler.jp . It's unknown how irc.2ch.sc is going. So I deleted it.