### PR TITLE
Added server entry for ICQ-Chat network to servlist.c

### DIFF
--- a/src/common/servlist.c
+++ b/src/common/servlist.c
@@ -207,6 +207,9 @@ static const struct defaultserver def[] =
 	{"Hashmark",	0},
 	{0,			"irc.hashmark.net"},
 
+	{"ICQ-Chat", 0, 0, 0, LOGIN_SASL, 0, TRUE},
+	{0,			"irc.icq-chat.com/+6697"},
+
 	{"IdleMonkeys", 0},
 	{0,			"irc.idlemonkeys.net"},
 

--- a/src/common/servlist.c
+++ b/src/common/servlist.c
@@ -208,7 +208,7 @@ static const struct defaultserver def[] =
 	{0,			"irc.hashmark.net"},
 
 	{"ICQ-Chat", 0, 0, 0, LOGIN_SASL, 0, TRUE},
-	{0,			"irc.icq-chat.com/+6697"},
+	{0,			"irc.icq-chat.com"},
 
 	{"IdleMonkeys", 0},
 	{0,			"irc.idlemonkeys.net"},


### PR DESCRIPTION
This adds a server entry for the ICQ-Chat IRC network (See https://icq-chat.com)

Note that this server entry is _not_ the discontinued IRC service that was provided by icq.com several years ago.