### PR TITLE
Added irc.juggler.jp , a big Japanese IRC network.

### DIFF
--- a/src/common/servlist.c
+++ b/src/common/servlist.c
@@ -206,6 +206,11 @@ static const struct defaultserver def[] =
 	{"Interlinked", 0, 0, 0, LOGIN_SASL, 0, TRUE},
 	{0,			"irc.interlinked.me"},
 
+	{"irc.juggler.jp", 0, 0, "iso-2022-jp", 0, 0},
+	{0,			"irc.juggler.jp"},
+	{0,			"irc1.juggler.jp"},
+	{0,			"irc2.juggler.jp"},
+
 	{"IRC4Fun", 0, 0, 0, LOGIN_SASL, 0, TRUE},
 	{0,				"irc.irc4fun.net"},
 


### PR DESCRIPTION
irc.juggler.jp is a big Japanese IRC network. It uses an old server software with enabling Kanji channel names in iso-2022-jp encoding.