### PR TITLE
Add support for the standard-replies capability.

### DIFF
--- a/src/common/inbound.c
+++ b/src/common/inbound.c
@@ -1736,6 +1736,7 @@ static const char * const supported_caps[] = {
 	"invite-notify",
 	"account-tag",
 	"extended-monitor",
+	"standard-replies",
 
 	/* ZNC */
 	"znc.in/server-time-iso",


### PR DESCRIPTION
Ref: ircv3/ircv3-specifications#506

HexChat already handles arbitrary standard replies so there's no need to do anything special here other than request the cap.