### PR TITLE
  Fix PROTOCTL NAMESX and only send when not using `multi-prefix`.

### DIFF
--- a/src/common/modes.c
+++ b/src/common/modes.c
@@ -918,8 +918,12 @@ inbound_005 (server * serv, char *word[], const message_tags_data *tags_data)
 			server_set_encoding (serv, "UTF-8");
 		} else if (g_strcmp0 (tokname, "NAMESX") == 0)
 		{
-									/* 12345678901234567 */
-			tcp_send_len (serv, "PROTOCTL NAMESX\r\n", 17);
+			if (tokadding && !serv->have_namesx)
+			{
+				/* only use protoctl if the server doesn't have the equivalent cap */
+				tcp_send_len (serv, "PROTOCTL NAMESX\r\n", 17);
+				serv->have_namesx = TRUE;
+			}
 		} else if (g_strcmp0 (tokname, "WHOX") == 0)
 		{
 			serv->have_whox = tokadding;


### PR DESCRIPTION
This capability is the equivalent of the old protoctl token so there's no need to send the old method if the capability is enabled.

This pull request also fixes `PROTOCTL NAMESX` on servers that support protoctl but not capability negotiation.