### PR TITLE
Remove some weird guesswork on the 004 numeric.

### DIFF
--- a/src/common/modes.c
+++ b/src/common/modes.c
@@ -67,8 +67,8 @@ send_channel_modes (session *sess, char *tbuf, char *word[], int wpos,
 	int usable_modes, orig_len, len, wlen, i, max;
 	server *serv = sess->server;
 
-	/* sanity check. IRC RFC says three per line. */
-	if (serv->modes_per_line < 3)
+	/* sanity check. IRC RFC says three per line but some servers may support less. */
+	if (serv->modes_per_line < 1)
 		serv->modes_per_line = 3;
 	if (modes_per_line < 1)
 		modes_per_line = serv->modes_per_line;

--- a/src/common/proto-irc.c
+++ b/src/common/proto-irc.c
@@ -503,22 +503,6 @@ process_numeric (session * sess, int n,
 
 		goto def;
 
-	case 4:	/* check the ircd type */
-		serv->use_listargs = FALSE;
-		serv->modes_per_line = 3;		/* default to IRC RFC */
-		if (strncmp (word[5], "bahamut", 7) == 0)				/* DALNet */
-		{
-			serv->use_listargs = TRUE;		/* use the /list args */
-		} else if (strncmp (word[5], "u2.10.", 6) == 0)		/* Undernet */
-		{
-			serv->use_listargs = TRUE;		/* use the /list args */
-			serv->modes_per_line = 6;		/* allow 6 modes per line */
-		} else if (strncmp (word[5], "glx2", 4) == 0)
-		{
-			serv->use_listargs = TRUE;		/* use the /list args */
-		}
-		goto def;
-
 	case 5:
 		inbound_005 (serv, word, tags_data);
 		goto def;

--- a/src/common/server.c
+++ b/src/common/server.c
@@ -1770,6 +1770,7 @@ server_set_defaults (server *serv)
 	serv->chanmodes = g_strdup ("beI,k,l");
 	serv->nick_prefixes = g_strdup ("@%+");
 	serv->nick_modes = g_strdup ("ohv");
+	serv->modes_per_line = 3;
 	serv->sasl_mech = MECH_PLAIN;
 
 	if (!serv->encoding)
@@ -1778,6 +1779,7 @@ server_set_defaults (server *serv)
 	serv->nickcount = 1;
 	serv->end_of_motd = FALSE;
 	serv->sent_capend = FALSE;
+	serv->use_listargs = FALSE;
 	serv->is_away = FALSE;
 	serv->supports_watch = FALSE;
 	serv->supports_monitor = FALSE;

--- a/src/common/server.c
+++ b/src/common/server.c
@@ -1770,7 +1770,7 @@ server_set_defaults (server *serv)
 	serv->chanmodes = g_strdup ("beI,k,l");
 	serv->nick_prefixes = g_strdup ("@%+");
 	serv->nick_modes = g_strdup ("ohv");
-	serv->modes_per_line = 3;
+	serv->modes_per_line = 3; /* https://datatracker.ietf.org/doc/html/rfc1459#section-4.2.3.1 */
 	serv->sasl_mech = MECH_PLAIN;
 
 	if (!serv->encoding)


### PR DESCRIPTION
Bahamut and ircu both send 005 MODES and ELIST so this is entirely unnecessary. The other IRCd checked for here is for a dead network.

While we're editing this code fix HexChat on servers that can only support one mode at a time (these are mostly gateway servers).