### PR TITLE
Ported the checksum plugin to the async file read functions

### DIFF
--- a/plugins/checksum/checksum.c
+++ b/plugins/checksum/checksum.c
@@ -22,244 +22,431 @@
 
 #include "config.h"
 
-#include <stdlib.h>
-#include <glib.h>
-#include <glib/gstdio.h>
 #include <gio/gio.h>
+#include <glib.h>
+#include <glib/gerror.h>
+#include <glib/gstdio.h>
+#include <stdlib.h>
 
 #include "hexchat-plugin.h"
 
 #define BUFSIZE 32768
-#define DEFAULT_LIMIT 256									/* default size is 256 MiB */
+#define DEFAULT_LIMIT 256 /* default size is 256 MiB */
 #define SHA256_DIGEST_LENGTH 32
 #define SHA256_BUFFER_LENGTH 65
 
-static hexchat_plugin *ph;									/* plugin handle */
+static hexchat_plugin *ph; /* plugin handle */
 static char name[] = "Checksum";
 static char desc[] = "Calculate checksum for DCC file transfers";
-static char version[] = "3.1";
+static char version[] = "3.3";
 
-static void
-set_limit (char *size)
-{
-	int limit = atoi (size);
+static void set_limit(char *size) {
+  int limit = atoi(size);
 
-	if (limit > 0 && limit < INT_MAX)
-	{
-		if (hexchat_pluginpref_set_int (ph, "limit", limit))
-			hexchat_printf (ph, "Checksum: File size limit has successfully been set to: %d MiB\n", limit);
-		else
-			hexchat_printf (ph, "Checksum: File access error while saving!\n");
-	}
-	else
-	{
-		hexchat_printf (ph, "Checksum: Invalid input!\n");
-	}
+  if (limit > 0 && limit < INT_MAX) {
+    if (hexchat_pluginpref_set_int(ph, "limit", limit))
+      hexchat_printf(
+          ph,
+          "Checksum: File size limit has successfully been set to: %d MiB\n",
+          limit);
+    else
+      hexchat_printf(ph, "Checksum: File access error while saving!\n");
+  } else {
+    hexchat_printf(ph, "Checksum: Invalid input!\n");
+  }
 }
 
-static int
-get_limit (void)
-{
-	int size = hexchat_pluginpref_get_int (ph, "limit");
+static int get_limit(void) {
+  int size = hexchat_pluginpref_get_int(ph, "limit");
 
-	if (size <= 0 || size >= INT_MAX)
-		return DEFAULT_LIMIT;
-	else
-		return size;
+  if (size <= 0 || size >= INT_MAX)
+    return DEFAULT_LIMIT;
+  else
+    return size;
 }
 
-static gboolean
-check_limit (GFile *file)
-{
-	GFileInfo *file_info;
-	goffset file_size;
+static gboolean check_limit(GFile *file) {
+  GFileInfo *file_info;
+  goffset file_size;
 
-	file_info = g_file_query_info (file, G_FILE_ATTRIBUTE_STANDARD_SIZE, G_FILE_QUERY_INFO_NONE,
-									NULL, NULL);
+  file_info = g_file_query_info(file, G_FILE_ATTRIBUTE_STANDARD_SIZE,
+                                G_FILE_QUERY_INFO_NONE, NULL, NULL);
 
-	if (!file_info)
-		return FALSE;
+  if (!file_info)
+    return FALSE;
 
-	file_size = g_file_info_get_size (file_info);
-	g_object_unref (file_info);
+  file_size = g_file_info_get_size(file_info);
+  g_object_unref(file_info);
 
-	if (file_size > get_limit () * 1048576ll)
-		return FALSE;
+  if (file_size > get_limit() * 1048576ll)
+    return FALSE;
 
-	return TRUE;
+  return TRUE;
 }
 
-static gboolean
-sha256_from_stream (GFileInputStream *file_stream, char out_buf[])
-{
-	GChecksum *checksum;
-	gssize bytes_read;
-	guint8 digest[SHA256_DIGEST_LENGTH];
-	gsize digest_len = sizeof(digest);
-	guchar buffer[BUFSIZE];
-	gsize i;
+typedef void async_result_cb(gboolean, gpointer);
 
-	checksum = g_checksum_new (G_CHECKSUM_SHA256);
+typedef struct {
+  GChecksum *checksum;
+  async_result_cb *result_callback;
+  guchar *buffer;
+  size_t *buffer_size;
+  char *out_buf;
+  gpointer bound_data;
+} stream_async_cb_data;
 
-	while ((bytes_read = g_input_stream_read (G_INPUT_STREAM (file_stream), buffer, sizeof (buffer), NULL, NULL)))
-	{
-		if (bytes_read == -1)
-		{
-			g_checksum_free (checksum);
-			return FALSE;
-		}
-
-		g_checksum_update (checksum, buffer, bytes_read);
-	}
-
-	g_checksum_get_digest (checksum, digest, &digest_len);
-	g_checksum_free (checksum);
-
-	for (i = 0; i < SHA256_DIGEST_LENGTH; i++)
-	{
-		/* out_buf will be exactly SHA256_BUFFER_LENGTH including null */
-		g_sprintf (out_buf + (i * 2), "%02x", digest[i]);
-	}
-
-	return TRUE;
+static void free_user_data(stream_async_cb_data *user_data) {
+  free(user_data->buffer_size);
+  free(user_data->buffer);
+  g_checksum_free(user_data->checksum);
+  free(user_data);
 }
 
-static gboolean
-sha256_from_file (char *filename, char out_buf[])
-{
-	GFileInputStream *file_stream;
-	char *filename_fs;
-	GFile *file;
+static void stream_async_cb(GObject *source_object, GAsyncResult *res,
+                            gpointer user_data) {
+  stream_async_cb_data *bound_vars = (void *)user_data;
 
-	filename_fs = g_filename_from_utf8 (filename, -1, NULL, NULL, NULL);
-	if (!filename_fs)
-	{
-		hexchat_printf (ph, "Checksum: Invalid filename (%s)\n", filename);
-		return FALSE;
-	}
+  GInputStream *stream = G_INPUT_STREAM(source_object);
+  GError *error = NULL;
+  gssize bytes_read = g_input_stream_read_finish(stream, res, &error);
 
-	file = g_file_new_for_path (filename_fs);
-	g_free (filename_fs);
-	if (!file)
-	{
-		hexchat_printf (ph, "Checksum: Failed to open %s\n", filename);
-		return FALSE;
-	}
+  if (bytes_read != 0) {
+    if (bytes_read == -1 || error) {
+      async_result_cb *cb = bound_vars->result_callback;
+      gpointer bound_data = bound_vars->bound_data;
+      free_user_data(bound_vars);
+      return cb(FALSE, bound_data);
+    }
 
-	if (!check_limit (file))
-	{
-		hexchat_printf (ph, "Checksum: %s is larger than size limit. You can increase it with /CHECKSUM SET.\n", filename);
-		g_object_unref (file);
-		return FALSE;
-	}
+    g_checksum_update(bound_vars->checksum, bound_vars->buffer, bytes_read);
 
-	file_stream = g_file_read (file, NULL, NULL);
-	if (!file_stream)
-	{
-		hexchat_printf (ph, "Checksum: Failed to read file %s\n", filename);
-		g_object_unref (file);
-		return FALSE;
-	}
+    return g_input_stream_read_async(
+        stream, bound_vars->buffer, *bound_vars->buffer_size,
+        G_PRIORITY_DEFAULT, NULL, stream_async_cb, user_data);
+  }
 
-	if (!sha256_from_stream (file_stream, out_buf))
-	{
-		hexchat_printf (ph, "Checksum: Failed to generate checksum for %s\n", filename);
-		g_object_unref (file_stream);
-		g_object_unref (file);
-		return FALSE;
-	}
+  guint8 digest[SHA256_DIGEST_LENGTH];
+  gsize digest_len = sizeof(digest);
 
-	g_object_unref (file_stream);
-	g_object_unref (file);
-	return TRUE;
+  g_checksum_get_digest(bound_vars->checksum, digest, &digest_len);
+  gpointer bound_data = bound_vars->bound_data;
+  char *out_buf =  bound_vars->out_buf;
+  async_result_cb *cb = bound_vars->result_callback;
+  free_user_data(user_data);
+
+  gsize i;
+  for (i= 0; i < SHA256_DIGEST_LENGTH; i++) {
+    /* out_buf will be exactly SHA256_BUFFER_LENGTH including null */
+    g_sprintf(out_buf + (i * 2), "%02x", digest[i]);
+  }
+
+  cb(TRUE, bound_data);
 }
 
-static int
-dccrecv_cb (char *word[], void *userdata)
-{
-	const char *dcc_completed_dir;
-	char *filename, checksum[SHA256_BUFFER_LENGTH];
+static void sha256_from_stream_async(GFileInputStream *file_stream,
+                                     char out_buf[], async_result_cb *result_cb,
+                                     gpointer bound_data) {
 
-	/* Print in the privmsg tab of the sender */
-	hexchat_set_context (ph, hexchat_find_context (ph, NULL, word[3]));
+  size_t *buffer_size = malloc(sizeof(size_t));
+  if (buffer_size == NULL) {
+    return result_cb(FALSE, bound_data);
+  }
 
-	if (hexchat_get_prefs (ph, "dcc_completed_dir", &dcc_completed_dir, NULL) == 1 && dcc_completed_dir[0] != '\0')
-		filename = g_build_filename (dcc_completed_dir, word[1], NULL);
-	else
-		filename = g_strdup (word[2]);
+  *buffer_size = BUFSIZ * sizeof(guchar);
+  guchar *buffer = malloc(*buffer_size);
+  if (buffer == NULL) {
+    free(buffer_size);
+    return result_cb(FALSE, bound_data);
+  }
 
-	if (sha256_from_file (filename, checksum))
-	{
-		hexchat_printf (ph, "SHA-256 checksum for %s (local): %s\n", word[1], checksum);
-	}
+  GChecksum *checksum = g_checksum_new(G_CHECKSUM_SHA256);
+  if (checksum == NULL) {
+    free(buffer_size);
+    free(buffer);
+    return result_cb(FALSE, bound_data);
+  }
 
-	g_free (filename);
-	return HEXCHAT_EAT_NONE;
+  stream_async_cb_data *user_data = malloc(sizeof(stream_async_cb_data));
+  if (user_data == NULL) {
+    free(buffer_size);
+    free(buffer);
+    g_checksum_free(checksum);
+    return result_cb(FALSE, bound_data);
+  }
+
+  user_data->checksum = checksum;
+  user_data->result_callback = result_cb;
+  user_data->buffer = buffer;
+  user_data->buffer_size = buffer_size;
+  user_data->out_buf = out_buf;
+  user_data->bound_data = bound_data;
+
+  g_input_stream_read_async(G_INPUT_STREAM(file_stream), buffer, *buffer_size,
+                            G_PRIORITY_DEFAULT, NULL, stream_async_cb,
+                            (void *)user_data);
 }
 
-static int
-dccoffer_cb (char *word[], void *userdata)
-{
-	char checksum[SHA256_BUFFER_LENGTH];
+typedef struct {
+  async_result_cb *result_cb;
+  GFileInputStream *file_stream;
+  char *filename;
+  GFile *file;
+  gpointer bound_data;
+} file_async_cb_data;
 
-	/* Print in the privmsg tab of the receiver */
-	hexchat_set_context (ph, hexchat_find_context (ph, NULL, word[3]));
+static void file_async_cb(gboolean result, gpointer user_data) {
 
-	if (sha256_from_file (word[3], checksum))
-	{
-		hexchat_commandf (ph, "quote PRIVMSG %s :SHA-256 checksum for %s (remote): %s", word[2], word[1], checksum);
-	}
+  file_async_cb_data *bound_vars = (void *)user_data;
 
-	return HEXCHAT_EAT_NONE;
+  if (!result) {
+    hexchat_printf(ph, "Checksum: Failed to generate checksum for %s\n",
+                   bound_vars->filename);
+  }
+
+  g_object_unref(bound_vars->file_stream);
+  g_object_unref(bound_vars->file);
+  async_result_cb *cb = bound_vars->result_cb;
+  gpointer bound_data = bound_vars->bound_data;
+  free(bound_vars);
+
+  return cb(result, bound_data);
 }
 
-static int
-checksum (char *word[], char *word_eol[], void *userdata)
-{
-	if (!g_ascii_strcasecmp ("GET", word[2]))
-	{
-		hexchat_printf (ph, "File size limit for checksums: %d MiB", get_limit ());
-	}
-	else if (!g_ascii_strcasecmp ("SET", word[2]))
-	{
-		set_limit (word[3]);
-	}
-	else
-	{
-		hexchat_printf (ph, "Usage: /CHECKSUM GET|SET\n");
-		hexchat_printf (ph, "  GET - print the maximum file size (in MiB) to be hashed\n");
-		hexchat_printf (ph, "  SET <filesize> - set the maximum file size (in MiB) to be hashed\n");
-	}
+static void sha256_from_file_async(char *filename, char out_buf[],
+                                   async_result_cb *result_cb,
+                                   gpointer bound_data) {
+  GFileInputStream *file_stream;
+  char *filename_fs;
+  GFile *file;
 
-	return HEXCHAT_EAT_ALL;
+  filename_fs = g_filename_from_utf8(filename, -1, NULL, NULL, NULL);
+  if (!filename_fs) {
+    hexchat_printf(ph, "Checksum: Invalid filename (%s)\n", filename);
+    return result_cb(FALSE, bound_data);
+  }
+
+  file = g_file_new_for_path(filename_fs);
+  g_free(filename_fs);
+  if (!file) {
+    hexchat_printf(ph, "Checksum: Failed to open %s\n", filename);
+    return result_cb(FALSE, bound_data);
+  }
+
+  if (!check_limit(file)) {
+    hexchat_printf(ph,
+                   "Checksum: %s is larger than size limit. You can increase "
+                   "it with /CHECKSUM SET.\n",
+                   filename);
+    g_object_unref(file);
+    return result_cb(FALSE, bound_data);
+  }
+
+  file_stream = g_file_read(file, NULL, NULL);
+  if (!file_stream) {
+    hexchat_printf(ph, "Checksum: Failed to read file %s\n", filename);
+    g_object_unref(file);
+    return result_cb(FALSE, bound_data);
+  }
+
+  file_async_cb_data *user_data = malloc(sizeof(file_async_cb_data));
+  if (user_data == NULL) {
+    hexchat_printf(ph, "Checksum: Failed to malloc needed memory\n");
+    g_object_unref(file);
+    return result_cb(FALSE, bound_data);
+  }
+
+  user_data->result_cb = result_cb;
+  user_data->file_stream = file_stream;
+  user_data->filename = filename;
+  user_data->file = file;
+  user_data->bound_data = bound_data;
+
+  sha256_from_stream_async(file_stream, out_buf, file_async_cb,
+                           (void *)user_data);
 }
 
-int
-hexchat_plugin_init (hexchat_plugin *plugin_handle, char **plugin_name, char **plugin_desc, char **plugin_version, char *arg)
-{
-	ph = plugin_handle;
+typedef struct {
+  char *checksum;
+  char *word_1;
+  char *filename;
+} dccrecv_async_cb_data;
 
-	*plugin_name = name;
-	*plugin_desc = desc;
-	*plugin_version = version;
+void dccrecv_async_cb(gboolean result, gpointer user_data) {
 
-	/* this is required for the very first run */
-	if (hexchat_pluginpref_get_int (ph, "limit") == -1)
-	{
-		hexchat_pluginpref_set_int (ph, "limit", DEFAULT_LIMIT);
-	}
+  dccrecv_async_cb_data *bound_vars = (void *)user_data;
 
-	hexchat_hook_command (ph, "CHECKSUM", HEXCHAT_PRI_NORM, checksum, "Usage: /CHECKSUM GET|SET", NULL);
-	hexchat_hook_print (ph, "DCC RECV Complete", HEXCHAT_PRI_NORM, dccrecv_cb, NULL);
-	hexchat_hook_print (ph, "DCC Offer", HEXCHAT_PRI_NORM, dccoffer_cb, NULL);
+  if (result) {
+    hexchat_printf(ph, "SHA-256 checksum for %s (local): %s\n",
+                   bound_vars->word_1, bound_vars->checksum);
+  }
 
-	hexchat_printf (ph, "%s plugin loaded\n", name);
-	return 1;
+  free(bound_vars->word_1);
+  free(bound_vars->checksum);
+  g_free(bound_vars->filename);
+
+  free(bound_vars);
 }
 
-int
-hexchat_plugin_deinit (void)
-{
-	hexchat_printf (ph, "%s plugin unloaded\n", name);
-	return 1;
+static int dccrecv_cb(char *word[], void *userdata) {
+  const char *dcc_completed_dir;
+  char *filename;
+  char *checksum = malloc(SHA256_BUFFER_LENGTH);
+  if (checksum == NULL) {
+    hexchat_commandf(ph, "Checksum: Failed to malloc needed memory\n");
+    return HEXCHAT_EAT_NONE;
+  }
+
+  /* Print in the privmsg tab of the sender */
+  hexchat_set_context(ph, hexchat_find_context(ph, NULL, word[3]));
+
+  if (hexchat_get_prefs(ph, "dcc_completed_dir", &dcc_completed_dir, NULL) ==
+          1 &&
+      dcc_completed_dir[0] != '\0') {
+    filename = g_build_filename(dcc_completed_dir, word[1], NULL);
+  } else {
+    filename = g_strdup(word[2]);
+  }
+
+  dccrecv_async_cb_data *user_data = malloc(sizeof(dccrecv_async_cb_data));
+  if (user_data == NULL) {
+    hexchat_printf(ph, "Checksum: Failed to malloc needed memory\n");
+    free(checksum);
+    return HEXCHAT_EAT_NONE;
+  }
+
+  user_data->checksum = checksum;
+
+  char *word_1 = malloc(strlen(word[1]) + 1);
+  if (word_1 == NULL) {
+    hexchat_printf(ph, "Checksum: Failed to malloc needed memory\n");
+    free(checksum);
+    free(user_data);
+    return HEXCHAT_EAT_NONE;
+  }
+
+  strcpy(word_1, word[1]);
+
+  user_data->word_1 = word_1;
+  user_data->filename = filename;
+
+  sha256_from_file_async(filename, checksum, dccrecv_async_cb,
+                         (void *)user_data);
+
+  return HEXCHAT_EAT_NONE;
+}
+
+typedef struct {
+  char *checksum;
+  char *word_1;
+  char *word_2;
+} dccoffer_async_cb_data;
+
+void dccoffer_async_cb(gboolean result, gpointer user_data) {
+
+  dccoffer_async_cb_data *bound_vars = (void *)user_data;
+
+  if (result) {
+    hexchat_commandf(
+        ph, "quote PRIVMSG %s :SHA-256 checksum for %s (remote): %s",
+        bound_vars->word_2, bound_vars->word_1, bound_vars->checksum);
+  }
+
+  free(bound_vars->word_2);
+  free(bound_vars->word_1);
+  free(bound_vars->checksum);
+
+  free(bound_vars);
+}
+
+static int dccoffer_cb(char *word[], void *userdata) {
+
+  /* Print in the privmsg tab of the receiver */
+  hexchat_set_context(ph, hexchat_find_context(ph, NULL, word[3]));
+
+  char *checksum = malloc(SHA256_BUFFER_LENGTH);
+  if (checksum == NULL) {
+    hexchat_commandf(ph, "Checksum: Failed to malloc needed memory\n");
+    return HEXCHAT_EAT_NONE;
+  }
+
+  dccoffer_async_cb_data *user_data = malloc(sizeof(dccoffer_async_cb_data));
+  if (user_data == NULL) {
+    hexchat_printf(ph, "Checksum: Failed to malloc needed memory\n");
+    free(checksum);
+    return HEXCHAT_EAT_NONE;
+  }
+
+  user_data->checksum = checksum;
+
+  char *word_1 = malloc(strlen(word[1]) + 1);
+  if (word_1 == NULL) {
+    hexchat_printf(ph, "Checksum: Failed to malloc needed memory\n");
+    free(checksum);
+    free(user_data);
+    return HEXCHAT_EAT_NONE;
+  }
+
+  char *word_2 = malloc(strlen(word[2]) + 1);
+  if (word_2 == NULL) {
+    hexchat_printf(ph, "Checksum: Failed to malloc needed memory\n");
+    free(checksum);
+    free(user_data);
+    free(word_1);
+    return HEXCHAT_EAT_NONE;
+  }
+
+  strcpy(word_1, word[1]);
+  strcpy(word_2, word[2]);
+
+  user_data->word_1 = word_1;
+  user_data->word_2 = word_2;
+
+  sha256_from_file_async(word[3], checksum, dccoffer_async_cb,
+                         (void *)user_data);
+  return HEXCHAT_EAT_NONE;
+}
+
+static int checksum(char *word[], char *word_eol[], void *userdata) {
+  if (!g_ascii_strcasecmp("GET", word[2])) {
+    hexchat_printf(ph, "File size limit for checksums: %d MiB", get_limit());
+  } else if (!g_ascii_strcasecmp("SET", word[2])) {
+    set_limit(word[3]);
+  } else {
+    hexchat_printf(ph, "Usage: /CHECKSUM GET|SET\n");
+    hexchat_printf(
+        ph, "  GET - print the maximum file size (in MiB) to be hashed\n");
+    hexchat_printf(
+        ph,
+        "  SET <filesize> - set the maximum file size (in MiB) to be hashed\n");
+  }
+
+  return HEXCHAT_EAT_ALL;
+}
+
+int hexchat_plugin_init(hexchat_plugin *plugin_handle, char **plugin_name,
+                        char **plugin_desc, char **plugin_version, char *arg) {
+  ph = plugin_handle;
+
+  *plugin_name = name;
+  *plugin_desc = desc;
+  *plugin_version = version;
+
+  /* this is required for the very first run */
+  if (hexchat_pluginpref_get_int(ph, "limit") == -1) {
+    hexchat_pluginpref_set_int(ph, "limit", DEFAULT_LIMIT);
+  }
+
+  hexchat_hook_command(ph, "CHECKSUM", HEXCHAT_PRI_NORM, checksum,
+                       "Usage: /CHECKSUM GET|SET", NULL);
+  hexchat_hook_print(ph, "DCC RECV Complete", HEXCHAT_PRI_NORM, dccrecv_cb,
+                     NULL);
+  hexchat_hook_print(ph, "DCC Offer", HEXCHAT_PRI_NORM, dccoffer_cb, NULL);
+
+  hexchat_printf(ph, "%s plugin loaded\n", name);
+  return 1;
+}
+
+int hexchat_plugin_deinit(void) {
+  hexchat_printf(ph, "%s plugin unloaded\n", name);
+  return 1;
 }


### PR DESCRIPTION
Summary: Ported the checksum plugin to the async file read functions and bumped the version up to 3.3:

solves #2434

The checksum plugin now uses the async file read functions, to make non blocking reads.

To achive this in c, since c doesn't support lambdas like e.g c++ every single function that involved something synchronus had to be rewritten completely:


Here is an example pattern for that:

```c
boolean do_something_normal(char* somethings, char *out_buf){

char* local_buffer[BUF_CAP];

int result = do_something_normal(char* some_options);
if(result){
  hexchat_printf(
            ph,
            "some message",
  }
return result;
}
```


```c
void do_something_async(char* somethings, char *out_buf,  void fn_pt(boolean, void *)){

char* local_buffer = malloc[BUF_SIZE];
// handle malloc error

struct xy = malloc(sizeof(struct xy));
// handle malloc error

do_something_async(char* some_options, cb, data_struct);
}

void cb(boolean result, void* data_struct){

if(result){
  hexchat_printf(
            ph,
            "some message",

    do_something_with(data_struct->checksum);

   data_struct->cb(TRUE, data_struct->checksum)
return;
  }
  data_struct->cb(FALSE, data_struct->checksum)
  free(everything);
}
```


Essentially every variable has to be passed around all functions by pointers in malloced memory, that only gets freed, after everything is done with that memory.

This structs are like bound variables in c++, since if we would allocate them in the function do_something_async it would be out of lifetime when we actually need it.

I tested everything multiple times (only in Linux!) in different scenarios, from big (28 GB) to small files. I also ran it with valgrind and some other analytic c tools to check, that I haven't forgotten any frees. But nevertheless, I would be happy if someone would test this too.



