### PR TITLE
Add a workaround for icons not scaling right on HiDPI screens.

### DIFF
--- a/src/fe-gtk/pixmaps.c
+++ b/src/fe-gtk/pixmaps.c
@@ -111,8 +111,8 @@ load_pixmap (const char *filename)
 		iscale = atoi (scale);
 		if (iscale >= 0)
 		{
-			scaledpixbuf = gdk_pixbuf_scale_simple (pixbuf, gdk_pixbuf_get_height (pixbuf) * iscale,
-				gdk_pixbuf_get_width (pixbuf) * iscale, GDK_INTERP_BILINEAR);
+			scaledpixbuf = gdk_pixbuf_scale_simple (pixbuf, gdk_pixbuf_get_width (pixbuf) * iscale,
+				gdk_pixbuf_get_height (pixbuf) * iscale, GDK_INTERP_BILINEAR);
 
 			g_object_unref (pixbuf);
 			pixbuf = scaledpixbuf;

--- a/src/fe-gtk/pixmaps.c
+++ b/src/fe-gtk/pixmaps.c
@@ -114,8 +114,11 @@ load_pixmap (const char *filename)
 			scaledpixbuf = gdk_pixbuf_scale_simple (pixbuf, gdk_pixbuf_get_width (pixbuf) * iscale,
 				gdk_pixbuf_get_height (pixbuf) * iscale, GDK_INTERP_BILINEAR);
 
-			g_object_unref (pixbuf);
-			pixbuf = scaledpixbuf;
+			if (scaledpixbuf)
+			{
+				g_object_unref (pixbuf);
+				pixbuf = scaledpixbuf;
+			}
 		}
 	}
 

--- a/src/fe-gtk/pixmaps.c
+++ b/src/fe-gtk/pixmaps.c
@@ -89,7 +89,9 @@ pixmap_load_from_file (char *filename)
 static GdkPixbuf *
 load_pixmap (const char *filename)
 {
-	GdkPixbuf *pixbuf;
+	GdkPixbuf *pixbuf, *scaledpixbuf;
+	const char *scale;
+	int iscale;
 
 	gchar *path = g_strdup_printf ("%s" G_DIR_SEPARATOR_S "icons" G_DIR_SEPARATOR_S "%s.png", get_xdir (), filename);
 	pixbuf = gdk_pixbuf_new_from_file (path, 0);
@@ -100,6 +102,21 @@ load_pixmap (const char *filename)
 		path = g_strdup_printf ("/icons/%s.png", filename);
 		pixbuf = gdk_pixbuf_new_from_resource (path, NULL);
 		g_free (path);
+	}
+
+	// Hack to avoid unbearably tiny icons on HiDPI screens.
+	scale = getenv ("GDK_SCALE");
+	if (scale)
+	{
+		iscale = atoi (scale);
+		if (iscale >= 0)
+		{
+			scaledpixbuf = gdk_pixbuf_scale_simple (pixbuf, gdk_pixbuf_get_height (pixbuf) * iscale,
+				gdk_pixbuf_get_width (pixbuf) * iscale, GDK_INTERP_BILINEAR);
+
+			g_object_unref (pixbuf);
+			pixbuf = scaledpixbuf;
+		}
 	}
 
 	g_warn_if_fail (pixbuf != NULL);

--- a/src/fe-gtk/pixmaps.c
+++ b/src/fe-gtk/pixmaps.c
@@ -105,11 +105,11 @@ load_pixmap (const char *filename)
 	}
 
 	// Hack to avoid unbearably tiny icons on HiDPI screens.
-	scale = getenv ("GDK_SCALE");
+	scale = g_getenv ("GDK_SCALE");
 	if (scale)
 	{
 		iscale = atoi (scale);
-		if (iscale >= 0)
+		if (iscale > 0)
 		{
 			scaledpixbuf = gdk_pixbuf_scale_simple (pixbuf, gdk_pixbuf_get_width (pixbuf) * iscale,
 				gdk_pixbuf_get_height (pixbuf) * iscale, GDK_INTERP_BILINEAR);


### PR DESCRIPTION
Currently on Linux (Ubuntu 21.04 in my case) HiDPI screens icons are not rendered at the correct size. This is problematic if you have a HiDPI screen because icons are just completely invisible. Unfortunately because HexChat uses GTK2 it's not really possible to automatically scale to the screen resolution so this patch adds a workaround by having it check a common environment variable used for UI scaling in GDK3 and then scaling the icons by that size on load.

Without this patch on my system:

![Screenshot from 2021-05-23 07-44-08](https://user-images.githubusercontent.com/1565825/119251041-32698300-bb9c-11eb-8791-4f5f07eaf58f.png)

With this patch and GDK_SCALE=3 set in the environment on my system:

![Screenshot from 2021-05-23 07-43-27](https://user-images.githubusercontent.com/1565825/119251042-32698300-bb9c-11eb-8847-45f33f48d795.png)

If anyone can recommend a better way of doing this then I'll be happy to change this.