### PR TITLE
change joind default radio button

### DIFF
--- a/src/fe-gtk/joind.c
+++ b/src/fe-gtk/joind.c
@@ -250,6 +250,7 @@ joind_show_dialog (server *serv)
 		if (g_ascii_strcasecmp(((ircnet*)serv->network)->name, "Libera.Chat") == 0)
 		{
 			gtk_entry_set_text (GTK_ENTRY (entry1), "#hexchat");
+			gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON(radiobutton2), TRUE);
 		}
 
 	gtk_widget_grab_focus (okbutton1);


### PR DESCRIPTION
in the joind dialog window, default the radio button to "join this channel" if we have a channel to recommend

Otherwise the radio defaults to the first entry "Nothing, I'll join a
channel later", which in my opinion is weird if we are at the same time
pre-setting a channel name.