### PR TITLE
Replace identify-msg support with solanum.chat/identify-msg.

### DIFF
--- a/plugins/fishlim/plugin_hexchat.c
+++ b/plugins/fishlim/plugin_hexchat.c
@@ -418,8 +418,6 @@ static int handle_keyx_notice(char *word[], char *word_eol[], void *userdata) {
         g_assert(hexchat_set_context(ph, query_ctx) == 1);
 
     dh_message++; /* : prefix */
-    if (*dh_message == '+' || *dh_message == '-')
-        dh_message++; /* identify-msg */
 
     if (g_strcmp0 (word[6], "CBC") == 0)
         mode = FISH_CBC_MODE;

--- a/src/common/ctcp.c
+++ b/src/common/ctcp.c
@@ -94,9 +94,6 @@ ctcp_handle (session *sess, char *to, char *nick, char *ip,
 	char outbuf[1024];
 	int ctcp_offset = 2;
 
-	if (serv->have_idmsg && (word[4][1] == '+' || word[4][1] == '-') )
-			ctcp_offset = 3;
-
 	/* consider DCC to be different from other CTCPs */
 	if (!g_ascii_strncasecmp (msg, "DCC", 3))
 	{
@@ -129,7 +126,7 @@ ctcp_handle (session *sess, char *to, char *nick, char *ip,
 		if (ctcp_check (sess, nick, word, word_eol, word[4] + ctcp_offset))
 			goto generic;
 
-		inbound_action (sess, to, nick, ip, msg + 7, FALSE, id, tags_data);
+		inbound_action (sess, to, nick, ip, msg + 7, FALSE, tags_data->identified, tags_data);
 		return;
 	}
 

--- a/src/common/hexchat.h
+++ b/src/common/hexchat.h
@@ -567,7 +567,7 @@ typedef struct server
 	unsigned int have_awaynotify:1;
 	unsigned int have_uhnames:1;
 	unsigned int have_whox:1;		/* have undernet's WHOX features */
-	unsigned int have_idmsg:1;		/* freenode's IDENTIFY-MSG */
+	unsigned int have_idmsg:1;		/* cap solanum.chat/identify-msg */
 	unsigned int have_accnotify:1; /* cap account-notify */
 	unsigned int have_extjoin:1;	/* cap extended-join */
 	unsigned int have_account_tag:1;	/* cap account-tag */

--- a/src/common/inbound.c
+++ b/src/common/inbound.c
@@ -190,7 +190,7 @@ inbound_privmsg (server *serv, char *from, char *ip, char *text, int id,
 
 		if (ip && ip[0])
 			set_topic (sess, ip, ip);
-		inbound_chanmsg (serv, NULL, NULL, from, text, FALSE, id, tags_data);
+		inbound_chanmsg (serv, NULL, NULL, from, text, FALSE, tags_data->identified, tags_data);
 		return;
 	}
 
@@ -1656,7 +1656,7 @@ inbound_toggle_caps (server *serv, const char *extensions_str, gboolean enable)
 	{
 		const char *extension = extensions[i];
 
-		if (!strcmp (extension, "identify-msg"))
+		if (!strcmp (extension, "solanum.chat/identify-msg"))
 			serv->have_idmsg = enable;
 		else if (!strcmp (extension, "multi-prefix"))
 			serv->have_namesx = enable;
@@ -1713,8 +1713,6 @@ inbound_cap_del (server *serv, char *nick, char *extensions,
 }
 
 static const char * const supported_caps[] = {
-	"identify-msg",
-
 	/* IRCv3.1 */
 	"multi-prefix",
 	"away-notify",
@@ -1737,6 +1735,9 @@ static const char * const supported_caps[] = {
 
 	/* Twitch */
 	"twitch.tv/membership",
+
+	/* Solanum */
+	"solanum.chat/identify-msg",
 };
 
 static int

--- a/src/common/proto-irc.h
+++ b/src/common/proto-irc.h
@@ -26,6 +26,7 @@
 #define MESSAGE_TAGS_DATA_INIT			\
 	{									\
 		NULL, /* account name */		\
+		FALSE, /* identified to nick */ \
 		(time_t)0, /* timestamp */		\
 	}
 
@@ -38,6 +39,7 @@
 typedef struct 
 {
 	char *account;
+	gboolean identified;
 	time_t timestamp;
 } message_tags_data;
 


### PR DESCRIPTION
Now that freenode has committed suicide there's no significant users of ircd-seven. This means that there's essentially no point to supporting the ircd-seven specific identify-msg cap.

However, the successor to ircd-seven, Solanum, which is currently used by Libera Chat and will be used by OFTC in the future has a replacement for it which uses a cap instead of message prefix which removes the need do the messy character skipping logic. Cool!