### PR TITLE
Hide Focus Channel when the selected channel is already focussed

### DIFF
--- a/src/fe-gtk/menu.c
+++ b/src/fe-gtk/menu.c
@@ -1030,8 +1030,11 @@ menu_chanmenu (struct session *sess, GdkEventButton * event, char *chan)
 {
 	GtkWidget *menu;
 	int is_joined = FALSE;
+	session * chan_session;
 
-	if (find_channel (sess->server, chan))
+	chan_session = find_channel (sess->server, chan);
+
+	if (chan_session)
 		is_joined = TRUE;
 
 	g_free (str_copy);
@@ -1047,8 +1050,9 @@ menu_chanmenu (struct session *sess, GdkEventButton * event, char *chan)
 												 str_copy);
 	else
 	{
-		menu_quick_item_with_callback (menu_chan_focus, _("Focus Channel"), menu,
-												 str_copy);
+		if (chan_session != current_sess)
+			menu_quick_item_with_callback (menu_chan_focus, _("Focus Channel"), menu,
+													 str_copy);
 		menu_quick_item_with_callback (menu_chan_part, _("Part Channel"), menu,
 												 str_copy);
 		menu_quick_item_with_callback (menu_chan_cycle, _("Cycle Channel"), menu,


### PR DESCRIPTION
When the channel is focussed, the menu item does nothing so
it isn't useful to have it in the menu.
    
Fixes: commit c361bdca6afdc933eeac35732334464990295cd4
See-also: https://github.com/hexchat/hexchat/pull/2255#issuecomment-475841824