### PR TITLE
Avoid direct use of libproxy

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -33,7 +33,6 @@ config_h.set10('ENABLE_NLS', true)
 
 # Optional features
 config_h.set('USE_OPENSSL', get_option('with-ssl'))
-config_h.set('USE_LIBPROXY', get_option('with-libproxy'))
 config_h.set('USE_LIBCANBERRA', get_option('with-libcanberra'))
 config_h.set('USE_DBUS', get_option('with-dbus'))
 config_h.set('USE_PLUGIN', get_option('with-plugin'))

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -13,9 +13,6 @@ option('with-plugin', type: 'boolean',
 option('with-dbus', type: 'boolean',
   description: 'Support used for single-instance and scripting interface, Unix only'
 )
-option('with-libproxy', type: 'boolean',
-  description: 'Support for getting proxy information, Unix only'
-)
 option('with-libnotify', type: 'boolean',
   description: 'Support for freedesktop notifications, Unix only'
 )

--- a/src/common/hexchat.c
+++ b/src/common/hexchat.c
@@ -57,10 +57,6 @@
 #include <glib-object.h>			/* for g_type_init() */
 #endif
 
-#ifdef USE_LIBPROXY
-#include <proxy.h>
-#endif
-
 GSList *popup_list = 0;
 GSList *button_list = 0;
 GSList *dlgbutton_list = 0;
@@ -110,10 +106,6 @@ gint arg_existing = FALSE;
 struct session *current_tab;
 struct session *current_sess = 0;
 struct hexchatprefs prefs;
-
-#ifdef USE_LIBPROXY
-pxProxyFactory *libproxy_factory;
-#endif
 
 /*
  * Update the priority queue of the "interesting sessions"
@@ -1102,10 +1094,6 @@ main (int argc, char *argv[])
 	hexchat_remote ();
 #endif
 
-#ifdef USE_LIBPROXY
-	libproxy_factory = px_proxy_factory_new ();
-#endif
-
 #ifdef WIN32
 	coinit_result = CoInitializeEx (NULL, COINIT_APARTMENTTHREADED);
 	if (SUCCEEDED (coinit_result))
@@ -1146,10 +1134,6 @@ main (int argc, char *argv[])
 	{
 		CoUninitialize ();
 	}
-#endif
-
-#ifdef USE_LIBPROXY
-	px_proxy_factory_free (libproxy_factory);
 #endif
 
 #ifdef WIN32

--- a/src/common/meson.build
+++ b/src/common/meson.build
@@ -77,10 +77,6 @@ if get_option('with-ssl')
   common_deps += libssl_dep
 endif
 
-if get_option('with-libproxy')
-  common_deps += dependency('libproxy-1.0')
-endif
-
 if get_option('with-libcanberra')
   common_deps += dependency('libcanberra', version: '>= 0.22')
 endif

--- a/src/common/server.c
+++ b/src/common/server.c
@@ -61,10 +61,6 @@
 #include "ssl.h"
 #endif
 
-#ifdef USE_LIBPROXY
-#include <proxy.h>
-#endif
-
 #ifdef USE_OPENSSL
 /* local variables */
 static struct session *g_sess = NULL;
@@ -78,9 +74,15 @@ static void server_disconnect (session * sess, int sendquit, int err);
 static int server_cleanup (server * serv);
 static void server_connect (server *serv, char *hostname, int port, int no_login);
 
-#ifdef USE_LIBPROXY
-extern pxProxyFactory *libproxy_factory;
-#endif
+static void
+write_error (char *message, GError **error)
+{
+	if (error == NULL || *error == NULL) {
+		return;
+	}
+	g_printerr ("%s: %s\n", message, (*error)->message);
+	g_clear_error (error);
+}
 
 /* actually send to the socket. This might do a character translation or
    send via SSL. server/dcc both use this function. */
@@ -1392,14 +1394,16 @@ server_child (server * serv)
 
 	if (!serv->dont_use_proxy) /* blocked in serverlist? */
 	{
-#ifdef USE_LIBPROXY
 		if (prefs.hex_net_proxy_type == 5)
 		{
 			char **proxy_list;
 			char *url, *proxy;
+			GProxyResolver *resolver;
+			GError *error = NULL;
 
+			resolver = g_proxy_resolver_get_default ();
 			url = g_strdup_printf ("irc://%s:%d", hostname, port);
-			proxy_list = px_proxy_factory_get_proxies (libproxy_factory, url);
+			proxy_list = g_proxy_resolver_lookup (resolver, url, NULL, &error);
 
 			if (proxy_list) {
 				/* can use only one */
@@ -1412,6 +1416,8 @@ server_child (server * serv)
 					proxy_type = 3;
 				else if (!strncmp (proxy, "socks", 5))
 					proxy_type = 2;
+			} else {
+				write_error ("Failed to lookup proxy", &error);
 			}
 
 			if (proxy_type) {
@@ -1426,7 +1432,7 @@ server_child (server * serv)
 			g_strfreev (proxy_list);
 			g_free (url);
 		}
-#endif
+
 		if (prefs.hex_net_proxy_host[0] &&
 			   prefs.hex_net_proxy_type > 0 &&
 			   prefs.hex_net_proxy_use != 2) /* proxy is NOT dcc-only */

--- a/src/fe-gtk/setup.c
+++ b/src/fe-gtk/setup.c
@@ -614,9 +614,7 @@ static const char *const proxytypes[] =
 	N_("SOCKS4"),
 	N_("SOCKS5"),
 	N_("HTTP"),
-#ifdef USE_LIBPROXY
 	N_("Auto"),
-#endif
 	NULL
 };
 


### PR DESCRIPTION
Since hexchat already depends on GLib, it's better to use GProxyResolver
instead. This might use libproxy, or not, as appropriate.

P.S. This removes a memory safety issue because proxy_list is allocated
using malloc(), not g_malloc(), and therefore using g_strfreev() is
incorrect. The proper way to free the proxy list returned by libproxy
is to use px_proxy_factory_free_proxies() (but nobody does that because
it was added in libproxy 0.4.16, which is somewhat recent).

Note: libproxy is not used by default. It's only used if the proxy type setting in Preferences is switched to Auto, i.e. `net_proxy_type = 5` in hexchat.conf. I didn't test hexchat with an actual proxy server (who uses proxies in 2021?) but I did test that the proxy variables in server_child() get set properly by adding a debug print:

```
diff --git a/src/common/server.c b/src/common/server.c
index c2a046e6..7afaa375 100644
--- a/src/common/server.c
+++ b/src/common/server.c
@@ -1429,6 +1429,7 @@ server_child (server * serv)
                                *c = '\0';
                                proxy_port = atoi (c + 1);
                        }
+g_warning ("Decided to use proxy %s (%d)", proxy, proxy_type);
 
                        g_strfreev (proxy_list);
                        g_free (url);
```

By default it looks like this:

```
** (hexchat:30991): WARNING **: 08:51:06.601: Decided to use proxy direct:// (0)
```

No proxy, everything works fine. But if I sabotage my GNOME HTTP proxy settings to use http://127.0.0.1 (I didn't try an actual proxy server), then hexchat fails to connect and my debug prints this instead:

```
** (hexchat:31206): WARNING **: 08:51:35.485: Decided to use proxy http://127.0.0.1:8080 (4)
```

Seems good.