### PR TITLE
src/common/url.c : #2507 add UTF Cyrillic support in nicknames

### DIFF
--- a/src/common/url.c
+++ b/src/common/url.c
@@ -620,7 +620,8 @@ re_email (void)
 /*	NICK description --- */
 /* For NICKPRE see before url_check_word() */
 #define NICKHYP	"-"
-#define NICKLET "a-z"
+/* UTF-8 range \u0400-\u04FF for support Cyrillic on some servers */
+#define NICKLET "a-z\u0400-\u04FF"
 #define NICKDIG "0-9"
 /*	Note for NICKSPE:  \\\\ boils down to a single \ */
 #define NICKSPE	"\\[\\]\\\\`_^{|}"


### PR DESCRIPTION
On some servers, for example RusNET, the use of Cyrillic characters in nicknames is allowed, which leads to issue #2507 .