### PR TITLE
fish: enable the legacy provider if build against OpenSSL3

### DIFF
--- a/plugins/fishlim/fish.h
+++ b/plugins/fishlim/fish.h
@@ -35,6 +35,8 @@ enum fish_mode {
   FISH_CBC_MODE = 0x2
 };
 
+int fish_init(void);
+void fish_deinit(void);
 char *fish_base64_encode(const char *message, size_t message_len);
 char *fish_base64_decode(const char *message, size_t *final_len);
 char *fish_encrypt(const char *key, size_t keylen, const char *message, size_t message_len, enum fish_mode mode);

--- a/plugins/fishlim/plugin_hexchat.c
+++ b/plugins/fishlim/plugin_hexchat.c
@@ -815,6 +815,9 @@ int hexchat_plugin_init(hexchat_plugin *plugin_handle,
     hexchat_hook_server_attrs(ph, "TOPIC", HEXCHAT_PRI_NORM, handle_incoming, NULL);
     hexchat_hook_server_attrs(ph, "332", HEXCHAT_PRI_NORM, handle_incoming, NULL);
 
+    if (!fish_init())
+        return 0;
+
     if (!dh1080_init())
         return 0;
 
@@ -828,6 +831,7 @@ int hexchat_plugin_init(hexchat_plugin *plugin_handle,
 int hexchat_plugin_deinit(void) {
     g_clear_pointer(&pending_exchanges, g_hash_table_destroy);
     dh1080_deinit();
+    fish_deinit();
 
     hexchat_printf(ph, "%s plugin unloaded\n", plugin_name);
     return 1;

--- a/plugins/fishlim/tests/tests.c
+++ b/plugins/fishlim/tests/tests.c
@@ -278,5 +278,8 @@ main(int argc, char *argv[]) {
     g_test_add_func("/fishlim/max_text_command_len", test_max_text_command_len);
     g_test_add_func("/fishlim/foreach_utf8_data_chunks", test_foreach_utf8_data_chunks);
 
-    return g_test_run();
+    fish_init();
+    int ret = g_test_run();
+    fish_deinit();
+    return ret;
 }


### PR DESCRIPTION
OpenSSL 3.0 disables a number of "legacy" algorithms by default, and we
need to enable them manually using their provider system. Note that
explicitly loading a provider will disable the implicit default
provider, which is why we need to load it explicitly.

Closes #2629

Signed-off-by: Simon Chopin <simon.chopin@canonical.com>