### PR TITLE
Re-Add Furnet

### DIFF
--- a/src/common/servlist.c
+++ b/src/common/servlist.c
@@ -152,6 +152,9 @@ static const struct defaultserver def[] =
 	/* Self signed */
 	{0,			"irc.fdfnet.net"},
 
+	{"Furnet", 0, 0, 0, 0, 0, TRUE},
+	{0,			"irc.furnet.org"},
+	
 	{"GameSurge", 0},
 	{0,			"irc.gamesurge.net"},
 


### PR DESCRIPTION
This network seems to have been removed from the list because of a malicious misconception, I am proposing to re-add it for discoverability purposes.

Please feel free to accept or deny this PR as you wish, this isn't meant to be a point of contention