### PR TITLE
python: fix for timers that unhook themselves

### DIFF
--- a/plugins/python/python.py
+++ b/plugins/python/python.py
@@ -291,7 +291,15 @@ def _on_timer_hook(userdata):
     if hook.callback(hook.userdata) == True:
         return 1
 
-    hook.is_unload = True  # Don't unhook
+    try:
+        # Avoid calling hexchat_unhook twice if unnecessary
+        hook.is_unload = True
+    except ReferenceError:
+        # hook is a weak reference, it might have been destroyed by the callback
+        # in which case it has already been removed from hook.plugin.hooks and
+        # we wouldn't be able to test it with h == hook anyway.
+        return 0
+
     for h in hook.plugin.hooks:
         if h == hook:
             hook.plugin.hooks.remove(h)


### PR DESCRIPTION
When a timer hook unhooks itself and return False, the internal code generates an exception about a weakly-referenced object that no longer exists.

I am unsure how it all works. My tests work, but they might not be exhaustive enough.

In particular, I don't understand why setting `hook.is_unload = True` is necessary. But my guess is that this line can be safely ignored when the `Hook` object has already been destroyed, since the only effect it could have had was in `Hook.__del__`. Which won't be called again because the object no longer exists.

I also note that the code relying on `__del__` seems quite fragile. As far as I understand, the python plugin uses weak references to avoid references loops. This lets the CPython garbage collector free the object as soon as the last reference is destroyed, and thus call `__del__` at that time. As far as I know, this behavior is an [implementation detail](https://docs.python.org/3/reference/datamodel.html#object.__del__) and a more straightforward logic might be warranted in the future.