### PR TITLE
Update _hexchat.py

### DIFF
--- a/plugins/python/_hexchat.py
+++ b/plugins/python/_hexchat.py
@@ -319,7 +319,7 @@ def del_pluginpref(name):
 def list_pluginpref():
     prefs_str = ffi.new('char[4096]')
     if lib.hexchat_pluginpref_list(lib.ph, prefs_str) == 1:
-        return __decode(prefs_str).split(',')
+        return __decode(ffi.string(prefs_str)).split(',')
 
     return []
 


### PR DESCRIPTION
Fixes https://github.com/hexchat/hexchat/issues/2531

On line 322, `__decode` cannot work (with Python3) because `prefs_str` has no attribute `decode`. This error appears when loading the addon `bookmarks.py` if there are saved bookmarks. I suppose that it appears for any add-on getting the content of `add-on_python.conf`.

So, I guess that `ffi` can cast to string what it created. So far so good. An experimented developer should have a look at it before merging.