### PR TITLE
Add 6697 to default server list

### DIFF
--- a/src/common/servlist.c
+++ b/src/common/servlist.c
@@ -53,7 +53,18 @@ static const struct defaultserver def[] =
 	{"2600net",	0},
 	/* Invalid hostname in cert */
 	{0,			"irc.2600.net"},
-
+	
+	{"6697", 0},
+#ifdef USE_OPENSSL
+	/* Certs should never be invalid!!! */
+	{0,			"irc.6697.co.uk/+6697"},
+	{0,			"irc.mystagic.org/+6697"},
+	{0,			"charybdis.mystagic.dev /+6697"},
+	{0,			"irc.jupe.city/+6697"},
+#endif
+	{0,			"irc.6697.co.uk"},
+	{0,			"irc.jupe.city"},
+	
 	{"AccessIRC",	0},
 	/* Self signed */
 	{0,			"irc.accessirc.net"},

--- a/src/common/servlist.c
+++ b/src/common/servlist.c
@@ -59,7 +59,7 @@ static const struct defaultserver def[] =
 	/* Certs should never be invalid!!! */
 	{0,			"irc.6697.co.uk/+6697"},
 	{0,			"irc.mystagic.org/+6697"},
-	{0,			"charybdis.mystagic.dev /+6697"},
+	{0,			"charybdis.mystagic.dev/+6697"},
 	{0,			"irc.jupe.city/+6697"},
 #endif
 	{0,			"irc.6697.co.uk"},


### PR DESCRIPTION
This network has been around for a couple of years and would like to be added to the default server list for hexchat.