### PR TITLE
Add ACN IRC Network

### DIFF
--- a/src/common/servlist.c
+++ b/src/common/servlist.c
@@ -58,7 +58,7 @@ static const struct defaultserver def[] =
 	/* Self signed */
 	{0,			"irc.accessirc.net"},
 
-	{"ACN", 0},
+	{"ACN", 0, 0, 0, LOGIN_SASL, 0, TRUE},
 	{0,			"global.acn.gr"},
 
 	{"AfterNET", 0, 0, 0, LOGIN_SASL, 0, TRUE},

--- a/src/common/servlist.c
+++ b/src/common/servlist.c
@@ -58,6 +58,9 @@ static const struct defaultserver def[] =
 	/* Self signed */
 	{0,			"irc.accessirc.net"},
 
+	{"ACN", 0},
+	{0,			"global.acn.gr"},
+
 	{"AfterNET", 0, 0, 0, LOGIN_SASL, 0, TRUE},
 	{0,			"irc.afternet.org"},
 


### PR DESCRIPTION
Website: https://irc.acn.gr

Round-Robin DNS: global.acn.gr

Ports: 6667 - 6697(ssl only).