### PR TITLE
SASL EXTERNAL doesn't necessitate a certificate

### DIFF
--- a/src/common/inbound.c
+++ b/src/common/inbound.c
@@ -1805,7 +1805,7 @@ inbound_cap_ls (server *serv, char *nick, char *extensions_str,
 		/* if the SASL password is set AND auth mode is set to SASL, request SASL auth */
 		if (!g_strcmp0 (extension, "sasl") &&
 			((serv->loginmethod == LOGIN_SASL && strlen (serv->password) != 0)
-				|| (serv->loginmethod == LOGIN_SASLEXTERNAL && serv->have_cert)))
+				|| serv->loginmethod == LOGIN_SASLEXTERNAL))
 		{
 			if (value)
 			{


### PR DESCRIPTION
there's 2 reasons for this
- SASL `EXTERNAL` could be something other than certificate
- not even trying SASL `EXTERNAL` when there's no cert means there's no SASL failure in logs