### PR TITLE
Notification: Implement notification option for channels

### DIFF
--- a/src/common/chanopt.c
+++ b/src/common/chanopt.c
@@ -58,6 +58,7 @@ typedef struct
 
 static const channel_options chanopt[] =
 {
+	{"alert_balloon", NULL, S_F(alert_balloon)},
 	{"alert_beep", "BEEP", S_F(alert_beep)},
 	{"alert_taskbar", NULL, S_F(alert_taskbar)},
 	{"alert_tray", "TRAY", S_F(alert_tray)},
@@ -182,6 +183,7 @@ typedef struct
 {
 	/* Per-Channel Alerts */
 	/* use a byte, because we need a pointer to each element */
+    guint8 alert_balloon;
 	guint8 alert_beep;
 	guint8 alert_taskbar;
 	guint8 alert_tray;

--- a/src/common/hexchat.c
+++ b/src/common/hexchat.c
@@ -493,6 +493,7 @@ session_new (server *serv, char *from, int type, int focus)
 	sess->logfd = -1;
 	sess->type = type;
 
+    sess->alert_balloon = SET_DEFAULT;
 	sess->alert_beep = SET_DEFAULT;
 	sess->alert_taskbar = SET_DEFAULT;
 	sess->alert_tray = SET_DEFAULT;

--- a/src/common/hexchat.h
+++ b/src/common/hexchat.h
@@ -363,6 +363,7 @@ typedef struct session
 {
 	/* Per-Channel Alerts */
 	/* use a byte, because we need a pointer to each element */
+    guint8 alert_balloon;
 	guint8 alert_beep;
 	guint8 alert_taskbar;
 	guint8 alert_tray;

--- a/src/common/plugin.c
+++ b/src/common/plugin.c
@@ -115,6 +115,34 @@ enum
 	HOOK_DELETED      = 1 << 7  /* marked for deletion */
 };
 
+enum
+{
+    CHANNEL_FLAG_CONNECTED             = 1 << 0,
+    CHANNEL_FLAG_CONNECING             = 1 << 1,
+    CHANNEL_FLAG_AWAY                  = 1 << 2,
+    CHANNEL_FLAG_END_OF_MOTD           = 1 << 3,
+    CHANNEL_FLAG_HAS_WHOX              = 1 << 4,
+    CHANNEL_FLAG_HAS_IDMSG             = 1 << 5,
+    CHANNEL_FLAG_HIDE_JOIN_PARTS       = 1 << 6,
+    CHANNEL_FLAG_HIDE_JOIN_PARTS_UNSET = 1 << 7,
+    CHANNEL_FLAG_BEEP                  = 1 << 8,
+    CHANNEL_FLAG_BEEP_UNSET            = 1 << 9,
+    CHANNEL_FLAG_UNUSED                = 1 << 10,
+    CHANNEL_FLAG_LOGGING               = 1 << 11,
+    CHANNEL_FLAG_LOGGING_UNSET         = 1 << 12,
+    CHANNEL_FLAG_SCROLLBACK            = 1 << 13,
+    CHANNEL_FLAG_SCROLLBACK_UNSET      = 1 << 14,
+    CHANNEL_FLAG_STRIP_COLORS          = 1 << 15,
+    CHANNEL_FLAG_STRIP_COLORS_UNSET    = 1 << 16,
+    CHANNEL_FLAG_TRAY                  = 1 << 17,
+    CHANNEL_FLAG_TRAY_UNSET            = 1 << 18,
+    CHANNEL_FLAG_TASKBAR               = 1 << 19,
+    CHANNEL_FLAG_TASKBAR_UNSET         = 1 << 20,
+    CHANNEL_FLAG_BALLOON               = 1 << 21,
+    CHANNEL_FLAG_BALLOON_UNSET         = 1 << 22,
+    CHANNEL_FLAG_COUNT                 = 23
+};
+
 GSList *plugin_list = NULL;	/* export for plugingui.c */
 static GSList *hook_list = NULL;
 
@@ -1521,7 +1549,11 @@ hexchat_list_int (hexchat_plugin *ph, hexchat_list *xlist, const char *name)
 {
 	guint32 hash = str_hash (name);
 	gpointer data = ph->context;
-	int tmp = 0;
+
+    int channel_flag;
+	int channel_flags[CHANNEL_FLAG_COUNT];
+	int channel_flags_flag = 0;
+
 	int type = LIST_CHANNELS;
 
 	/* a NULL xlist is a shortcut to current "channels" context */
@@ -1582,48 +1614,38 @@ hexchat_list_int (hexchat_plugin *ph, hexchat_list *xlist, const char *name)
 		case 0xd1b:	/* id */
 			return ((struct session *)data)->server->id;
 		case 0x5cfee87:	/* flags */
-			/* used if alert_taskbar is unset */                 /* 20 */
-			tmp <<= 1;
-			tmp |= ((struct session *)data)->alert_taskbar;      /* 19 */
-			tmp <<= 1;
-			/* used if alert_tray is unset */                    /* 18 */
-			tmp <<= 1;
-			tmp |= ((struct session *)data)->alert_tray;         /* 17 */
-			tmp <<= 1;
-			/* used if text_strip is unset */                    /* 16 */
-			tmp <<= 1;
-			tmp |= ((struct session *)data)->text_strip;          /* 15 */
-			tmp <<= 1;
-			/* used if text_scrollback is unset */               /* 14 */
-			tmp <<= 1;
-			tmp |= ((struct session *)data)->text_scrollback;    /* 13 */
-			tmp <<= 1;
-			/* used if text_logging is unset */                  /* 12 */
-			tmp <<= 1;
-			tmp |= ((struct session *)data)->text_logging;       /* 11 */
-			tmp <<= 1;
-			/* unused for historical reasons */                  /* 10 */
-			tmp <<= 1;
-			/* used if alert_beep is unset */                    /* 9 */
-			tmp <<= 1;
-			tmp |= ((struct session *)data)->alert_beep;         /* 8 */
-			tmp <<= 1;
-			/* used if text_hidejoinpart is unset */              /* 7 */
-			tmp <<= 1;
-			tmp |= ((struct session *)data)->text_hidejoinpart;   /* 6 */
-			tmp <<= 1;
-			tmp |= ((struct session *)data)->server->have_idmsg; /* 5 */
-			tmp <<= 1;
-			tmp |= ((struct session *)data)->server->have_whox;  /* 4 */
-			tmp <<= 1;
-			tmp |= ((struct session *)data)->server->end_of_motd;/* 3 */
-			tmp <<= 1;
-			tmp |= ((struct session *)data)->server->is_away;    /* 2 */
-			tmp <<= 1;
-			tmp |= ((struct session *)data)->server->connecting; /* 1 */ 
-			tmp <<= 1;
-			tmp |= ((struct session *)data)->server->connected;  /* 0 */
-			return tmp;
+            channel_flags[0] = ((struct session *)data)->server->connected;
+            channel_flags[1] = ((struct session *)data)->server->connecting;
+            channel_flags[2] = ((struct session *)data)->server->is_away;
+            channel_flags[3] = ((struct session *)data)->server->end_of_motd;
+            channel_flags[4] = ((struct session *)data)->server->have_whox;
+            channel_flags[5] = ((struct session *)data)->server->have_idmsg;
+            channel_flags[6] = ((struct session *)data)->text_hidejoinpart;
+            channel_flags[7] = ((struct session *)data)->text_hidejoinpart == SET_DEFAULT;
+            channel_flags[8] = ((struct session *)data)->alert_beep;
+            channel_flags[9] = ((struct session *)data)->alert_beep == SET_DEFAULT;
+            channel_flags[10] = 0; /* unused for historical reasons */
+            channel_flags[11] = ((struct session *)data)->text_logging;
+            channel_flags[12] = ((struct session *)data)->text_logging == SET_DEFAULT;
+            channel_flags[13] = ((struct session *)data)->text_scrollback;
+            channel_flags[14] = ((struct session *)data)->text_scrollback == SET_DEFAULT;
+            channel_flags[15] = ((struct session *)data)->text_strip;
+            channel_flags[16] = ((struct session *)data)->text_strip == SET_DEFAULT;
+            channel_flags[17] = ((struct session *)data)->alert_tray;
+            channel_flags[18] = ((struct session *)data)->alert_tray == SET_DEFAULT;
+            channel_flags[19] = ((struct session *)data)->alert_taskbar;
+            channel_flags[20] = ((struct session *)data)->alert_taskbar == SET_DEFAULT;
+            channel_flags[21] = ((struct session *)data)->alert_balloon;
+            channel_flags[22] = ((struct session *)data)->alert_balloon == SET_DEFAULT;
+
+            /* Set flags */
+            for (channel_flag = 0; channel_flag < CHANNEL_FLAG_COUNT; ++channel_flag) {
+                if (channel_flags[channel_flag]) {
+                    channel_flags_flag |= 1 << channel_flag;
+                }
+            }
+
+			return channel_flags_flag;
 		case 0x1a192: /* lag */
 			return ((struct session *)data)->server->lag;
 		case 0x1916144c: /* maxmodes */

--- a/src/fe-gtk/maingui.c
+++ b/src/fe-gtk/maingui.c
@@ -1519,15 +1519,33 @@ mg_create_perchannelmenu (session *sess, GtkWidget *menu)
 static void
 mg_create_alertmenu (session *sess, GtkWidget *menu)
 {
-	GtkWidget *submenu;
+    GtkWidget *submenu;
+    int hex_balloon, hex_beep, hex_tray, hex_flash;
 
-	submenu = menu_quick_sub (_("_Extra Alerts"), menu, NULL, XCMENU_MNEMONIC, -1);
 
-	mg_perchan_menu_item (_("Beep on _Message"), submenu, &sess->alert_beep, prefs.hex_input_beep_chans);
+    switch (sess->type) {
+        case SESS_DIALOG:
+            hex_balloon = prefs.hex_input_balloon_priv;
+            hex_beep = prefs.hex_input_beep_priv;
+            hex_tray = prefs.hex_input_tray_priv;
+            hex_flash = prefs.hex_input_flash_priv;
+            break;
+        default:
+            hex_balloon = prefs.hex_input_balloon_chans;
+            hex_beep = prefs.hex_input_beep_chans;
+            hex_tray = prefs.hex_input_tray_chans;
+            hex_flash = prefs.hex_input_flash_chans;
+    }
 
-	mg_perchan_menu_item (_("Blink Tray _Icon"), submenu, &sess->alert_tray, prefs.hex_input_tray_chans);
+    submenu = menu_quick_sub(_("_Extra Alerts"), menu, NULL, XCMENU_MNEMONIC, -1);
 
-	mg_perchan_menu_item (_("Blink Task _Bar"), submenu, &sess->alert_taskbar, prefs.hex_input_flash_chans);
+    mg_perchan_menu_item(_("Show Notifications"), submenu, &sess->alert_balloon, hex_balloon);
+
+    mg_perchan_menu_item(_("Beep on _Message"), submenu, &sess->alert_beep, hex_beep);
+
+    mg_perchan_menu_item(_("Blink Tray _Icon"), submenu, &sess->alert_tray, hex_tray);
+
+    mg_perchan_menu_item(_("Blink Task _Bar"), submenu, &sess->alert_taskbar, hex_flash);
 }
 
 static void

--- a/src/fe-gtk/plugin-notification.c
+++ b/src/fe-gtk/plugin-notification.c
@@ -25,6 +25,9 @@
 
 static hexchat_plugin *ph;
 
+const int CHANNEL_FLAG_BALLOON       = 1 << 21;
+const int CHANNEL_FLAG_BALLOON_UNSET = 1 << 22;
+
 static gboolean
 should_alert (void)
 {
@@ -116,21 +119,50 @@ incoming_hilight_cb (char *word[], gpointer userdata)
 static int
 incoming_message_cb (char *word[], gpointer userdata)
 {
-	int message;
+    int message;
+    int flags;
+    int alert = 0;
 
-	if (hexchat_get_prefs (ph, "input_balloon_chans", NULL, &message) == 3 && message && should_alert ())
-	{
-		show_notificationf (word[2], _("Channel message from: %s (%s)"), word[1], hexchat_get_info (ph, "channel"));
-	}
-	return HEXCHAT_EAT_NONE;
+    flags = hexchat_list_int(ph, NULL, "flags");
+
+    /* Let sure that can alert */
+    if (should_alert()) {
+        /* Follow the channel rules if set */
+        if (!(flags & CHANNEL_FLAG_BALLOON_UNSET)) {
+            alert = (flags & CHANNEL_FLAG_BALLOON);
+        } else {
+            /* Else follow global environment */
+            alert = (hexchat_get_prefs(ph, "input_balloon_chans", NULL, &message) == 3 && message);
+        }
+    }
+
+    if (alert) {
+        show_notificationf(word[2], _("Channel message from: %s (%s)"), word[1], hexchat_get_info(ph, "channel"));
+    }
+    return HEXCHAT_EAT_NONE;
 }
 
 static int
 incoming_priv_cb (char *word[], gpointer userdata)
 {
 	int priv;
+	int flags;
+    int alert = 0;
 
-	if (hexchat_get_prefs (ph, "input_balloon_priv", NULL, &priv) == 3 && priv && should_alert ())
+    flags = hexchat_list_int(ph, NULL, "flags");
+
+    /* Let sure that can alert */
+    if (should_alert()) {
+        /* Follow the private rules if set */
+        if (!(flags & CHANNEL_FLAG_BALLOON_UNSET)) {
+            alert = (flags & CHANNEL_FLAG_BALLOON);
+        } else {
+            /* Else follow global environment */
+            alert = (hexchat_get_prefs(ph, "input_balloon_priv", NULL, &priv) == 3 && priv);
+        }
+    }
+
+	if (alert)
 	{
 		const char *network = hexchat_get_info (ph, "network");
 		if (!network)


### PR DESCRIPTION
Hi @TingPing,

I implemented the flow of notifications for channels as we accorded:

Flow:

1. You can control the notifications in a global environment
2. chanopts per each channel/pm/network MUST be followed overloading any other setting

Related: https://github.com/hexchat/hexchat/issues/876 https://github.com/hexchat/hexchat/issues/1172

Regards.