### PR TITLE
Replace calls to ctime() with a safer wrapper.

### DIFF
--- a/src/common/inbound.c
+++ b/src/common/inbound.c
@@ -810,14 +810,11 @@ void
 inbound_topictime (server *serv, char *chan, char *nick, time_t stamp,
 						 const message_tags_data *tags_data)
 {
-	char *tim = ctime (&stamp);
+	char *tim = safe_timestr (stamp);
 	session *sess = find_channel (serv, chan);
 
 	if (!sess)
 		sess = serv->server_session;
-
-	if (tim != NULL)
-		tim[24] = 0;	/* get rid of the \n */
 
 	EMIT_SIGNAL_TIMESTAMP (XP_TE_TOPICDATE, sess, chan, nick, tim, NULL, 0,
 								  tags_data->timestamp);
@@ -1488,19 +1485,8 @@ int
 inbound_banlist (session *sess, time_t stamp, char *chan, char *mask, 
 					  char *banner, int rplcode, const message_tags_data *tags_data)
 {
-	char *time_str = ctime (&stamp);
+	char *time_str = safe_timestr (stamp);
 	server *serv = sess->server;
-	char *nl;
-
-	if (stamp <= 0 || time_str == NULL)
-	{
-		time_str = "";
-	}
-	else
-	{
-		if ((nl = strchr (time_str, '\n')))
-			*nl = 0;
-	}
 
 	sess = find_channel (serv, chan);
 	if (!sess)

--- a/src/common/outbound.c
+++ b/src/common/outbound.c
@@ -4315,8 +4315,7 @@ auto_insert (char *dest, gsize destlen, unsigned char *src, char *word[],
 					utf = s; break;
 				case 't':
 					now = time (0);
-					utf = ctime (&now);
-					utf[19] = 0;
+					utf = safe_timestr (now);
 					break;
 				case 'u':
 					utf = u; break;

--- a/src/common/proto-irc.c
+++ b/src/common/proto-irc.c
@@ -453,9 +453,7 @@ channel_date (session *sess, char *chan, char *timestr,
 				  const message_tags_data *tags_data)
 {
 	time_t timestamp = (time_t) atol (timestr);
-	char *tim = ctime (&timestamp);
-	if (tim != NULL)
-		tim[24] = 0;	/* get rid of the \n */
+	char *tim = safe_timestr (timestamp);
 	EMIT_SIGNAL_TIMESTAMP (XP_TE_CHANDATE, sess, chan, tim, NULL, NULL, 0,
 								  tags_data->timestamp);
 }
@@ -598,9 +596,7 @@ process_numeric (session * sess, int n,
 											  outbuf, NULL, NULL, 0, tags_data->timestamp);
 			else
 			{
-				tim = ctime (&timestamp);
-				if (tim != NULL)
-					tim[19] = 0; 	/* get rid of the \n */
+				tim = safe_timestr (timestamp);
 				EMIT_SIGNAL_TIMESTAMP (XP_TE_WHOIS4T, whois_sess, word[4],
 											  outbuf, tim, NULL, 0, tags_data->timestamp);
 			}

--- a/src/common/text.c
+++ b/src/common/text.c
@@ -344,7 +344,7 @@ scrollback_load (session *sess)
 
 	if (lines)
 	{
-		text = ctime (&stamp);
+		text = safe_timestr (stamp);
 		buf = g_strdup_printf ("\n*\t%s %s\n", _("Loaded log from"), text);
 		fe_print_text (sess, buf, 0, TRUE);
 		g_free (buf);
@@ -363,7 +363,7 @@ log_close (session *sess)
 		currenttime = time (NULL);
 		write (sess->logfd, obuf,
 			 g_snprintf (obuf, sizeof (obuf) - 1, _("**** ENDING LOGGING AT %s\n"),
-						  ctime (&currenttime)));
+						  safe_timestr (currenttime)));
 		close (sess->logfd);
 		sess->logfd = -1;
 	}
@@ -575,7 +575,7 @@ log_open_file (char *servname, char *channame, char *netname)
 	currenttime = time (NULL);
 	write (fd, buf,
 			 g_snprintf (buf, sizeof (buf), _("**** BEGIN LOGGING AT %s\n"),
-						  ctime (&currenttime)));
+						  safe_timestr (currenttime)));
 
 	return fd;
 }

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -74,6 +74,7 @@ int token_foreach (char *str, char sep, int (*callback) (char *str, void *ud), v
 guint32 str_hash (const char *key);
 guint32 str_ihash (const unsigned char *key);
 void safe_strcpy (char *dest, const char *src, int bytes_left);
+const char *safe_timestr(time_t ts);
 void canonalize_key (char *key);
 int portable_mode (void);
 char *encode_sasl_pass_plain (char *user, char *pass);

--- a/src/fe-gtk/chanlist.c
+++ b/src/fe-gtk/chanlist.c
@@ -483,7 +483,7 @@ chanlist_filereq_done (server *serv, char *file)
 		return;
 
 	g_snprintf (buf, sizeof buf, "HexChat Channel List: %s - %s\n",
-				 serv->servername, ctime (&t));
+				 serv->servername, safe_timestr (t));
 	write (fh, buf, strlen (buf));
 
 	if (gtk_tree_model_get_iter_first (model, &iter))

--- a/src/fe-gtk/dccgui.c
+++ b/src/fe-gtk/dccgui.c
@@ -158,8 +158,7 @@ dcc_prepare_row_chat (struct DCC *dcc, GtkListStore *store, GtkTreeIter *iter,
 	static char pos[16], size[16];
 	char *date;
 
-	date = ctime (&dcc->starttime);
-	date[strlen (date) - 1] = 0;	/* remove the \n */
+	date = safe_timestr (dcc->starttime);
 
 	proper_unit (dcc->pos, pos, sizeof (pos));
 	proper_unit (dcc->size, size, sizeof (size));


### PR DESCRIPTION
This wrapper can handle a much bigger date range on 64-bit platforms and will always return a value instead of NULL on error avoiding a potential crash if the server sends a weird value.

Currently for unrepresentable values it returns "?" (where it would have previously returned NULL and potentially crashed) but I'm open to changing this if a better value can be proposed.