### PR TITLE
Make build job names more descriptive

### DIFF
--- a/.github/workflows/flatpak-build.yml
+++ b/.github/workflows/flatpak-build.yml
@@ -1,7 +1,7 @@
 name: Flatpak Build
 on: [push, pull_request]
 jobs:
-  build:
+  flatpack_build:
     runs-on: ubuntu-latest
     container:
       image: bilelmoussaoui/flatpak-github-actions:gnome-40

--- a/.github/workflows/flatpak-build.yml
+++ b/.github/workflows/flatpak-build.yml
@@ -1,7 +1,7 @@
 name: Flatpak Build
 on: [push, pull_request]
 jobs:
-  flatpack_build:
+  flatpak_build:
     runs-on: ubuntu-latest
     container:
       image: bilelmoussaoui/flatpak-github-actions:gnome-40

--- a/.github/workflows/msys-build.yml
+++ b/.github/workflows/msys-build.yml
@@ -2,7 +2,7 @@ name: MSYS2 Build
 on: [push, pull_request]
 
 jobs:
-  build:
+  msys2_build:
     runs-on: windows-latest
     defaults:
       run:

--- a/.github/workflows/ubuntu-build.yml
+++ b/.github/workflows/ubuntu-build.yml
@@ -1,7 +1,7 @@
 name: Ubuntu Build
 on: [push, pull_request]
 jobs:
-  build:
+  ubuntu_build:
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -2,7 +2,7 @@ name: Windows Build
 on: [push, pull_request]
 
 jobs:
-  build:
+  windows_build:
     runs-on: windows-2019
     strategy:
       matrix:


### PR DESCRIPTION
Previously every build showed up in the CI as "build".

Update the job names to reflect what they are. For example the Ubuntu
build is now called "ubuntu_build"