### PR TITLE
Open links properly if ending with "

### DIFF
--- a/src/fe-gtk/xtext.c
+++ b/src/fe-gtk/xtext.c
@@ -64,7 +64,7 @@
 
 /* is delimiter */
 #define is_del(c) \
-	(c == ' ' || c == '\n' || c == '>' || c == '<' || c == 0)
+	(c == ' ' || c == '\n' || c == '>' || c == '<' || c == 0 || c == '"')
 
 /* force scrolling off */
 #define dontscroll(buf) (buf)->last_pixel_pos = 0x7fffffff


### PR DESCRIPTION
When a link is shown with " at the end, hexchat forwards " with the link into the browser. Which gives then an 404.

