### PR TITLE
Implement support for the IRCv3 account-tag specification.

### DIFF
--- a/src/common/hexchat.h
+++ b/src/common/hexchat.h
@@ -569,6 +569,7 @@ typedef struct server
 	unsigned int have_idmsg:1;		/* freenode's IDENTIFY-MSG */
 	unsigned int have_accnotify:1; /* cap account-notify */
 	unsigned int have_extjoin:1;	/* cap extended-join */
+	unsigned int have_account_tag:1;	/* cap account-tag */
 	unsigned int have_server_time:1;	/* cap server-time */
 	unsigned int have_sasl:1;		/* SASL capability */
 	unsigned int have_except:1;	/* ban exemptions +e */

--- a/src/common/inbound.c
+++ b/src/common/inbound.c
@@ -1671,6 +1671,8 @@ inbound_toggle_caps (server *serv, const char *extensions_str, gboolean enable)
 			serv->have_server_time = enable;
 		else if (!strcmp (extension, "away-notify"))
 			serv->have_awaynotify = enable;
+		else if (!strcmp (extension, "account-tag"))
+			serv->have_account_tag = enable;
 		else if (!strcmp (extension, "sasl"))
 		{
 			serv->have_sasl = enable;
@@ -1726,6 +1728,7 @@ static const char * const supported_caps[] = {
 	"chghost",
 	"setname",
 	"invite-notify",
+	"account-tag",
 
 	/* ZNC */
 	"znc.in/server-time-iso",

--- a/src/common/proto-irc.c
+++ b/src/common/proto-irc.c
@@ -1029,7 +1029,7 @@ process_named_msg (session *sess, char *type, char *word[], char *word_eol[],
 		ex[0] = '!';
 
 		account = tags_data->account && *tags_data->account ? tags_data->account : "*";
-		userlist_set_account (sess, nick, account);
+		inbound_account (serv, nick, account, tags_data);
 	}
 
 	if (len == 4)

--- a/src/common/proto-irc.c
+++ b/src/common/proto-irc.c
@@ -1026,6 +1026,10 @@ process_named_msg (session *sess, char *type, char *word[], char *word_eol[],
 		ex[0] = 0;
 		safe_strcpy (nick, word[1], sizeof (nick));
 		ex[0] = '!';
+
+		if (tags_data->account)
+			inbound_user_info (sess, NULL, NULL, NULL, NULL, nick, NULL,
+							   tags_data->account, 0xff, tags_data);
 	}
 
 	if (len == 4)
@@ -1522,6 +1526,9 @@ handle_message_tags (server *serv, const char *tags_str,
 		*value = '\0';
 		value++;
 
+		if (serv->have_account_tag && !strcmp (key, "account"))
+			tags_data->account = g_strdup (value);
+
 		if (serv->have_server_time && !strcmp (key, "time"))
 			handle_message_tag_time (value, tags_data);
 	}
@@ -1619,7 +1626,14 @@ irc_inline (server *serv, char *buf, int len)
 	}
 
 xit:
+	message_tags_data_free (&tags_data);
 	g_free (pdibuf);
+}
+
+void
+message_tags_data_free (message_tags_data *tags_data)
+{
+	g_free (tags_data->account);
 }
 
 void

--- a/src/common/proto-irc.c
+++ b/src/common/proto-irc.c
@@ -1010,6 +1010,7 @@ process_named_msg (session *sess, char *type, char *word[], char *word_eol[],
 						 const message_tags_data *tags_data)
 {
 	server *serv = sess->server;
+	char *account;
 	char ip[128], nick[NICKLEN];
 	char *text, *ex;
 	int len = strlen (type);
@@ -1027,9 +1028,8 @@ process_named_msg (session *sess, char *type, char *word[], char *word_eol[],
 		safe_strcpy (nick, word[1], sizeof (nick));
 		ex[0] = '!';
 
-		if (tags_data->account)
-			inbound_user_info (sess, NULL, NULL, NULL, NULL, nick, NULL,
-							   tags_data->account, 0xff, tags_data);
+		account = tags_data->account && *tags_data->account ? tags_data->account : "*";
+		userlist_set_account (sess, nick, account);
 	}
 
 	if (len == 4)

--- a/src/common/proto-irc.c
+++ b/src/common/proto-irc.c
@@ -1633,7 +1633,7 @@ xit:
 void
 message_tags_data_free (message_tags_data *tags_data)
 {
-	g_free (tags_data->account);
+	g_clear_pointer (&tags_data->account, g_free);
 }
 
 void

--- a/src/common/proto-irc.c
+++ b/src/common/proto-irc.c
@@ -1027,7 +1027,12 @@ process_named_msg (session *sess, char *type, char *word[], char *word_eol[],
 		ex[0] = 0;
 		safe_strcpy (nick, word[1], sizeof (nick));
 		ex[0] = '!';
+	}
 
+
+	/** Update the account for this message's source. */
+	if (serv->have_account_tag)
+	{
 		account = tags_data->account && *tags_data->account ? tags_data->account : "*";
 		inbound_account (serv, nick, account, tags_data);
 	}

--- a/src/common/proto-irc.h
+++ b/src/common/proto-irc.h
@@ -25,6 +25,7 @@
 
 #define MESSAGE_TAGS_DATA_INIT			\
 	{									\
+		NULL, /* account name */		\
 		(time_t)0, /* timestamp */		\
 	}
 
@@ -36,8 +37,11 @@
  */
 typedef struct 
 {
+	char *account;
 	time_t timestamp;
 } message_tags_data;
+
+void message_tags_data_free (message_tags_data *tags_data);
 
 void proto_fill_her_up (server *serv);
 

--- a/src/common/server.c
+++ b/src/common/server.c
@@ -1784,6 +1784,7 @@ server_set_defaults (server *serv)
 	serv->have_idmsg = FALSE;
 	serv->have_accnotify = FALSE;
 	serv->have_extjoin = FALSE;
+	serv->have_account_tag = FALSE;
 	serv->have_server_time = FALSE;
 	serv->have_sasl = FALSE;
 	serv->have_except = FALSE;

--- a/src/common/userlist.c
+++ b/src/common/userlist.c
@@ -101,13 +101,17 @@ userlist_set_account (struct session *sess, char *nick, char *account)
 	user = userlist_find (sess, nick);
 	if (user)
 	{
-		g_free (user->account);
-			
 		if (strcmp (account, "*") == 0)
+		{
+			g_free (user->account);
 			user->account = NULL;
-		else
+		}
+		else if (g_strcmp0 (user->account, account))
+		{
+			g_free (user->account);
 			user->account = g_strdup (account);
-			
+		}
+
 		/* gui doesnt currently reflect login status, maybe later
 		fe_userlist_rehash (sess, user); */
 	}

--- a/src/common/userlist.c
+++ b/src/common/userlist.c
@@ -103,10 +103,8 @@ userlist_set_account (struct session *sess, char *nick, char *account)
 	{
 		if (strcmp (account, "*") == 0)
 		{
-			g_free (user->account);
-			user->account = NULL;
-		}
-		else if (g_strcmp0 (user->account, account))
+			g_clear_pointer (&user->account, g_free);
+		} else if (g_strcmp0 (user->account, account))
 		{
 			g_free (user->account);
 			user->account = g_strdup (account);


### PR DESCRIPTION
Exactly what it says on the tin.

This probably conflicts with #2571 but I can resolve that if necessary.

---

One thing that could be improved with this is unsetting the user's account if the cap is enabled but the tag isn't sent. I'm reasonably sure that this is possible but I haven't verified that all servers send the tag on all messages yet.