### PR TITLE
Raise the max length of a server password to 1024

### DIFF
--- a/src/common/hexchat.h
+++ b/src/common/hexchat.h
@@ -501,7 +501,7 @@ typedef struct server
 	int joindelay_tag;				/* waiting before we send JOIN */
 	char hostname[128];				/* real ip number */
 	char servername[128];			/* what the server says is its name */
-	char password[86];
+	char password[1024];
 	char nick[NICKLEN];
 	char linebuf[8704];				/* RFC says 512 chars including \r\n, IRCv3 message tags add 8191, plus the NUL byte */
 	char *last_away_reason;


### PR DESCRIPTION
This might look like a careless hack, but I did poke around the source code enough to make sure it was really that simple. While not a definitive fix (which would not be very practical), for all purposes mentioned in the issue this will hopefully fix #1296.
I have built and installed the patched version of HexChat locally and, having tested it with some very long passwords, can verify it works for SASL-enabled servers without visible issues.

### Research

The `serv->password` field is always filled out using the `safe_strcpy` function like this:
https://github.com/hexchat/hexchat/blob/2638c884797b82054116166523ed35c0e303aaa7/src/common/outbound.c#L3524
This ensures that the string inside `serv->password` is always `sizeof(serv->password)` characters long (currently 86) and null-terminated. Thus making checks like `strlen (serv->password) != 0`[🡭][1] and `strchr (serv->password, ' ')`[🡭][2] somewhat safer later on.

Now, the only times `serv->password` is actually used (and possibly copied somewhere) is inside `encode_pass_sasl_plain()`
https://github.com/hexchat/hexchat/blob/2638c884797b82054116166523ed35c0e303aaa7/src/common/inbound.c#L1916
and `challengeauth_response()`.
https://github.com/hexchat/hexchat/blob/2638c884797b82054116166523ed35c0e303aaa7/src/common/proto-irc.c#L1244
Inside both of those functions the field ends up handled via GLib functions like `g_strdup_printf()` and `g_strndup()`, which could reasonably be expected to handle the new suggested length of the field (1024) gracefully.

**Most importantly, I didn't find any more buffers of static length that this field is copied into down the line, which means that hopefully nothing will get overflown.**

### Possible further enhancements
- Define all arbitrary constants like this separately and use them in checks like `strnlen` instead of relying on `strlen` and null-terminatedness. Seeing how `strlen` is used liberally throughout the source at this time, I don't think it's very practical to do this for one specific field.
- Let go of arbitrary length restrictions. Lots of added dynamic memory management business. Probably not worth it at this point.

### Motivation
Some IRC servers and IRC bouncer deployments are known to require long generated tokens to be provided in the place of a SASL password. One of such installations is the `soju` bouncer instance deployed at chat.sr.ht, which [authenticates](https://man.sr.ht/chat.sr.ht/quickstart.md#connecting-with-your-own-irc-client) users with a long OAuth2 token. This case was [mentioned][3] in the original issue, and it's potentially blocking for a few hundred users.
The new maximum length of 1024 characters for the server password was originally [suggested][4] by @ddevault, an admin at said instance.

[1]: https://github.com/hexchat/hexchat/blob/2638c884797b82054116166523ed35c0e303aaa7/src/common/inbound.c#L1816
[2]: https://github.com/hexchat/hexchat/blob/2638c884797b82054116166523ed35c0e303aaa7/src/common/proto-irc.c#L57
[3]: https://github.com/hexchat/hexchat/issues/1296#issuecomment-982139694
[4]: https://github.com/hexchat/hexchat/issues/1296#issuecomment-986646275