### PR TITLE
python: add flush() to Stdout

### DIFF
--- a/plugins/python/python.py
+++ b/plugins/python/python.py
@@ -64,6 +64,10 @@ class Stdout:
         else:
             self.buffer += string
 
+    def flush(self):
+        lib.hexchat_print(lib.ph, bytes(self.buffer))
+        self.buffer = bytearray()
+
     def isatty(self):
         return False
 


### PR DESCRIPTION
Python sometime calls flush() on sys.stdout or sys.stderr.
In particular, it might do so when an exception is raised. This fixes
the second error message that was generated in such cases.