### PR TITLE
Parse the output of the 005 numeric correctly.

### DIFF
--- a/src/common/modes.c
+++ b/src/common/modes.c
@@ -891,7 +891,7 @@ inbound_005 (server * serv, char *word[], const message_tags_data *tags_data)
 			serv->supports_monitor = tokadding;
 		} else if (g_strcmp0 (tokname, "NETWORK") == 0)
 		{
-			if (serv->server_session->type == SESS_SERVER)
+			if (serv->server_session->type == SESS_SERVER && strlen (tokvalue))
 			{
 				safe_strcpy (serv->server_session->channel, tokvalue, CHANLEN);
 				fe_set_channel (serv->server_session);

--- a/src/common/modes.c
+++ b/src/common/modes.c
@@ -825,7 +825,7 @@ parse_005_token (const char *token, char **name, char **value, gboolean *adding)
 				for (idx = 0; idx < 4; ++idx)
 				{
 					/* We need to do this to avoid jumping past the end of the array. */
-					if (toksplit)
+					if (*toksplit)
 						toksplit++;
 				}
 			} else

--- a/src/common/modes.c
+++ b/src/common/modes.c
@@ -798,7 +798,7 @@ parse_005_token (const char *token, char **name, char **value, gboolean *adding)
 
 	if (token[0] == '-')
 	{
-		adding = FALSE;
+		*adding = FALSE;
 		token++;
 	} else
 	{

--- a/src/common/modes.c
+++ b/src/common/modes.c
@@ -792,7 +792,7 @@ hex_to_chr(char chr)
 }
 
 static void
-parse_005_token (const char *token, char **name, char** value, gboolean* adding)
+parse_005_token (const char *token, char **name, char **value, gboolean *adding)
 {
 	char *toksplit, *valuecurr;
 

--- a/src/common/modes.c
+++ b/src/common/modes.c
@@ -795,6 +795,7 @@ static void
 parse_005_token (const char *token, char **name, char **value, gboolean *adding)
 {
 	char *toksplit, *valuecurr;
+	size_t idx;
 
 	if (token[0] == '-')
 	{
@@ -821,7 +822,12 @@ parse_005_token (const char *token, char **name, char **value, gboolean *adding)
 				if (toksplit[1] == 'x' && g_ascii_isxdigit (toksplit[2]) && g_ascii_isxdigit (toksplit[3]))
 					*valuecurr++ = hex_to_chr (toksplit[2]) << 4 | hex_to_chr (toksplit[3]);
 
-				toksplit += 4;
+				for (idx = 0; idx < 4; ++idx)
+				{
+					/* We need to do this to avoid jumping past the end of the array. */
+					if (toksplit)
+						toksplit++;
+				}
 			} else
 			{
 				/** Non-escape characters can be copied as is. */


### PR DESCRIPTION
This implements support for the full 005 numeric syntax including negation and value escapes as defined in [draft-hardy-irc-isupport-00](https://datatracker.ietf.org/doc/html/draft-hardy-irc-isupport-00). This fixes HexChat on servers that:

1. Have unloaded a previously supported feature at runtime (e.g. unloading the monitor module in InspIRCd removing the MONITOR token).
2. Have escaped spaces in the network name (see testnet.inspircd.org for an example of this).
3. Send a value for a token where HexChat expects none (e.g. INVEX on InspIRCd &mdash; the value for this token is optional) or vice versa.