### PR TITLE
meson: Fix exported functions for python plugin

### DIFF
--- a/plugins/python/meson.build
+++ b/plugins/python/meson.build
@@ -28,4 +28,5 @@ shared_module('python', python3_source,
   install: true,
   install_dir: plugindir,
   name_prefix: '',
+  vs_module_defs: 'python.def'
 )


### PR DESCRIPTION
This fixes loading python plugin in Windows by exporting functions using
python.def file. Otherwise, hexchat_plugin_init symbol error is shown.