### PR TITLE
proto-irc.c: handle WHOX replies with realnames that aren't :-prefixed

### DIFF
--- a/src/common/proto-irc.c
+++ b/src/common/proto-irc.c
@@ -762,7 +762,7 @@ process_numeric (session * sess, int n,
 
 				/* :server 354 yournick 152 #channel ~ident host servname nick H account :realname */
 				inbound_user_info (sess, word[5], word[6], word[7], word[8],
-										 word[9], word_eol[12]+1, word[11], away,
+										 word[9], word_eol[12][0] == ':' ? word_eol[12] + 1 : word_eol[12], word[11], away,
 										 tags_data);
 
 				/* try to show only user initiated whos */


### PR DESCRIPTION
The colon is not required if the last argument is a single word.

This was causing issues where the user info context menu was stripping the first character of single-word realnames when sending the WHOX command `WHO #channel %chtsunfra,152`. Discovered the issue by seeing that plain `WHO #channel` fixed the issue temporarily.

Tested on Void Linux, with this patch applied on top of 2.16.1.
