### PR TITLE
Fix user list not tracking mode changes

### DIFF
--- a/src/common/modes.c
+++ b/src/common/modes.c
@@ -880,7 +880,7 @@ inbound_005 (server * serv, char *word[], const message_tags_data *tags_data)
 				g_free (serv->nick_prefixes);
 				g_free (serv->nick_modes);
 				serv->nick_prefixes = g_strdup (pre + 1);
-				serv->nick_modes = g_strdup (tokvalue);
+				serv->nick_modes = g_strdup (tokvalue + 1);
 			} else
 			{
 				/* bad! some ircds don't give us the modes. */


### PR DESCRIPTION
The `PREFIX` key in `ISUPPORT` (usually) takes the form
`(modes)prefixes` e.g. `(ov)@+`. The current implementation will
therefore set `serv->nick_modes` to a string like `"(ov"` instead
of the desired `"ov"`. This causes the nick list to not properly
update with which users have which prefix modes. Skip over the
initial `'('` so we capture the correct modes and fix that issue.

Fixes #2599