### PR TITLE
Use latest meson version

### DIFF
--- a/.github/workflows/ubuntu-build.yml
+++ b/.github/workflows/ubuntu-build.yml
@@ -12,8 +12,9 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson libcanberra-dev libdbus-glib-1-dev libglib2.0-dev libgtk2.0-dev libluajit-5.1-dev libnotify-dev libpci-dev libperl-dev libproxy-dev libssl-dev python3-dev python3-cffi mono-devel desktop-file-utils
-
+          sudo apt-get install -y ninja-build libcanberra-dev libdbus-glib-1-dev libglib2.0-dev libgtk2.0-dev libluajit-5.1-dev libnotify-dev libpci-dev libperl-dev libproxy-dev libssl-dev python3-dev python3-cffi python3-setuptools mono-devel desktop-file-utils
+          sudo pip3 install meson
+          
       - name: Configure
         run: meson build -Dwith-text=true -Dwith-theme-manager=true
 


### PR DESCRIPTION
Dear @TingPing,

I'm currently developing the [tests](https://github.com/BakasuraRCE/hexchat/blob/a41918b0a7ff41a8f9b94471973fabbe8e899d33/plugins/fishlim/tests/tests.c) and [features](https://github.com/BakasuraRCE/hexchat-fishlim-reloaded/issues/1) of [Fishlim](https://github.com/hexchat/hexchat/pull/2347) plugin, for it I use the [cmocka](https://cmocka.org/) testing framework that require meson 0.48.0+, but the Github Actions build is using 0.45.0.

This PR update the build to run always the latest version of meson. Could you give me feedback about if I'm in a good choice or I need to change the system of tests?

Regards.