### PR TITLE
Add support for the IRCv3 extended-monitor specification.

### DIFF
--- a/src/common/inbound.c
+++ b/src/common/inbound.c
@@ -1474,9 +1474,16 @@ inbound_user_info (session *sess, char *chan, char *user, char *host,
 		for (list = sess_list; list; list = list->next)
 		{
 			sess = list->data;
-			if (sess->type == SESS_CHANNEL && sess->server == serv)
+			if (sess->server != serv)
+				continue;
+
+			if (sess->type == SESS_CHANNEL)
 			{
 				userlist_add_hostname (sess, nick, uhost, realname, servname, account, away);
+			}
+			else if (sess->type == SESS_DIALOG && uhost && !serv->p_cmp (sess->channel, nick))
+			{
+				set_topic (sess, uhost, uhost);
 			}
 		}
 	}

--- a/src/common/inbound.c
+++ b/src/common/inbound.c
@@ -1728,6 +1728,7 @@ static const char * const supported_caps[] = {
 	"setname",
 	"invite-notify",
 	"account-tag",
+	"extended-monitor",
 
 	/* ZNC */
 	"znc.in/server-time-iso",


### PR DESCRIPTION
This allows getting hostname/awaymsg/etc updates for monitored clients which will update the internal cache for that data as well as any queries.

While working on this I also noticed that the user@host in the topic bar of queries was not being updated on CHGHOST so I fixed that as well.