### PR TITLE
url.c: add gemini & gopher parsing

### DIFF
--- a/src/common/url.c
+++ b/src/common/url.c
@@ -518,6 +518,8 @@ struct
 	{ "pop",       "/", URI_AUTHORITY | URI_OPT_USERINFO | URI_PATH },
 	{ "nfs",       "/", URI_AUTHORITY | URI_OPT_USERINFO | URI_PATH },
 	{ "smb",       "/", URI_AUTHORITY | URI_OPT_USERINFO | URI_PATH },
+	{ "gopher",    "/", URI_AUTHORITY | URI_PATH },
+	{ "gemini",    "/", URI_AUTHORITY | URI_PATH },
 	{ "ssh",       "",  URI_AUTHORITY | URI_OPT_USERINFO },
 	{ "sip",       "",  URI_AUTHORITY | URI_USERINFO },
 	{ "sips",      "",  URI_AUTHORITY | URI_USERINFO },


### PR DESCRIPTION
This PR adds URL parsing support for two "small-Internet" protocols, [Gemini](https://gemini.circumlunar.space/) and [Gopher](https://en.wikipedia.org/wiki/Gopher_(protocol)). This is especially useful for those of us who discuss these particular protocols over IRC!

Example URLs:
* gemini://gemini.circumlunar.space
* gopher://sdf.org