### PR TITLE
Build HexChat with GSEAL_ENABLE and fix internal field accesses.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -43,6 +43,7 @@ config_h.set('USE_LIBCANBERRA', libcanberra_dep.found())
 config_h.set('USE_DBUS', dbus_glib_dep.found())
 config_h.set('USE_PLUGIN', get_option('plugin'))
 
+config_h.set('GSEAL_ENABLE', true)
 config_h.set('G_DISABLE_SINGLE_INCLUDES', true)
 config_h.set('GTK_DISABLE_DEPRECATED', true)
 config_h.set('GTK_DISABLE_SINGLE_INCLUDES', true)

--- a/src/fe-gtk/menu.c
+++ b/src/fe-gtk/menu.c
@@ -301,9 +301,9 @@ menu_quick_item (char *cmd, char *label, GtkWidget * menu, int flags,
 			{
 				item = gtk_menu_item_new_with_label ("");
 				if (flags & XCMENU_MNEMONIC)
-					gtk_label_set_markup_with_mnemonic (GTK_LABEL (GTK_BIN (item)->child), label);
+					gtk_label_set_markup_with_mnemonic (GTK_LABEL (gtk_bin_get_child (GTK_BIN (item))), label);
 				else
-					gtk_label_set_markup (GTK_LABEL (GTK_BIN (item)->child), label);
+					gtk_label_set_markup (GTK_LABEL (gtk_bin_get_child (GTK_BIN (item))), label);
 			} else
 			{
 				if (flags & XCMENU_MNEMONIC)
@@ -352,7 +352,7 @@ menu_quick_sub (char *name, GtkWidget *menu, GtkWidget **sub_item_ret, int flags
 	if (flags & XCMENU_MARKUP)
 	{
 		sub_item = gtk_menu_item_new_with_label ("");
-		gtk_label_set_markup (GTK_LABEL (GTK_BIN (sub_item)->child), name);
+		gtk_label_set_markup (GTK_LABEL (gtk_bin_get_child (GTK_BIN (sub_item))), name);
 	}
 	else
 	{
@@ -392,7 +392,7 @@ toggle_cb (GtkWidget *item, char *pref_name)
 {
 	char buf[256];
 
-	if (GTK_CHECK_MENU_ITEM (item)->active)
+	if (gtk_check_menu_item_get_active (GTK_CHECK_MENU_ITEM (item)))
 		g_snprintf (buf, sizeof (buf), "set %s 1", pref_name);
 	else
 		g_snprintf (buf, sizeof (buf), "set %s 0", pref_name);
@@ -707,7 +707,7 @@ fe_userlist_update (session *sess, struct User *user)
 	g_signal_handlers_disconnect_by_func (nick_submenu, menu_nickinfo_cb, sess);
 
 	/* destroy all the old items */
-	items = ((GtkMenuShell *) nick_submenu)->children;
+	items = gtk_container_get_children( GTK_CONTAINER (nick_submenu));
 	while (items)
 	{
 		next = items->next;
@@ -838,7 +838,7 @@ menu_setting_foreach (void (*callback) (session *), int id, guint state)
 			if (sess->gui->is_tab)
 				maindone = TRUE;
 			if (id != -1)
-				GTK_CHECK_MENU_ITEM (sess->gui->menu_item[id])->active = state;
+				gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM (sess->gui->menu_item[id]), state);
 			if (callback)
 				callback (sess);
 		}
@@ -1014,7 +1014,7 @@ menu_chan_focus (GtkWidget * menu, char *chan)
 }
 
 static void
-menu_chan_join (GtkWidget * menu, char *chan)
+menu_chan_join (GtkWidget * menu, const char *chan)
 {
 	char tbuf[256];
 
@@ -1168,7 +1168,7 @@ usermenu_create (GtkWidget *menu)
 static void
 usermenu_destroy (GtkWidget * menu)
 {
-	GList *items = ((GtkMenuShell *) menu)->children;
+	GList *items = gtk_container_get_children (GTK_CONTAINER (menu));
 	GList *next;
 
 	while (items)
@@ -1387,7 +1387,7 @@ menu_join_cb (GtkWidget *dialog, gint response, GtkEntry *entry)
 	switch (response)
 	{
 	case GTK_RESPONSE_ACCEPT:
-		menu_chan_join (NULL, entry->text);
+		menu_chan_join (NULL, gtk_entry_get_text (GTK_ENTRY (entry)));
 		break;
 
 	case GTK_RESPONSE_HELP:
@@ -1415,12 +1415,12 @@ menu_join (GtkWidget * wid, gpointer none)
 									GTK_STOCK_CANCEL, GTK_RESPONSE_REJECT,
 									GTK_STOCK_OK, GTK_RESPONSE_ACCEPT,
 									NULL);
-	gtk_box_set_homogeneous (GTK_BOX (GTK_DIALOG (dialog)->vbox), TRUE);
+	gtk_box_set_homogeneous (GTK_BOX (gtk_dialog_get_content_area (GTK_DIALOG (dialog))), TRUE);
 	gtk_window_set_position (GTK_WINDOW (dialog), GTK_WIN_POS_MOUSE);
 	hbox = gtk_hbox_new (TRUE, 0);
 
 	entry = gtk_entry_new ();
-	GTK_ENTRY (entry)->editable = 0;	/* avoid auto-selection */
+	gtk_editable_set_editable (GTK_EDITABLE (entry), FALSE); /* avoid auto-selection */
 	gtk_entry_set_text (GTK_ENTRY (entry), "#");
 	g_signal_connect (G_OBJECT (entry), "activate",
 						 	G_CALLBACK (menu_join_entry_cb), dialog);
@@ -1432,7 +1432,7 @@ menu_join (GtkWidget * wid, gpointer none)
 	g_signal_connect (G_OBJECT (dialog), "response",
 						   G_CALLBACK (menu_join_cb), entry);
 
-	gtk_container_add (GTK_CONTAINER (GTK_DIALOG (dialog)->vbox), hbox);
+	gtk_container_add (GTK_CONTAINER (gtk_dialog_get_content_area (GTK_DIALOG (dialog))), hbox);
 
 	gtk_widget_show_all (dialog);
 
@@ -1655,7 +1655,7 @@ static void
 menu_layout_cb (GtkWidget *item, gpointer none)
 {
 	prefs.hex_gui_tab_layout = 2;
-	if (GTK_CHECK_MENU_ITEM (item)->active)
+	if (gtk_check_menu_item_get_active (GTK_CHECK_MENU_ITEM (item)))
 		prefs.hex_gui_tab_layout = 0;
 
 	menu_change_layout ();
@@ -1670,7 +1670,7 @@ menu_apply_metres_cb (session *sess)
 static void
 menu_metres_off (GtkWidget *item, gpointer none)
 {
-	if (GTK_CHECK_MENU_ITEM (item)->active)
+	if (gtk_check_menu_item_get_active (GTK_CHECK_MENU_ITEM (item)))
 	{
 		prefs.hex_gui_lagometer = 0;
 		prefs.hex_gui_throttlemeter = 0;
@@ -1682,7 +1682,7 @@ menu_metres_off (GtkWidget *item, gpointer none)
 static void
 menu_metres_text (GtkWidget *item, gpointer none)
 {
-	if (GTK_CHECK_MENU_ITEM (item)->active)
+	if (gtk_check_menu_item_get_active (GTK_CHECK_MENU_ITEM (item)))
 	{
 		prefs.hex_gui_lagometer = 2;
 		prefs.hex_gui_throttlemeter = 2;
@@ -1694,7 +1694,7 @@ menu_metres_text (GtkWidget *item, gpointer none)
 static void
 menu_metres_graph (GtkWidget *item, gpointer none)
 {
-	if (GTK_CHECK_MENU_ITEM (item)->active)
+	if (gtk_check_menu_item_get_active (GTK_CHECK_MENU_ITEM (item)))
 	{
 		prefs.hex_gui_lagometer = 1;
 		prefs.hex_gui_throttlemeter = 1;
@@ -1706,7 +1706,7 @@ menu_metres_graph (GtkWidget *item, gpointer none)
 static void
 menu_metres_both (GtkWidget *item, gpointer none)
 {
-	if (GTK_CHECK_MENU_ITEM (item)->active)
+	if (gtk_check_menu_item_get_active (GTK_CHECK_MENU_ITEM (item)))
 	{
 		prefs.hex_gui_lagometer = 3;
 		prefs.hex_gui_throttlemeter = 3;
@@ -1920,7 +1920,7 @@ menu_canacaccel (GtkWidget *widget, guint signal_id, gpointer user_data)
 static GtkMenuItem *
 menu_find_item (GtkWidget *menu, char *name)
 {
-	GList *items = ((GtkMenuShell *) menu)->children;
+	GList *items = gtk_container_get_children (GTK_CONTAINER (menu));
 	GtkMenuItem *item;
 	GtkWidget *child;
 	const char *labeltext;
@@ -1928,7 +1928,7 @@ menu_find_item (GtkWidget *menu, char *name)
 	while (items)
 	{
 		item = items->data;
-		child = GTK_BIN (item)->child;
+		child = gtk_bin_get_child (GTK_BIN (item));
 		if (child)	/* separators arn't labels, skip them */
 		{
 			labeltext = g_object_get_data (G_OBJECT (item), "name");
@@ -2025,7 +2025,7 @@ menu_update_cb (GtkWidget *menu, menu_entry *me, char *target)
 		gtk_widget_set_sensitive (item, me->enable);
 		/* must do it without triggering the callback */
 		if (GTK_IS_CHECK_MENU_ITEM (item))
-			GTK_CHECK_MENU_ITEM (item)->active = me->state;
+			gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM (item), me->state);
 	}
 }
 
@@ -2034,7 +2034,7 @@ static void
 menu_radio_cb (GtkCheckMenuItem *item, menu_entry *me)
 {
 	me->state = 0;
-	if (item->active)
+	if (gtk_check_menu_item_get_active (item))
 		me->state = 1;
 
 	/* update the state, incase this was changed via right-click. */
@@ -2050,7 +2050,7 @@ static void
 menu_toggle_cb (GtkCheckMenuItem *item, menu_entry *me)
 {
 	me->state = 0;
-	if (item->active)
+	if (gtk_check_menu_item_get_active (item))
 		me->state = 1;
 
 	/* update the state, incase this was changed via right-click. */
@@ -2092,7 +2092,7 @@ menu_reorder (GtkMenu *menu, GtkWidget *item, int pos)
 		return;
 
 	if (pos < 0)	/* position offset from end/bottom */
-		gtk_menu_reorder_child (menu, item, (g_list_length (GTK_MENU_SHELL (menu)->children) + pos) - 1);
+		gtk_menu_reorder_child (menu, item, (g_list_length (gtk_container_get_children (GTK_CONTAINER (menu))) + pos) - 1);
 	else
 		gtk_menu_reorder_child (menu, item, pos);
 }
@@ -2158,7 +2158,7 @@ menu_add_sub (GtkWidget *menu, menu_entry *me)
 	{
 		pos = me->pos;
 		if (pos < 0)	/* position offset from end/bottom */
-			pos = g_list_length (GTK_MENU_SHELL (menu)->children) + pos;
+			pos = g_list_length (gtk_container_get_children (GTK_CONTAINER (menu))) + pos;
 		menu_quick_sub (me->label, menu, &item, me->markup ? XCMENU_MARKUP|XCMENU_MNEMONIC : XCMENU_MNEMONIC, pos);
 	}
 	return item;
@@ -2436,7 +2436,7 @@ normalitem:
 			item = gtk_check_menu_item_new_with_mnemonic (_(mymenu[i].text));
 togitem:
 			/* must avoid callback for Radio buttons */
-			GTK_CHECK_MENU_ITEM (item)->active = mymenu[i].state;
+			gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM (item), mymenu[i].state);
 			/*gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM (item),
 													 mymenu[i].state);*/
 			if (mymenu[i].key != 0)

--- a/win32/hexchat.props
+++ b/win32/hexchat.props
@@ -14,8 +14,7 @@
 		<!-- YOU SHOULDN'T TOUCH ANYTHING BELOW -->
 
 		<!-- G_DISABLE_DEPRECATED is unfeasible due to g_completion_* -->
-		<!-- must be buildable with GSEAL_ENABLE in the future, xtext, setup, and chanview-tabs stand in the way -->
-		<OwnFlags>GTK_DISABLE_DEPRECATED;GDK_PIXBUF_DISABLE_DEPRECATED;G_DISABLE_SINGLE_INCLUDES;GDK_PIXBUF_DISABLE_SINGLE_INCLUDES;GTK_DISABLE_SINGLE_INCLUDES;HAVE_X509_GET_SIGNATURE_NID;HAVE_SSL_CTX_GET_SSL_METHOD;DEFAULT_CERT_FILE="cert.pem";HAVE_STRTOULL;strtoull=_strtoui64;strcasecmp=stricmp;strncasecmp=strnicmp;__inline__=__inline</OwnFlags>
+		<OwnFlags>GSEAL_ENABLE;GTK_DISABLE_DEPRECATED;GDK_PIXBUF_DISABLE_DEPRECATED;G_DISABLE_SINGLE_INCLUDES;GDK_PIXBUF_DISABLE_SINGLE_INCLUDES;GTK_DISABLE_SINGLE_INCLUDES;HAVE_X509_GET_SIGNATURE_NID;HAVE_SSL_CTX_GET_SSL_METHOD;DEFAULT_CERT_FILE="cert.pem";HAVE_STRTOULL;strtoull=_strtoui64;strcasecmp=stricmp;strncasecmp=strnicmp;__inline__=__inline</OwnFlags>
 		<!-- FIXME: Add ability to use debug builds -->
 		<DepsRoot>$(YourDepsPath)\$(PlatformName)\release</DepsRoot>
 		<GendefPath>$(YourGendefPath)</GendefPath>


### PR DESCRIPTION
GTK 3 makes a whole bunch of struct fields private. We can emulate this on GTK 2 with GSEAL_ENABLE to allow us to fix it now.

This has required changing a bunch of places to use getters/setters as well as reworking some SexySpellEntry internals to work around the preedit length not being accessible with either a custom method or `g_object_get`.