### PR TITLE
Split long SASL auth strings into 400-byte chunks

### DIFF
--- a/src/common/inbound.c
+++ b/src/common/inbound.c
@@ -1929,7 +1929,24 @@ inbound_sasl_authenticate (server *serv, char *data)
 			return;
 		}
 
-		tcp_sendf (serv, "AUTHENTICATE %s\r\n", pass);
+		/* long SASL passwords must be split into 400-byte chunks
+		   https://ircv3.net/specs/extensions/sasl-3.1#the-authenticate-command */
+		size_t pass_len = strlen(pass);
+		if (pass_len <= 400) {
+			tcp_sendf (serv, "AUTHENTICATE %s\r\n", pass);
+		}
+		else {
+			size_t sent = 0;
+			while (sent < pass_len) {
+				char* pass_chunk = g_strndup(pass + sent, 400);
+				tcp_sendf (serv, "AUTHENTICATE %s\r\n", pass_chunk);
+				sent += 400;
+				g_free(pass_chunk);
+			}
+		}
+		if (pass_len % 400 == 0) {
+			tcp_sendf (serv, "AUTHENTICATE +\r\n");
+		}
 		g_free (pass);
 
 		

--- a/src/common/inbound.c
+++ b/src/common/inbound.c
@@ -1931,7 +1931,7 @@ inbound_sasl_authenticate (server *serv, char *data)
 
 		/* long SASL passwords must be split into 400-byte chunks
 		   https://ircv3.net/specs/extensions/sasl-3.1#the-authenticate-command */
-		size_t pass_len = strlen(pass);
+		size_t pass_len = strlen (pass);
 		if (pass_len <= 400)
 			tcp_sendf (serv, "AUTHENTICATE %s\r\n", pass);
 		else

--- a/src/common/inbound.c
+++ b/src/common/inbound.c
@@ -1932,16 +1932,17 @@ inbound_sasl_authenticate (server *serv, char *data)
 		/* long SASL passwords must be split into 400-byte chunks
 		   https://ircv3.net/specs/extensions/sasl-3.1#the-authenticate-command */
 		size_t pass_len = strlen(pass);
-		if (pass_len <= 400) {
+		if (pass_len <= 400)
 			tcp_sendf (serv, "AUTHENTICATE %s\r\n", pass);
-		}
-		else {
+		else
+		{
 			size_t sent = 0;
-			while (sent < pass_len) {
-				char* pass_chunk = g_strndup(pass + sent, 400);
+			while (sent < pass_len)
+			{
+				char *pass_chunk = g_strndup (pass + sent, 400);
 				tcp_sendf (serv, "AUTHENTICATE %s\r\n", pass_chunk);
 				sent += 400;
-				g_free(pass_chunk);
+				g_free (pass_chunk);
 			}
 		}
 		if (pass_len % 400 == 0) {

--- a/src/common/inbound.c
+++ b/src/common/inbound.c
@@ -1945,9 +1945,8 @@ inbound_sasl_authenticate (server *serv, char *data)
 				g_free (pass_chunk);
 			}
 		}
-		if (pass_len % 400 == 0) {
+		if (pass_len % 400 == 0)
 			tcp_sendf (serv, "AUTHENTICATE +\r\n");
-		}
 		g_free (pass);
 
 		


### PR DESCRIPTION
- Fix #2705

I tested this locally and it works for me with very long passwords.
Passwords resulting in exactly 400, 800 and 1200 byte long auth strings are handled properly.