### PR TITLE
Migrate to GTK 3: remove deprecated/removed functions

### DIFF
--- a/src/fe-gtk/chanlist.c
+++ b/src/fe-gtk/chanlist.c
@@ -459,7 +459,7 @@ chanlist_join (GtkWidget * wid, server *serv)
 			g_snprintf (tbuf, sizeof (tbuf), "join %s", chan);
 			handle_command (serv->server_session, tbuf, FALSE);
 		} else
-			gdk_beep ();
+			gdk_display_beep (gdk_display_get_default ());
 		g_free (chan);
 	}
 }

--- a/src/fe-gtk/chanlist.c
+++ b/src/fe-gtk/chanlist.c
@@ -777,7 +777,6 @@ chanlist_opengui (server *serv, int do_refresh)
 	chanlist_add_column (view, COL_CHANNEL, 96, _("Channel"), FALSE);
 	chanlist_add_column (view, COL_USERS,   50, _("Users"),   TRUE);
 	chanlist_add_column (view, COL_TOPIC,   50, _("Topic"),   FALSE);
-	gtk_tree_view_set_rules_hint (GTK_TREE_VIEW (view), TRUE);
 	/* this is a speed up, but no horizontal scrollbar :( */
 	/*gtk_tree_view_set_fixed_height_mode (GTK_TREE_VIEW (view), TRUE);*/
 	gtk_widget_show (view);

--- a/src/fe-gtk/dccgui.c
+++ b/src/fe-gtk/dccgui.c
@@ -812,7 +812,6 @@ fe_dcc_open_recv_win (int passive)
 										 G_TYPE_STRING, G_TYPE_STRING, G_TYPE_STRING,
 										 G_TYPE_STRING, G_TYPE_POINTER, GDK_TYPE_COLOR);
 	view = gtkutil_treeview_new (vbox, GTK_TREE_MODEL (store), NULL, -1);
-	gtk_tree_view_set_rules_hint (GTK_TREE_VIEW (view), TRUE);
 	/* Up/Down Icon column */
 	gtk_tree_view_insert_column_with_attributes (GTK_TREE_VIEW (view), -1, NULL,
 																gtk_cell_renderer_pixbuf_new (),
@@ -1067,7 +1066,6 @@ fe_dcc_open_chat_win (int passive)
 	dcc_add_column (view, CCOL_START,  CCOL_COLOR, _("Start Time"), FALSE);
 
 	gtk_tree_view_column_set_expand (gtk_tree_view_get_column (GTK_TREE_VIEW (view), 1), TRUE);
-	gtk_tree_view_set_rules_hint (GTK_TREE_VIEW (view), TRUE);
 
 	dcccwin.list = view;
 	dcccwin.store = store;

--- a/src/fe-gtk/editlist.c
+++ b/src/fe-gtk/editlist.c
@@ -288,8 +288,6 @@ editlist_treeview_new (GtkWidget *box, char *title1, char *title2)
 	g_signal_connect (G_OBJECT (view), "key_press_event",
 						G_CALLBACK (editlist_keypress), NULL);
 
-	gtk_tree_view_set_rules_hint (GTK_TREE_VIEW (view), TRUE);
-
 	render = gtk_cell_renderer_text_new ();
 	g_object_set (render, "editable", TRUE, NULL);
 	g_signal_connect (G_OBJECT (render), "edited",

--- a/src/fe-gtk/fe-gtk.c
+++ b/src/fe-gtk/fe-gtk.c
@@ -698,7 +698,7 @@ fe_beep (session *sess)
 
 	if (ca_context_play (ca_con, 0, CA_PROP_EVENT_ID, "message-new-instant", NULL) != 0)
 #endif
-	gdk_beep ();
+	gdk_display_beep (gdk_display_get_default ());
 #endif
 }
 

--- a/src/fe-gtk/fkeys.c
+++ b/src/fe-gtk/fkeys.c
@@ -674,8 +674,6 @@ key_dialog_treeview_new (GtkWidget *box)
 	g_signal_connect (G_OBJECT (gtk_tree_view_get_selection (GTK_TREE_VIEW(view))),
 					"changed", G_CALLBACK (key_dialog_selection_changed), NULL);
 
-	gtk_tree_view_set_rules_hint (GTK_TREE_VIEW (view), TRUE);
-
 	render = gtk_cell_renderer_accel_new ();
 	g_object_set (render, "editable", TRUE,
 #ifndef WIN32

--- a/src/fe-gtk/ignoregui.c
+++ b/src/fe-gtk/ignoregui.c
@@ -165,7 +165,6 @@ ignore_treeview_new (GtkWidget *box)
 	                             UNIGNORE_COLUMN, _("Unignore"),
 	                             -1);
 
-	gtk_tree_view_set_rules_hint (GTK_TREE_VIEW (view), TRUE);
 	gtk_tree_view_column_set_expand (gtk_tree_view_get_column (GTK_TREE_VIEW (view), 0), TRUE);
 
 	/* attach to signals and customise columns */

--- a/src/fe-gtk/plugingui.c
+++ b/src/fe-gtk/plugingui.c
@@ -66,7 +66,6 @@ plugingui_treeview_new (GtkWidget *box)
 	                             FILE_COLUMN, _("File"),
 	                             DESC_COLUMN, _("Description"),
 	                             FILEPATH_COLUMN, NULL, -1);
