### PR TITLE
Reverse the notify.conf linked list before writing

### DIFF
--- a/src/common/notify.c
+++ b/src/common/notify.c
@@ -123,7 +123,11 @@ notify_save (void)
 {
 	int fh;
 	struct notify *notify;
-	GSList *list = notify_list;
+        // while reading the notify.conf file, elements are added by prepending to the
+        // list. reverse the list before writing to disk to keep the original
+        // order of the list
+        GSList *list = g_slist_copy(notify_list);
+        list = g_slist_reverse(list);
 
 	fh = hexchat_open_file ("notify.conf", O_TRUNC | O_WRONLY | O_CREAT, 0600, XOF_DOMODE);
 	if (fh != -1)
@@ -142,6 +146,7 @@ notify_save (void)
 		}
 		close (fh);
 	}
+        g_slist_free(list);
 }
 
 void


### PR DESCRIPTION
hexchat populates the single linked list `notify_list` defined in
`src/common/notify.c` from `notify.conf` file. Each new line read from
the file is added to the list by `g_slist_prepend()` which adds it to
the front of the list. But in `notify_save()` the list elements are read
from the start to end of the list and written to the `notify.conf`. This
means everytime hexchat is opened and closed, the contents of
`notify.conf` get reversed. This commit creates a
temporary glist in `notify_save()` and applies `g_slist_reverse()` on it
and writes the contents of this reversed list to `notify.conf`. And
solves issue #2680