### PR TITLE
Fix handling invalid ports.

### DIFF
--- a/src/common/server.c
+++ b/src/common/server.c
@@ -1567,6 +1567,7 @@ server_connect (server *serv, char *hostname, int port, int no_login)
 		if (serv->use_ssl)
 			port = 6697;
 #endif
+		g_debug ("Attempted to connect to invalid port, assuming default port %d", port);
 	}
 
 	if (serv->connected || serv->connecting || serv->recondelay_tag)

--- a/src/common/server.c
+++ b/src/common/server.c
@@ -1559,7 +1559,7 @@ server_connect (server *serv, char *hostname, int port, int no_login)
 	if (!hostname[0])
 		return;
 
-	if (port < 0)
+	if (port < 1 || port > 65535)
 	{
 		/* use default port for this server type */
 		port = 6667;
@@ -1568,7 +1568,6 @@ server_connect (server *serv, char *hostname, int port, int no_login)
 			port = 6697;
 #endif
 	}
-	port &= 0xffff;	/* wrap around */
 
 	if (serv->connected || serv->connecting || serv->recondelay_tag)
 		server_disconnect (sess, TRUE, -1);


### PR DESCRIPTION
Instead of wrapping around, which is not behaviour any reasonable user would expect, just use the default port if above 65535.

Disallow connecting on port 0. This port has special meaning and servers can not listen on it. It is more likely the user just gave an invalid value to the port field as `atoi("invalid") == 0`.