-	gtk_tree_view_set_rules_hint (GTK_TREE_VIEW (view), TRUE);
 	for (col_id=0; (col = gtk_tree_view_get_column (GTK_TREE_VIEW (view), col_id));
 	     col_id++)
 			gtk_tree_view_column_set_alignment (col, 0.5);

--- a/src/fe-gtk/setup.c
+++ b/src/fe-gtk/setup.c
@@ -908,7 +908,7 @@ setup_create_hscale (GtkWidget *table, int row, const setting *set)
 
 #ifndef WIN32 /* Windows always supports this */
 	/* Only used for transparency currently */
-	if (!gtk_widget_is_composited (current_sess->gui->window))
+	if (!gdk_screen_is_composited (gdk_window_get_screen (GDK_WINDOW (current_sess->gui->window))))
 		gtk_widget_set_sensitive (wid, FALSE);
 #endif
 }

--- a/src/fe-gtk/setup.c
+++ b/src/fe-gtk/setup.c
@@ -1793,7 +1793,6 @@ setup_create_sound_page (void)
 							G_CALLBACK (setup_snd_row_cb), NULL);
 	gtk_widget_show (sound_tree);
 	gtk_container_add (GTK_CONTAINER (scrolledwindow1), sound_tree);
-	gtk_tree_view_set_rules_hint (GTK_TREE_VIEW (sound_tree), TRUE);
 
 	table1 = gtk_table_new (2, 3, FALSE);
 	gtk_widget_show (table1);

--- a/src/fe-gtk/textgui.c
+++ b/src/fe-gtk/textgui.c
@@ -131,7 +131,7 @@ PrintTextRaw (void *xtbuf, unsigned char *text, int indent, time_t stamp)
 			{
 				beep_done = TRUE;
 				if (!prefs.hex_input_filter_beep)
-					gdk_beep ();
+					gdk_display_beep (gdk_display_get_default ());
 			}
 		default:
 			text++;

--- a/src/fe-gtk/textgui.c
+++ b/src/fe-gtk/textgui.c
@@ -356,7 +356,6 @@ pevent_treeview_new (GtkWidget *box)
 	view = gtk_tree_view_new_with_model (GTK_TREE_MODEL (store));
 	gtk_tree_view_set_fixed_height_mode (GTK_TREE_VIEW (view), TRUE);
 	gtk_tree_view_set_enable_search (GTK_TREE_VIEW (view), TRUE);
-	gtk_tree_view_set_rules_hint (GTK_TREE_VIEW (view), TRUE);
 
 	sel = gtk_tree_view_get_selection (GTK_TREE_VIEW (view));
 	g_signal_connect (G_OBJECT (sel), "changed",

--- a/src/fe-gtk/xtext.c
+++ b/src/fe-gtk/xtext.c
@@ -3811,7 +3811,8 @@ gtk_xtext_render_page (GtkXText * xtext)
 	if (xtext->buffer->indent < MARGIN)
 		xtext->buffer->indent = MARGIN;	  /* 2 pixels is our left margin */
 
-	gdk_drawable_get_size (GTK_WIDGET (xtext)->window, &width, &height);
+	width = gdk_window_get_width (GTK_WIDGET (xtext)->window);
+	height = gdk_window_get_height (GTK_WIDGET (xtext)->window);
 
 	if (width < 34 || height < xtext->fontsize || width < xtext->buffer->indent + 32)
 		return;


### PR DESCRIPTION
This is part one of my attempt to port HexChat to GTK 3. It's a pretty big changeset so I have split up my commits to make reviewing easier. This initial pull request just contains the low hanging fruit which can be dealt with whilst still depending on GTK 2.

---

The following functions which were removed/deprecated in GTK+3 have been replaced with their non-deprecated equivalents:

- `gdk_beep` -> `gdk_desktop_beep`
- `get_drawable_get_size` -> `gdk_window_get_width`, `gtk_window_get_height`
- `gtk_widget_is_composited` -> `gtk_screen_is_composited`

The following function have been removed:

- `gtk_tree_view_set_rules_hint` &mdash; this does nothing on GTK3 and also apparently does nothing with a lot of modern GTK2 themes that I have tried.