### PR TITLE
Fix various compiler warnings.

### DIFF
--- a/plugins/fishlim/fish.c
+++ b/plugins/fishlim/fish.c
@@ -91,7 +91,7 @@ static const signed char fish_unbase64[256] = {
 #include <openssl/provider.h>
 static OSSL_PROVIDER *legacy_provider;
 static OSSL_PROVIDER *default_provider;
-static OSSL_LIB_CTX* *ossl_ctx;
+static OSSL_LIB_CTX *ossl_ctx;
 #endif
 
 int fish_init(void)

--- a/src/common/proto-irc.c
+++ b/src/common/proto-irc.c
@@ -461,7 +461,7 @@ channel_date (session *sess, char *chan, char *timestr,
 }
 
 static int
-trailing_index(const char *word_eol[])
+trailing_index(char *word_eol[])
 {
 	int param_index;
 	for (param_index = 3; param_index < PDIWORDS; ++param_index)

--- a/src/common/util.c
+++ b/src/common/util.c
@@ -1375,11 +1375,16 @@ str_sha256hash (char *string)
 	int i;
 	unsigned char hash[SHA256_DIGEST_LENGTH];
 	char buf[SHA256_DIGEST_LENGTH * 2 + 1];		/* 64 digit hash + '\0' */
+
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+	SHA256 (string, strlen (string), hash);
+#else
 	SHA256_CTX sha256;
 
 	SHA256_Init (&sha256);
 	SHA256_Update (&sha256, string, strlen (string));
 	SHA256_Final (hash, &sha256);
+#endif
 
 	for (i = 0; i < SHA256_DIGEST_LENGTH; i++)
 	{

--- a/src/fe-gtk/fkeys.c
+++ b/src/fe-gtk/fkeys.c
@@ -894,7 +894,7 @@ key_save_kbs (void)
 #define STRIP_WHITESPACE \
 	while (buf[0] == ' ' || buf[0] == '\t') \
 		buf++; \
-		len = strlen (buf); \
+	len = strlen (buf); \
 	while (buf[len] == ' ' || buf[len] == '\t') \
 	{ \
 		buf[len] = 0; \

--- a/src/fe-gtk/xtext.c
+++ b/src/fe-gtk/xtext.c
@@ -947,7 +947,7 @@ gtk_xtext_find_char (GtkXText * xtext, int x, int y, int *off, int *out_of_bound
 	textentry *ent;
 	int line;
 	int subline;
-	int outofbounds;
+	int outofbounds = FALSE;
 
 	/* Adjust y value for negative rounding, double to int */
 	if (y < 0)


### PR DESCRIPTION
- fish.c &mdash; -Wincompatible-pointer-types &mdash; using a pointer pointer when it should just be using a pointer.

- fkeys.c &mdash; -Wmisleading-indentation &mdash; the indentation in STRIP_WHITESPACE was clearly wrong.

- proto-irc.c &mdash; -Wincompatible-pointer-types &mdash; word_eol is never const so we can't use const here.

- util.c &mdash; -Wdeprecated-declarations &mdash; OpenSSL v3 deprecated the raw SHA256 method in favour of a single function.

- xtext.c &mdash; -Wmaybe-uninitialized &mdash; Not all code paths initialize `outofbounds` so it should be initialized to FALSE by default.