### PR TITLE
Add ChillNet to server list

### DIFF
--- a/src/common/servlist.c
+++ b/src/common/servlist.c
@@ -89,6 +89,11 @@ static const struct defaultserver def[] =
 	{"ChatJunkies",	0},
 	{0,			"irc.chatjunkies.org"},
 
+#ifdef USE_OPENSSL
+	{"ChillNet", 0, 0, 0, LOGIN_SASL, 0, TRUE},
+	{0,			"irc.chillnet.org"},
+#endif
+
 	{"chatpat", 0, 0, "CP1251", LOGIN_CUSTOM, "MSG NS IDENTIFY %p"},
 	{0,			"irc.unibg.net"},
 	{0,			"irc.chatpat.bg"},


### PR DESCRIPTION
Signed-off-by: Georg Pfuetzenreuter <mail@georg-pfuetzenreuter.net>

Hello,

I hereby request ChillNet to be taken up into the server list - been around since almost twenty years now, figuring it'd be about time ... :-)

Some statistics can be found here, if needed: https://netsplit.de/networks/statistics.php?net=ChillNet

Let me know if I missed anything! It should have SSL enabled by default.