### PR TITLE
Increase the linebuf length to fit a full message including tags.

### DIFF
--- a/src/common/hexchat.h
+++ b/src/common/hexchat.h
@@ -503,7 +503,7 @@ typedef struct server
 	char servername[128];			/* what the server says is its name */
 	char password[86];
 	char nick[NICKLEN];
-	char linebuf[2048];				/* RFC says 512 chars including \r\n */
+	char linebuf[8704];				/* RFC says 512 chars including \r\n, IRCv3 message tags add 8191, plus the NUL byte */
 	char *last_away_reason;
 	int pos;								/* current position in linebuf */
 	int nickcount;

--- a/src/common/server.c
+++ b/src/common/server.c
@@ -362,7 +362,7 @@ server_read (GIOChannel *source, GIOCondition condition, server *serv)
 				serv->linebuf[serv->pos] = lbuf[i];
 				if (serv->pos >= (sizeof (serv->linebuf) - 1))
 					fprintf (stderr,
-								"*** HEXCHAT WARNING: Buffer overflow - shit server!\n");
+								"*** HEXCHAT WARNING: Buffer overflow - non-compliant server!\n");
 				else
 					serv->pos++;
 			}


### PR DESCRIPTION
In addition to the 512 bytes specified by RFC 1459 IRCv3 message tags can add up to 8191 extra bytes of data to a message. This means that the previous limit of 4096 is far too small to hold an IRC message whilst requesting caps that enable tags,
