### PR TITLE
Return userdata from pluginprefs __pairs metamethod to avoid immediate GC

### DIFF
--- a/plugins/lua/lua.c
+++ b/plugins/lua/lua.c
@@ -957,16 +957,21 @@ static int api_hexchat_pluginprefs_meta_pairs(lua_State *L)
 	hexchat_plugin *h;
 
 	if(!script->name)
+
 		return luaL_error(L, "cannot use hexchat.pluginprefs before registering with hexchat.register");
 
 	dest = lua_newuserdata(L, 4096);
+
 	h = script->handle;
 	if(!hexchat_pluginpref_list(h, dest))
 		strcpy(dest, "");
 	lua_pushlightuserdata(L, dest);
 	lua_pushlightuserdata(L, dest);
 	lua_pushcclosure(L, api_hexchat_pluginprefs_meta_pairs_closure, 2);
-	return 1;
+	lua_insert(L, -2); // Return the userdata (second return value from pairs),
+						// even though it's not used by the closure (first return
+						// value from pairs), so that Lua knows not to GC it.
+	return 2;
 }
 
 static int api_attrs_meta_index(lua_State *L)
@@ -1764,4 +1769,3 @@ G_MODULE_EXPORT int hexchat_plugin_deinit(hexchat_plugin *plugin_handle)
 	g_clear_pointer(&expand_buffer, g_free);
 	return 1;
 }
-


### PR DESCRIPTION
Consider the following contrived Lua plugin:

```lua
__module_name__ = "buftester"
__module_author__ = "William D. Jones (cr1901)"
__module_version__ = "0.1.0"
__module_description__ = "Test Lua buffers"

function unload_cb()
  print(__module_name__ .. ' version ' .. __module_version__ .. ' unloaded.')
end

-- Init
-- Without this, plugin unloads immediately.
hexchat.register(__module_name__, __module_version__, __module_description__)
hexchat.hook_unload(unload_cb)

if hexchat.pluginprefs["init_done"] ~= "true" then
  print("Initializing table...")
  for i=1,100,1 do
    hexchat.pluginprefs["key_" .. tostring(i)] = "value_" .. tostring(i)
  end

  hexchat.pluginprefs["init_done"] = "true"
end

print(pairs(hexchat.pluginprefs))
for k, v in pairs(hexchat.pluginprefs) do
  print(string.format('print string: Key = %s, Value = %s', k, v))
  debug_gc_string = string.format('debug GC\'d string: Key = %s, Value = %s', k, v)
end

print(__module_name__ .. ' version ' .. __module_version__ .. ' loaded.')
```

In practice, I would find this bug intermittently with my Lua [bookmarks plugin](http://gopher.wdj-consulting.com:70/store/bookmarks.lua); I found the above plugin to be a consistent way to duplicate the problem.

When this plugin is loaded into HexChat right now, the plugin will print something like this:

```
[10:25:08] Checksum plugin loaded
[10:25:08] Exec plugin loaded
[10:25:08] FiSHLiM plugin loaded
[10:25:08] Lua version 1.3/5.1 loaded.
[10:25:08] bookmarks_lua version 0.1.0 loaded.
[10:25:08] function: 0x39f6a7c0
[10:25:08] print string: Key = key_1, Value = value_1
[10:25:08] print string: Key = key_2, Value = value_2
[10:25:08] print string: Key = key_3, Value = value_3
...
[10:25:08] print string: Key = key_50, Value = value_50
[10:25:08] print string: Key = key_51, Value = value_51
[10:25:08] print string: Key = key_52, Value = value_52
[10:25:08] print string: Key = lue = value_52, Value = nil
[10:25:08] buftester version 0.1.0 loaded.
[10:25:08] Update Checker plugin loaded
[10:25:08] Winamp plugin loaded
[10:25:08] Sysinfo plugin loaded
```

Notice that the keys stop printing after 52, and that there's corruption for what should be `key_53`. By looking at the memory of a running HexChat, I realized that the buffer used to iterate over `hexchat.pluginprefs` using `pairs` was being GC'd by Lua. This would sometimes cause corruption w/ my bookmarks plugin, but deliberately printing lots of strings that aren't used gave me an easy way to always overwrite the buffer used for listing the key/values of `hexchat.pluginprefs`.

The `pairs` function in Lua actually returns 3 values: A closure that describes how to iterate, the data you wish to iterate over ("state"), and a start value. Because of how Lua works, you can return 2 or 1 values from your `pairs` implementation for C code (the `__pairs` metamethod) and things should still work. However, it appears that Lua GC's the buffer we use to hold the state of iterating over `hexchat.pluginprefs` immediately if we don't return that buffer as well. This PR returns that buffer back to Lua to prevent immediate GC'ing.

With my PR, the contrived plugin iterates to completion, and I can confirm that Lua preserves the buffer and allocates memory around it:

```
[10:26:36] Checksum plugin loaded
[10:26:36] Exec plugin loaded
[10:26:37] FiSHLiM plugin loaded
[10:26:37] Lua version 1.3/5.1 loaded.
[10:26:37] bookmarks_lua version 0.1.0 loaded.
[10:26:37] function: 0x3c4ea7c0 userdata: 0x3c4eb408
[10:26:37] print string: Key = key_1, Value = value_1
[10:26:37] print string: Key = key_2, Value = value_2
[10:26:37] print string: Key = key_3, Value = value_3
...
[10:26:37] print string: Key = key_98, Value = value_98
[10:26:37] print string: Key = key_99, Value = value_99
[10:26:37] print string: Key = key_100, Value = value_100
[10:26:37] print string: Key = init_done, Value = true
[10:26:37] buftester version 0.1.0 loaded.
[10:26:37] Update Checker plugin loaded
[10:26:37] Winamp plugin loaded
[10:26:37] Sysinfo plugin loaded
```