### PR TITLE
Change various types to the correct signedness to avoid warnings.

### DIFF
--- a/plugins/fishlim/fish.c
+++ b/plugins/fishlim/fish.c
@@ -145,7 +145,8 @@ void fish_deinit(void)
  */
 char *fish_base64_encode(const char *message, size_t message_len) {
     BF_LONG left = 0, right = 0;
-    int i, j;
+    int i;
+    size_t j;
     char *encoded = NULL;
     char *end = NULL;
     char *msg = NULL;

--- a/plugins/fishlim/tests/tests.c
+++ b/plugins/fishlim/tests/tests.c
@@ -36,7 +36,7 @@ static void
 random_string(char *out, size_t len)
 {
     GRand *rand = NULL;
-    int i = 0;
+    size_t i = 0;
 
     rand = g_rand_new();
     for (i = 0; i < len; ++i) {

--- a/src/common/dbus/dbus-client.c
+++ b/src/common/dbus/dbus-client.c
@@ -67,7 +67,7 @@ hexchat_remote (void)
 	gboolean hexchat_running;
 	GError *error = NULL;
 	char *command = NULL;
-	int i;
+	guint i;
 
 	/* if there is nothing to do, return now. */
 	if (!arg_existing || !(arg_url || arg_urls || arg_command)) {

--- a/src/common/modes.c
+++ b/src/common/modes.c
@@ -680,7 +680,7 @@ handle_mode (server * serv, char *word[], char *word_eol[],
 	int len;
 	size_t arg;
 	size_t i, num_args;
-	int num_modes;
+	size_t num_modes;
 	size_t offset = 3;
 	int all_modes_have_args = FALSE;
 	int using_front_tab = FALSE;

--- a/src/common/outbound.c
+++ b/src/common/outbound.c
@@ -468,7 +468,7 @@ create_mask (session * sess, char *mask, char *mode, char *typestr, int deop)
 			type = prefs.hex_irc_ban_type;
 
 		buf[0] = 0;
-		if (inet_addr (fullhost) != -1)	/* "fullhost" is really a IP number */
+		if (inet_addr (fullhost) != (guint32) -1)	/* "fullhost" is really a IP number */
 		{
 			lastdot = strrchr (fullhost, '.');
 			if (!lastdot)

--- a/src/common/url.c
+++ b/src/common/url.c
@@ -331,7 +331,7 @@ url_check_line (char *buf)
 	GRegex *re(void);
 	GMatchInfo *gmi;
 	char *po = buf;
-	int i;
+	size_t i;
 
 	/* Skip over message prefix */
 	if (*po == ':')

--- a/src/common/util.c
+++ b/src/common/util.c
@@ -988,7 +988,7 @@ void
 country_search (char *pattern, void *ud, void (*print)(void *, char *, ...))
 {
 	const domain_t *dom;
-	int i;
+	size_t i;
 
 	for (i = 0; i < sizeof (domain) / sizeof (domain_t); i++)
 	{

--- a/src/fe-gtk/xtext.c
+++ b/src/fe-gtk/xtext.c
@@ -170,7 +170,8 @@ xtext_pango_attr (PangoAttribute *attr)
 static void
 xtext_pango_init (GtkXText *xtext)
 {
-	int i, j;
+	size_t i;
+	int j;
 	char buf[2] = "\000";
 
 	if (attr_lists[0])


### PR DESCRIPTION
Hello, I was building from master and thought it would be nice to clean up some warnings. There are a lot more -Wsign-compare warnings but I only fixed simple ones where the variable was used once. I also added a cast when checking the return value of inet_addr in src/common/outbound.c since it should be unsigned. POSIX states it returns (in_addr_t) (-1) on failure which is equivalent to (uint32_t) (-1). However, Windows does not have this type and returns unsigned long so I opted to use guint32.